### PR TITLE
[codex] PG18 shared-infra merge and wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Lint
-        run: cargo clippy --all-targets --no-default-features --features pg17,bench -- -D warnings
+        run: cargo clippy --all-targets --no-default-features --features pg18,bench -- -D warnings
 
       - name: Unit tests
         run: cargo test
@@ -43,7 +43,35 @@ jobs:
       - name: Unsafe audit
         run: bash scripts/check_unsafe_comments.sh
 
-  pgrx:
+  pgrx-pg18:
+    name: pgrx pg18
+    runs-on: ubuntu-24.04
+    env:
+      PGRX_HOME: /tmp/tqvector_pgrx_home
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install PostgreSQL build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-server-dev-18 postgresql-server-dev-17 clang llvm pkg-config libssl-dev
+
+      - name: Install cargo-pgrx
+        run: cargo install cargo-pgrx --version 0.17.0 --locked
+
+      - name: Initialize pgrx for pg18 and pg17
+        run: cargo pgrx init --pg18 /usr/lib/postgresql/18/bin/pg_config --pg17 /usr/lib/postgresql/17/bin/pg_config
+
+      - name: pg18 tests
+        run: cargo pgrx test pg18
+
+  pgrx-pg17:
     name: pgrx pg17
     runs-on: ubuntu-24.04
     env:
@@ -60,13 +88,13 @@ jobs:
       - name: Install PostgreSQL build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y postgresql-server-dev-17 clang llvm pkg-config libssl-dev
+          sudo apt-get install -y postgresql-server-dev-18 postgresql-server-dev-17 clang llvm pkg-config libssl-dev
 
       - name: Install cargo-pgrx
         run: cargo install cargo-pgrx --version 0.17.0 --locked
 
-      - name: Initialize pgrx for pg17
-        run: cargo pgrx init --pg17 /usr/lib/postgresql/17/bin/pg_config
+      - name: Initialize pgrx for pg18 and pg17
+        run: cargo pgrx init --pg18 /usr/lib/postgresql/18/bin/pg_config --pg17 /usr/lib/postgresql/17/bin/pg_config
 
       - name: pg17 tests
         run: cargo pgrx test pg17

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tqvector"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]
@@ -11,11 +11,9 @@ name = "pgrx_embed_tqvector"
 path = "./src/bin/pgrx_embed.rs"
 
 [features]
-default = ["pg17"]
-pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
-pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
-pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+default = ["pg18"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = []
 bench = []
 dhat-heap = ["dhat"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,12 @@ name = "pgrx_embed_tqvector"
 path = "./src/bin/pgrx_embed.rs"
 
 [features]
-default = ["pg17"]
+default = ["pg18"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = []
 bench = []
 dhat-heap = ["dhat"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ iai-callgrind = "0.14"
 
 [build-dependencies]
 cc = "1"
+pgrx-pg-config = "0.17"
 
 [profile.dev]
 panic = "unwind"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt fmt-check lint test pg-test deny audit-unsafe build install clean
+.PHONY: fmt fmt-check lint lint-pg17 test pg-test pg-test-pg17 deny audit-unsafe build install clean
 .PHONY: bench bench-iai dhat-encode dhat-score proptest layout-check miri
 .PHONY: fuzz-parse-text fuzz-unpack fuzz-element-decode fuzz-neighbor-decode
 .PHONY: ci-quick ci-nightly
@@ -13,6 +13,9 @@ fmt-check:
 
 ## Run Clippy (deny warnings)
 lint:
+	cargo clippy --all-targets --no-default-features --features pg18,bench -- -D warnings
+
+lint-pg17:
 	cargo clippy --all-targets --no-default-features --features pg17,bench -- -D warnings
 
 ## Run unit tests (no Postgres required)
@@ -21,7 +24,10 @@ test:
 
 ## Run pgrx integration tests (requires: cargo pgrx init)
 pg-test:
-	cargo pgrx test
+	cargo pgrx test pg18
+
+pg-test-pg17:
+	cargo pgrx test pg17
 
 ## Check dependency licenses
 deny:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ fmt-check:
 
 ## Run Clippy (deny warnings)
 lint:
-	cargo clippy --all-targets --no-default-features --features pg17,bench -- -D warnings
+	cargo clippy --all-targets --no-default-features --features pg18,bench -- -D warnings
 
 ## Run unit tests (no Postgres required)
 test:

--- a/README.md
+++ b/README.md
@@ -39,18 +39,31 @@ LIMIT 10;
 ## Prerequisites
 
 - [Rust](https://rustup.rs/) stable
-- [cargo-pgrx](https://github.com/pgcentralfoundation/pgrx): `cargo install cargo-pgrx`
-- PostgreSQL 14–17 dev headers
+- [cargo-pgrx](https://github.com/pgcentralfoundation/pgrx) matching the `pgrx` version in `Cargo.toml`:
+  ```bash
+  cargo install cargo-pgrx --version "^0.17"
+  ```
+- System packages (Ubuntu/Debian):
+  ```bash
+  sudo apt-get install -y postgresql-server-dev-all postgresql-common \
+    build-essential pkg-config libssl-dev libreadline-dev bison flex
+  ```
 
 ## Getting Started
 
 ```bash
-cargo pgrx init          # builds a local Postgres for testing
+cargo pgrx init          # builds local Postgres instances for pg14–pg18
 make fmt                 # format code
 make lint                # clippy (deny warnings)
 make test                # unit tests
-make pg-test             # pgrx integration tests
+make pg-test             # pgrx integration tests (pg18 by default)
 make install             # install into local PG
+```
+
+To run integration tests against a specific version:
+
+```bash
+cargo pgrx test pg18
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ WITH (
 Switching an index from one storage format to the other requires `REINDEX`.
 There is no in-place format upgrade.
 
+## Development
+
+- [Rust](https://rustup.rs/) stable
+- [cargo-pgrx](https://github.com/pgcentralfoundation/pgrx) `0.17`
+- PostgreSQL 17 or 18 development headers
+
+```bash
+cargo pgrx init
+make fmt
+make lint
+make lint-pg17
+make test
+make pg-test
+make pg-test-pg17
+```
+
 ## Performance
 
 Measured on 1536-dimensional OpenAI embeddings ([DBpedia corpus](docs/recall-methodology.md)):

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,12 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=csrc/standalone_pg_backend_stubs.c");
+    println!("cargo:rerun-if-changed=csrc/pg18_pgstat_shim.c");
+    println!("cargo:rerun-if-env-changed=PGRX_PG_CONFIG_PATH");
 
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR should be present for build scripts");
 
     if target_os == "linux" && target_arch == "x86_64" {
         cc::Build::new()
@@ -11,9 +14,25 @@ fn main() {
             .cargo_metadata(false)
             .flag_if_supported("-std=c11")
             .compile("tqvector_pg_test_stubs");
-        println!(
-            "cargo:rustc-link-search=native={}",
-            std::env::var("OUT_DIR").expect("OUT_DIR should be present for build scripts")
-        );
+        println!("cargo:rustc-link-search=native={out_dir}");
+    }
+
+    if std::env::var_os("CARGO_FEATURE_PG18").is_some() {
+        let pgrx =
+            pgrx_pg_config::Pgrx::from_config().expect("PG18 shim build requires pgrx config");
+        let pg_config = pgrx
+            .get("pg18")
+            .expect("PG18 shim build requires a managed pg18 config");
+        let include_dir = pg_config
+            .includedir_server()
+            .expect("PG18 shim build requires PostgreSQL server headers");
+
+        cc::Build::new()
+            .file("csrc/pg18_pgstat_shim.c")
+            .include(include_dir)
+            .cargo_metadata(false)
+            .flag_if_supported("-std=c11")
+            .compile("tqvector_pg18_pgstat_shim");
+        println!("cargo:rustc-link-search=native={out_dir}");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -26,13 +26,20 @@ fn main() {
         let include_dir = pg_config
             .includedir_server()
             .expect("PG18 shim build requires PostgreSQL server headers");
+        let cppflags = pg_config
+            .cppflags()
+            .expect("PG18 shim build requires PostgreSQL cppflags");
 
-        cc::Build::new()
+        let mut build = cc::Build::new();
+        build
             .file("csrc/pg18_pgstat_shim.c")
             .include(include_dir)
             .cargo_metadata(false)
-            .flag_if_supported("-std=c11")
-            .compile("tqvector_pg18_pgstat_shim");
+            .flag_if_supported("-std=c11");
+        for flag in cppflags.to_string_lossy().split_whitespace() {
+            build.flag(flag);
+        }
+        build.compile("tqvector_pg18_pgstat_shim");
         println!("cargo:rustc-link-search=native={out_dir}");
     }
 }

--- a/csrc/pg18_pgstat_shim.c
+++ b/csrc/pg18_pgstat_shim.c
@@ -29,6 +29,13 @@ typedef struct TqVectorPgStatShared
 	TqVectorPgStatCounters reset_offset;
 } TqVectorPgStatShared;
 
+/*
+ * Claim a stable tqvector-specific custom kind instead of the shared
+ * PGSTAT_KIND_EXPERIMENTAL slot so preload-time registration does not collide
+ * with other extensions using the experimental ID.
+ */
+#define TQVECTOR_PGSTAT_KIND	((PgStat_Kind) (PGSTAT_KIND_CUSTOM_MIN + 1))
+
 static void tqvector_pgstat_init_shmem(void *stats);
 static void tqvector_pgstat_reset_all(TimestampTz ts);
 static void tqvector_pgstat_snapshot(void);
@@ -57,7 +64,7 @@ static TqVectorPgStatShared *
 tqvector_pgstat_shared(void)
 {
 	return (TqVectorPgStatShared *)
-		pgstat_get_custom_shmem_data(PGSTAT_KIND_EXPERIMENTAL);
+		pgstat_get_custom_shmem_data(TQVECTOR_PGSTAT_KIND);
 }
 
 static void
@@ -75,6 +82,11 @@ tqvector_pgstat_reset_all(TimestampTz ts)
 	(void) ts;
 
 	LWLockAcquire(&stats_shmem->lock, LW_EXCLUSIVE);
+	/*
+	 * Readers already use the changecount protocol for the live stats snapshot.
+	 * Keep the reset offset behind the same helper while we hold the lock so the
+	 * reset baseline and the live counters advance in a single ordered step.
+	 */
 	pgstat_copy_changecounted_stats(&stats_shmem->reset_offset,
 									&stats_shmem->stats,
 									sizeof(stats_shmem->stats),
@@ -88,7 +100,7 @@ tqvector_pgstat_snapshot(void)
 	TqVectorPgStatShared *stats_shmem = tqvector_pgstat_shared();
 	TqVectorPgStatCounters *stat_snap =
 		(TqVectorPgStatCounters *)
-		pgstat_get_custom_snapshot_data(PGSTAT_KIND_EXPERIMENTAL);
+		pgstat_get_custom_snapshot_data(TQVECTOR_PGSTAT_KIND);
 	TqVectorPgStatCounters reset;
 
 	pgstat_copy_changecounted_stats(stat_snap,
@@ -120,7 +132,7 @@ tqvector_pg18_pgstat_register_kind(void)
 	if (!process_shared_preload_libraries_in_progress)
 		return false;
 
-	pgstat_register_kind(PGSTAT_KIND_EXPERIMENTAL, &tqvector_pgstat_kind);
+	pgstat_register_kind(TQVECTOR_PGSTAT_KIND, &tqvector_pgstat_kind);
 	tqvector_pgstat_loaded = true;
 	return true;
 }
@@ -164,9 +176,9 @@ tqvector_pg18_pgstat_snapshot(TqVectorPgStatCounters *out)
 	if (!tqvector_pgstat_loaded || out == NULL)
 		return false;
 
-	pgstat_snapshot_fixed(PGSTAT_KIND_EXPERIMENTAL);
+	pgstat_snapshot_fixed(TQVECTOR_PGSTAT_KIND);
 	snapshot = (TqVectorPgStatCounters *)
-		pgstat_get_custom_snapshot_data(PGSTAT_KIND_EXPERIMENTAL);
+		pgstat_get_custom_snapshot_data(TQVECTOR_PGSTAT_KIND);
 	memcpy(out, snapshot, sizeof(*out));
 
 	return true;

--- a/csrc/pg18_pgstat_shim.c
+++ b/csrc/pg18_pgstat_shim.c
@@ -1,0 +1,173 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "postgres.h"
+
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "utils/pgstat_internal.h"
+#include "utils/pgstat_kind.h"
+
+typedef struct TqVectorPgStatCounters
+{
+	uint64_t	total_distance_calcs;
+	uint64_t	total_graph_hops;
+	uint64_t	total_linear_pages;
+	uint64_t	total_scans_started;
+	uint64_t	total_scans_bootstrap_only;
+	uint64_t	quantizer_cache_hits;
+	uint64_t	quantizer_cache_misses;
+} TqVectorPgStatCounters;
+
+typedef struct TqVectorPgStatShared
+{
+	LWLock		lock;
+	uint32		changecount;
+	TqVectorPgStatCounters stats;
+	TqVectorPgStatCounters reset_offset;
+} TqVectorPgStatShared;
+
+static void tqvector_pgstat_init_shmem(void *stats);
+static void tqvector_pgstat_reset_all(TimestampTz ts);
+static void tqvector_pgstat_snapshot(void);
+
+static const PgStat_KindInfo tqvector_pgstat_kind = {
+	.name = "tqvector",
+	.fixed_amount = true,
+	.accessed_across_databases = true,
+	.write_to_file = true,
+	.shared_size = sizeof(TqVectorPgStatShared),
+	.shared_data_off = offsetof(TqVectorPgStatShared, stats),
+	.shared_data_len = sizeof(((TqVectorPgStatShared *) 0)->stats),
+	.init_shmem_cb = tqvector_pgstat_init_shmem,
+	.reset_all_cb = tqvector_pgstat_reset_all,
+	.snapshot_cb = tqvector_pgstat_snapshot,
+};
+
+static bool tqvector_pgstat_loaded = false;
+
+void
+tqvector_pg18_pgstat_anchor(void)
+{
+}
+
+static TqVectorPgStatShared *
+tqvector_pgstat_shared(void)
+{
+	return (TqVectorPgStatShared *)
+		pgstat_get_custom_shmem_data(PGSTAT_KIND_EXPERIMENTAL);
+}
+
+static void
+tqvector_pgstat_init_shmem(void *stats)
+{
+	TqVectorPgStatShared *stats_shmem = (TqVectorPgStatShared *) stats;
+
+	LWLockInitialize(&stats_shmem->lock, LWTRANCHE_PGSTATS_DATA);
+}
+
+static void
+tqvector_pgstat_reset_all(TimestampTz ts)
+{
+	TqVectorPgStatShared *stats_shmem = tqvector_pgstat_shared();
+	(void) ts;
+
+	LWLockAcquire(&stats_shmem->lock, LW_EXCLUSIVE);
+	pgstat_copy_changecounted_stats(&stats_shmem->reset_offset,
+									&stats_shmem->stats,
+									sizeof(stats_shmem->stats),
+									&stats_shmem->changecount);
+	LWLockRelease(&stats_shmem->lock);
+}
+
+static void
+tqvector_pgstat_snapshot(void)
+{
+	TqVectorPgStatShared *stats_shmem = tqvector_pgstat_shared();
+	TqVectorPgStatCounters *stat_snap =
+		(TqVectorPgStatCounters *)
+		pgstat_get_custom_snapshot_data(PGSTAT_KIND_EXPERIMENTAL);
+	TqVectorPgStatCounters reset;
+
+	pgstat_copy_changecounted_stats(stat_snap,
+									&stats_shmem->stats,
+									sizeof(stats_shmem->stats),
+									&stats_shmem->changecount);
+
+	LWLockAcquire(&stats_shmem->lock, LW_SHARED);
+	memcpy(&reset, &stats_shmem->reset_offset, sizeof(reset));
+	LWLockRelease(&stats_shmem->lock);
+
+#define TQVECTOR_FIXED_COMP(fld) stat_snap->fld -= reset.fld;
+	TQVECTOR_FIXED_COMP(total_distance_calcs);
+	TQVECTOR_FIXED_COMP(total_graph_hops);
+	TQVECTOR_FIXED_COMP(total_linear_pages);
+	TQVECTOR_FIXED_COMP(total_scans_started);
+	TQVECTOR_FIXED_COMP(total_scans_bootstrap_only);
+	TQVECTOR_FIXED_COMP(quantizer_cache_hits);
+	TQVECTOR_FIXED_COMP(quantizer_cache_misses);
+#undef TQVECTOR_FIXED_COMP
+}
+
+bool
+tqvector_pg18_pgstat_register_kind(void)
+{
+	if (tqvector_pgstat_loaded)
+		return true;
+
+	if (!process_shared_preload_libraries_in_progress)
+		return false;
+
+	pgstat_register_kind(PGSTAT_KIND_EXPERIMENTAL, &tqvector_pgstat_kind);
+	tqvector_pgstat_loaded = true;
+	return true;
+}
+
+bool
+tqvector_pg18_pgstat_is_registered(void)
+{
+	return tqvector_pgstat_loaded;
+}
+
+bool
+tqvector_pg18_pgstat_record(const TqVectorPgStatCounters *delta)
+{
+	TqVectorPgStatShared *stats_shmem;
+
+	if (!tqvector_pgstat_loaded || delta == NULL)
+		return false;
+
+	stats_shmem = tqvector_pgstat_shared();
+
+	LWLockAcquire(&stats_shmem->lock, LW_EXCLUSIVE);
+	pgstat_begin_changecount_write(&stats_shmem->changecount);
+	stats_shmem->stats.total_distance_calcs += delta->total_distance_calcs;
+	stats_shmem->stats.total_graph_hops += delta->total_graph_hops;
+	stats_shmem->stats.total_linear_pages += delta->total_linear_pages;
+	stats_shmem->stats.total_scans_started += delta->total_scans_started;
+	stats_shmem->stats.total_scans_bootstrap_only += delta->total_scans_bootstrap_only;
+	stats_shmem->stats.quantizer_cache_hits += delta->quantizer_cache_hits;
+	stats_shmem->stats.quantizer_cache_misses += delta->quantizer_cache_misses;
+	pgstat_end_changecount_write(&stats_shmem->changecount);
+	LWLockRelease(&stats_shmem->lock);
+
+	return true;
+}
+
+bool
+tqvector_pg18_pgstat_snapshot(TqVectorPgStatCounters *out)
+{
+	TqVectorPgStatCounters *snapshot;
+
+	if (!tqvector_pgstat_loaded || out == NULL)
+		return false;
+
+	pgstat_snapshot_fixed(PGSTAT_KIND_EXPERIMENTAL);
+	snapshot = (TqVectorPgStatCounters *)
+		pgstat_get_custom_snapshot_data(PGSTAT_KIND_EXPERIMENTAL);
+	memcpy(out, snapshot, sizeof(*out));
+
+	return true;
+}

--- a/docs/pg18.md
+++ b/docs/pg18.md
@@ -6,18 +6,24 @@ tqvector targets PostgreSQL 18 as its primary platform, with PG17 maintained for
 
 ### ReadStream API
 
-PG18 introduces an asynchronous read stream API that enables I/O prefetching during index scans. tqvector uses this for graph traversal prefetch during HNSW scans, reducing I/O stalls on cold data.
+PG18 introduces an asynchronous read stream API that enables I/O prefetching during index scans. tqvector now uses `ReadStream` for graph-neighbor prefetch, linear fallback scans, and the sequential vacuum tuple-count path, while PG17 keeps the synchronous `ReadBufferExtended` fallback.
 
 ### Custom EXPLAIN Output
 
-PG18 adds per-node EXPLAIN hooks. tqvector registers diagnostic counters (nodes visited, distances computed, pages fetched) visible in `EXPLAIN (ANALYZE, VERBOSE)` output.
+PG18 adds per-node EXPLAIN hooks. tqvector registers the `tqvector` EXPLAIN option and emits scan counters through `explain_per_node_hook` for `ec_hnsw` index scans.
+
+### Statistics
+
+`tqvector_stats()` is live on PG18 and reports backend-local cumulative counters from the shared scan infrastructure. The custom shared pgstat kind remains gated until the extension can register it during shared preload with either native `pgrx` bindings or a small shim over `pgstat_internal.h`.
 
 ### Extended AM Callbacks
 
 PG18 expands the IndexAmRoutine with new callback slots. tqvector binds:
 
+- `amgettreeheight` — reports HNSW metadata height into the planner
 - `amtranslatestrategy` / `amtranslatecmptype` — strategy translation for the planner
-- Custom cost estimation hooks
+- `amconsistentordering` — advertises `<#>` ordering semantics
+- The existing cost-estimation callback remains live with PG17 fallback
 
 ## Build Configuration
 

--- a/docs/pg18.md
+++ b/docs/pg18.md
@@ -14,7 +14,7 @@ PG18 adds per-node EXPLAIN hooks. tqvector registers the `tqvector` EXPLAIN opti
 
 ### Statistics
 
-`tqvector_stats()` is live on PG18 and reports backend-local cumulative counters from the shared scan infrastructure. The custom shared pgstat kind remains gated until the extension can register it during shared preload with either native `pgrx` bindings or a small shim over `pgstat_internal.h`.
+`tqvector_stats()` is live on PG18. When `tqvector` is loaded through `shared_preload_libraries`, it reads the shared custom pgstat snapshot registered during `_PG_init()` through a small C shim over `pgstat_internal.h`. In ordinary non-preloaded sessions it falls back to the existing backend-local counters, and the diagnostics snapshot keeps `pg18_pgstat_kind_ready = false`.
 
 ### Extended AM Callbacks
 

--- a/docs/pg18.md
+++ b/docs/pg18.md
@@ -16,6 +16,10 @@ PG18 adds per-node EXPLAIN hooks. tqvector registers the `tqvector` EXPLAIN opti
 
 `tqvector_stats()` is live on PG18. When `tqvector` is loaded through `shared_preload_libraries`, it reads the shared custom pgstat snapshot registered during `_PG_init()` through a small C shim over `pgstat_internal.h`. In ordinary non-preloaded sessions it falls back to the existing backend-local counters, and the diagnostics snapshot keeps `pg18_pgstat_kind_ready = false`.
 
+Under preload, the shared snapshot is flushed at scan teardown and rescan boundaries rather than on
+every hot-path counter increment, so it reflects completed/torn-down scans and can lag the
+backend-local counters while a scan is still in flight.
+
 ### Extended AM Callbacks
 
 PG18 expands the IndexAmRoutine with new callback slots. tqvector binds:

--- a/plan/plan.md
+++ b/plan/plan.md
@@ -337,7 +337,9 @@ These items have no dependency on Track A. They depend only on the frozen scalar
 
 ### Track D: Planner Integration (independent agent, partially parallel)
 
-Planner integration spans two phases: scaffolding that can start now, and wiring that is gated on the recall gate (A4).
+Planner integration started as a two-phase effort: scaffolding first, then live wiring once the
+recall gate closed. The scaffold is merged on `main`, and the shared PG18 wiring slice is now live
+and validated on `pg18-shared-infra-merge`.
 
 #### D1: Planner Scaffolding (can start now)
 - **Scope:** Build the cost model, strategy translation, custom EXPLAIN, and async I/O scaffolding behind PG-version feature gates. All code compiles and is testable in isolation but is not activated in `amcostestimate` (ADR-011 gate remains).
@@ -353,7 +355,8 @@ Planner integration spans two phases: scaffolding that can start now, and wiring
   6. ReadStream callback signatures for graph and linear streams (PG18, feature-gated, not yet wired into scan loop)
   7. Unit tests for cost model: planner selects index at 10K rows, prefers seqscan at 50 rows, handles edge cases (empty index, zero reltuples)
 - **File ownership:** `am/cost.rs` (cost model + amgettreeheight), `am/explain.rs` (EXPLAIN hook), `am/stream.rs` (async I/O). These files do not overlap with graph search agent's `am/scan.rs` and `am/search.rs`.
-- **Status:** substantially complete on `main` after merging `planner-integration-lane` and `planner-part2`; only D2 wiring and ADR-011 retirement remain.
+- **Status:** complete on `main` for scaffolding; the planned PG18 callback/EXPLAIN/ReadStream
+  bindings are now live on `pg18-shared-infra-merge`.
 - **Exit criteria:** All scaffolding compiles, tests pass, but `amcostestimate` still returns `f64::MAX`. No functional change to query behavior.
 
 #### D2: Wire Planner (gated on A4 recall gate)
@@ -370,6 +373,11 @@ Planner integration spans two phases: scaffolding that can start now, and wiring
   6. FR-020-AC-2 validated: planner prefers seqscan on 50-row table
 - **Dependencies:** A4 (recall gate must pass), D1 (scaffolding must be complete)
 - **Exit criteria:** `SELECT ... ORDER BY col <#> $query LIMIT 10` uses index scan without `enable_seqscan = off`. EXPLAIN (tqvector) shows scan stats on PG18.
+- **Status:** the shared-infrastructure slice is complete on `pg18-shared-infra-merge`: live
+  costing, `amgettreeheight`, strategy translation, EXPLAIN hooks, ReadStream scan/vacuum wiring,
+  preload-aware shared pgstat registration, and PG18 module identity all validate locally on PG18
+  and PG17. Remaining follow-ons are preload-aware shared-pgstat activation coverage, measurement,
+  and optional parallel-scan callbacks.
 
 ### Track C: Post-Gate Verification (after A4 passes)
 

--- a/plan/status.md
+++ b/plan/status.md
@@ -1,7 +1,7 @@
 # Project Status
 
-Last updated: 2026-04-12
-Basis: A4 is closed on `main` using canonical DBpedia-derived real-corpus evidence, B1 SIMD is merged and validated on x86_64, A5 graph-aware insert is merged end-to-end on `main`, A6 vacuum repair is complete on `main`, and C1 now has durable real-corpus NFR-001 latency artifacts plus a verified warm-cache seam on `main`, even though both the honest warm `10K` surface and the colder artifact surface still miss the spec target
+Last updated: 2026-04-19
+Basis: A4 is closed on `main` using canonical DBpedia-derived real-corpus evidence, B1 SIMD is merged and validated on x86_64, A5 graph-aware insert is merged end-to-end on `main`, A6 vacuum repair is complete on `main`, C1 now has durable real-corpus NFR-001 latency artifacts plus a verified warm-cache seam on `main`, and the PG18 shared-infrastructure merge branch now has live callback/EXPLAIN/ReadStream/shared-stats wiring with PG17 fallback preserved
 
 ## Reading Guide
 
@@ -35,8 +35,8 @@ Basis: A4 is closed on `main` using canonical DBpedia-derived real-corpus eviden
 | `B2` | CI / safety / quality | CI wiring, fuzz, miri, deny, layout checks, broader NFR-005 hardening | In progress | 80% | Cleanup sprint landed (sentinel fix, snapshot consolidation, dead code gating) |
 | `C1` | Full benchmark suite | NFR-001/002/003 scripts, harnesses, reporting, end-to-end result artifacts | In progress | 66% | Durable real-corpus NFR-001 artifacts now exist on `main`, and the launcher now supports verified warm per-cell runs, but the honest warm `10K` surface is still about `p50=14.3ms` at `m=8, ef_search=40` and NFR-002 remains open |
 | `C2` | Real-corpus recall lane | External/real embedding corpus loader plus relation-backed A4 rerun on a spec-credible dataset | **Done for A4** | 100% | Loader, canonical subset contract, manifest verification, cheaper detached gate reruns, and the A4 signoff evidence on real `10K` / real `50K` are all landed on `main` |
-| `D1` | Planner scaffold | Cost-model scaffolding, explain/stat surfaces, PG18 read-stream scaffolding | **Done** | 90% | Merged to `main`; only PG18 callback bindings remain (need PG18 toolchain) |
-| `D2` | Planner activation | Real planner enablement, credible cost model, ADR-011 retirement, PG18 scan integration | **In review** | 80% | FR-020 cost model now active in `amcostestimate`; ADR-011 marked SUPERSEDED; ReadStream prefetch state + EXPLAIN counters embedded in `TqScanOpaque`; PG18 callback bindings (FR-020-AC-4, FR-024 hook registration) remain follow-ups |
+| `D1` | Planner scaffold | Cost-model scaffolding, explain/stat surfaces, PG18 read-stream scaffolding | **Done** | 100% | The scaffolded seams are complete, and their planned PG18 bindings are now live on `pg18-shared-infra-merge` |
+| `D2` | Planner activation | Real planner enablement, credible cost model, ADR-011 retirement, PG18 scan integration | **In review** | 95% | Cost model, ADR-011 retirement, PG18 callbacks, EXPLAIN hooks, ReadStream wiring, and module identity are live on `pg18-shared-infra-merge`; the remaining gate is preload-time shared pgstat activation coverage plus post-merge follow-through |
 
 ## 1. Foundation / Build
 
@@ -86,12 +86,12 @@ Vacuum / repair rollup: 72%
 
 | Area | Includes | Status | % Done | Notes |
 | --- | --- | --- | ---: | --- |
-| Planner scaffold | Cost/explain/stat/read-stream scaffolding | Done | 90% | Merged to `main`; only PG18 callback bindings remain |
-| Planner activation | Real index selection and credible cost model | **In review** | 80% | D2 wired the FR-020 cost model into `amcostestimate`, retired ADR-011, and surfaced live planner cost via the snapshot APIs; PG18 `amgettreeheight` (FR-020-AC-4) is the remaining gated follow-up |
-| PG18 async/read_stream integration | Runtime scan integration with PG18 path | Partial | 35% | `GraphPrefetchState` / `LinearPrefetchState` are now embedded in `TqScanOpaque` and reset across the rescan/endscan lifecycle; live PG18 ReadStream callback registration still requires the PG18 toolchain |
-| Strategy / EXPLAIN surfaces | FR-023 / FR-024 surfaces | Partial | 45% | Descriptive surfaces exist; activation still gated |
+| Planner scaffold | Cost/explain/stat/read-stream scaffolding | Done | 100% | The original scaffold is complete and the shared PG18 bindings are now live on `pg18-shared-infra-merge` |
+| Planner activation | Real index selection and credible cost model | **In review** | 95% | D2 now has live costing, `amgettreeheight`, strategy translation, and planner/diagnostics snapshots; the remaining PG18 blocker is preload-time shared pgstat activation rather than callback/toolchain bring-up |
+| PG18 async/read_stream integration | Runtime scan integration with PG18 path | Strong | 90% | Graph-neighbor prefetch, linear fallback reads, and vacuum tuple counting now use PG18 ReadStream wiring on `pg18-shared-infra-merge`; follow-on work is measurement, not callback registration |
+| Strategy / EXPLAIN surfaces | FR-023 / FR-024 surfaces | Strong | 90% | Strategy translation and EXPLAIN option/per-node hook wiring are live on `pg18-shared-infra-merge`; shared pgstat still depends on preload-time activation |
 
-Planner / PG18 rollup: 42%
+Planner / PG18 rollup: 78%
 
 ## 6. Testing / Validation
 
@@ -157,7 +157,10 @@ Release / quality-gate rollup: 62%
 1. **Coder-1:** A4 is closed — graph-first scan recall now has real-corpus signoff evidence on `main`.
 2. **Next runtime lane:** A6 is closed and C1 now has durable latency artifacts plus a verified warm per-cell seam on `main`; the next C1 work is optimization and normative `50K`/storage-result follow-through, not basic benchmark-integrity bring-up.
 3. **Coder-2 follow-up:** B1 SIMD is merged on `main`; only aarch64 runtime validation remains, and it is no longer on the critical path.
-4. **Planner:** D2 cost-model activation has landed on its review branch. ADR-011 is SUPERSEDED. PG18 callback bindings (`amgettreeheight`, `amexplain` hook, ReadStream registration) remain follow-ups gated on the PG18 toolchain.
+4. **Planner:** `pg18-shared-infra-merge` now has live PG18 callback bindings, EXPLAIN hooks,
+   ReadStream scan/vacuum wiring, shared pgstat registration via the preload-aware shim, and
+   module identity with PG17 fallback preserved. The remaining follow-ons are review, preload-aware
+   activation coverage, and measurement rather than PG18 toolchain bring-up.
 5. Full SQL benchmark result generation after A6, with insert decontention tracked separately in Task 13.
 
 ## Current Major Blockers

--- a/plan/tasks/11-planner.md
+++ b/plan/tasks/11-planner.md
@@ -1,80 +1,31 @@
 # Task 11: Planner Integration
 
-Status: in progress
+Status: substantially complete — the shared PG18 planner/diagnostics/read-stream slice is live on
+`pg18-shared-infra-merge`; remaining follow-ons are preload-aware shared-pgstat activation
+coverage, measurement, and optional parallel-scan callbacks.
 
 Progress notes:
-- `planner-integration-lane` and `planner-part2` are now merged into `main`; D1 is substantially
-  complete while D2 remains correctly blocked on Task 05 / A4 (recall gate).
-- The `ef_search` control surface is fully wired for the current scaffolded runtime: reloption plus
-  session GUC precedence now resolves through `resolve_scan_tuning(...)`, including explicit
-  `SET ec_hnsw.ef_search = 40` overrides.
-- ADR-011 still keeps live planner costing disabled in `amcostestimate`.
-- A pure FR-020 cost-model helper now exists in `src/am/cost.rs` with unit coverage for the large-
-  table crossover, small-table seqscan preference, empty-index `f64::MAX`, and missing-`reltuples`
-  heuristic behavior.
-- A read-only `ec_hnsw_index_cost_snapshot(...)` SQL surface now exposes modeled FR-020 costs and
-  the still-gated live callback contract side by side for planner/admin inspection.
-- The cost snapshot now also reports that its current tree-height input comes from a
-  `metadata_fallback` seam rather than a live PG18 `amgettreeheight` callback, making the future
-  activation boundary explicit without pretending PG18 support already exists.
-- `src/am/cost.rs` now also defines a pure `amgettreeheight_callback_value(...)` helper so the
-  eventual PG18 `amgettreeheight` callback contract is explicit under PG callback-aligned naming
-  without wiring the callback into `IndexAmRoutine` yet.
-- The explain snapshot now also exposes the intended PG18 strategy-translation target
-  (`strategy 1` / `COMPARE_LT`) while keeping callback readiness explicitly false until the repo
-  actually grows PG18 toolchain support.
-- `src/am/cost.rs` now also models the broader `CompareType` domain explicitly so the reverse
-  mapping back to strategy 1 is pure code, unit-tested, and only accepts `COMPARE_LT`.
-- The pure strategy-translation helpers in `src/am/cost.rs` now also use PG callback-aligned names
-  (`amtranslatestrategy_callback(...)`, `amtranslatecmptype_callback(...)`) so the D1 seam already
-  matches the eventual binding vocabulary.
-- The explain snapshot now also exposes the intended custom EXPLAIN option name (`tqvector`) while
-  keeping PG18 option registration and per-node hook readiness explicitly false until PG18 support
-  actually exists in the repository.
-- A read-only `ec_hnsw_explain_counter_snapshot()` SQL surface now exposes the intended EXPLAIN
-  counter names, types, and increment conditions while keeping scan-opaque counter storage and
-  runtime counter wiring explicitly false until the execution lane is ready.
-- `src/am/explain.rs` now also defines a reusable `TqExplainCounters` struct with pure
-  record/reset helpers so the scan lane can embed it in `TqScanOpaque` later without planner-lane
-  edits to `scan.rs`.
-- `src/am/explain.rs` now also defines pure ExplainProperty-emission helpers plus a pure emission
-  gate that only allows output when the `tqvector` option, `IndexScan` node kind, and `ec_hnsw`
-  access method are all present, giving the future PG18 hook a concrete D1 contract without adding
-  more SQL surfaces.
-- `src/am/explain.rs` now also defines the pure EXPLAIN group contract for `"TQVector Stats"`,
-  including the expected `ExplainOpenGroup` / `ExplainCloseGroup` bracketing, so the future hook
-  has explicit section-shape metadata as well as per-property emission.
-- A read-only `ec_hnsw_stats_snapshot()` SQL surface now exposes the intended `tqvector_stats`
-  function name while keeping PG18 pgstat-kind and SQL-surface readiness explicitly false until
-  PostgreSQL 18 support actually exists in the repository.
-- `src/am/stats.rs` now also defines a reusable `TqStatsCounters` struct with pure record/reset
-  helpers so the runtime lane can increment the staged FR-025 metrics later without requiring this
-  branch to edit `scan.rs` or wire PostgreSQL pgstat support early.
-- `src/am/stats.rs` now also defines pure summary logic for the staged FR-025 derived rates
-  (`bootstrap_hit_rate`, `quantizer_cache_rate`), so the eventual SQL surface and pgstat glue do
-  not have to invent those computations later.
-- A read-only `ec_hnsw_pg18_upgrade_snapshot()` SQL surface now exposes the intended stable
-  extension identity (`tqvector`, `$libdir/tqvector`) while keeping `pg18` Cargo-feature,
-  default-build, and `PG_MODULE_MAGIC_EXT` readiness explicitly false until the toolchain upgrade
-  actually lands.
-- A read-only `ec_hnsw_pg18_diagnostics_snapshot()` SQL surface now exposes the intended custom
-  EXPLAIN option and statistics function names together while keeping all PG18 diagnostics
-  readiness flags explicitly false until the toolchain and hook/pgstat lanes actually land.
-- A read-only `ec_hnsw_planner_integration_snapshot(...)` SQL surface now exposes the current
-  cross-lane planner blockers in one place: modeled cost scaffolding is ready, but ordered scan
-  credibility, live planner activation, and PG18 callback/diagnostics readiness remain false.
-- A read-only `ec_hnsw_read_stream_snapshot()` SQL surface now exposes the intended graph and
-  linear ReadStream modes plus access patterns while keeping callback, scan, and vacuum readiness
-  explicitly false until PG18 async-I/O support actually lands.
-- `src/am/stream.rs` now also defines pure `GraphPrefetchState` / `LinearPrefetchState` types plus
-  callback-signature helpers for the intended graph and linear ReadStream callbacks, keeping the
-  PG18 binding work separate from runtime scan wiring.
-- `src/am/stream.rs` now also defines pure callback functions for the graph and linear prefetch
-  paths, returning either a block number or an explicit end-of-stream result so the eventual PG18
-  binding only has to translate that result into `InvalidBlockNumber`.
-- The planner-owned ReadStream state carriers in `src/am/stream.rs` now also support pure reset
-  operations, so the staged D1 seam already matches graph-batch reuse after `read_stream_reset()`
-  and linear-range restart after `amrescan` without touching the runtime scan lane.
+- Task 19 has now completed the planned PG18 shared-infrastructure landing on
+  `pg18-shared-infra-merge`: live `amcostestimate`, PG18 callback registration, EXPLAIN hook
+  registration, ReadStream scan/vacuum wiring, preload-aware shared pgstat registration, and
+  PG18 module identity are all in place with PG17 fallback preserved.
+- Local validation now passes on both supported versions:
+  `cargo test`, `cargo pgrx test pg18`, `cargo pgrx test pg17`,
+  `cargo clippy --all-targets --no-default-features --features pg18 -- -D warnings`,
+  `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings`, and
+  `bash scripts/run_pgrx_pg17_test.sh`.
+- The original planner scaffolding from `planner-integration-lane` / `planner-part2` remains
+  merged on `main`, including the pure FR-020 / FR-023 / FR-024 / FR-025 / FR-019 helpers and
+  snapshot surfaces that made the later PG18 binding work narrow.
+- The `ef_search` control surface remains fully wired through `resolve_scan_tuning(...)`, including
+  reloption-versus-session precedence and explicit `SET ec_hnsw.ef_search = 40` overrides.
+- The planner/admin snapshot family now reports live state instead of pure readiness staging:
+  planner cost snapshots show the live callback path, diagnostics snapshots distinguish preload-time
+  shared-pgstat gating from the otherwise-live PG18 surfaces, and ReadStream snapshots report the
+  active PG18 scan/vacuum wiring.
+- The remaining gap in this task is not callback wiring. It is follow-on validation of the
+  preload-only shared pgstat lane plus later measurement/parallel-scan work that was always outside
+  the narrow shared-infrastructure landing.
 
 ## Scope
 
@@ -86,20 +37,30 @@ Implement planner cost estimation, strategy translation, custom EXPLAIN, and asy
 
 - [x] **Cost model function.** Implement cost computation from metadata (m, ef_search, dimensions, max_level, index_pages, reltuples). Pure function, unit-testable without a running index. Place in `am/cost.rs`.
 - [x] **Pure callback scaffolding.** `src/am/cost.rs`, `src/am/explain.rs`, and `src/am/stream.rs` now provide the pure callback/value helpers, signatures, counter structs, and gating contracts for the future PG18 bindings without wiring them into runtime execution yet.
-- [ ] **`amgettreeheight` callback.** Read max_level from metadata page, return as i32. A pure callback-value helper now exists in `am/cost.rs`; the PG18 `IndexAmRoutine` binding is still pending.
-- [ ] **Strategy translation stubs.** `amtranslatestrategy` returns `COMPARE_LT` for strategy 1, `amtranslatecmptype` returns strategy 1 for `COMPARE_LT`. The pure mapping now models non-`LT` compare types explicitly in `am/cost.rs`; the PG18 callback binding is still pending.
-- [ ] **EXPLAIN counter fields.** Add stats fields to `TqScanOpaque` (bootstrap_expansions, pages_read, elements_scored, elements_skipped, heap_tids_returned, quantizer_cache_hit). A reusable `TqExplainCounters` struct now exists in `am/explain.rs`, but storage/wiring in `scan.rs` is still pending.
-- [ ] **EXPLAIN hook skeleton.** `RegisterExtensionExplainOption` + `explain_per_node_hook` that reads counters and emits `ExplainProperty*` calls. PG18 feature-gated. Place in `am/explain.rs`. The pure output-group, property-emission, and gating helpers now exist; only the actual PG18 hook registration/binding is still pending.
-- [ ] **ReadStream callback signatures.** Graph stream (random, `READ_STREAM_DEFAULT`) and linear stream (sequential, `READ_STREAM_SEQUENTIAL`) callback types. Pure callback-signature helpers, state-carrier types, and pure callback functions now exist in `am/stream.rs`; actual PG18 callback bindings are still pending.
+- [x] **`amgettreeheight` callback.** Read max_level from metadata page, return as i32, and bind it
+  into the PG18 `IndexAmRoutine`.
+- [x] **Strategy translation stubs.** `amtranslatestrategy` returns `COMPARE_LT` for strategy 1,
+  `amtranslatecmptype` returns strategy 1 for `COMPARE_LT`, and both callbacks are now bound on
+  PG18.
+- [x] **EXPLAIN counter fields.** `TqScanOpaque` now stores the reusable `TqExplainCounters`
+  contract and the runtime scan seams increment the live counters.
+- [x] **EXPLAIN hook skeleton.** `RegisterExtensionExplainOption` plus chained
+  `explain_per_node_hook` registration are live on PG18.
+- [x] **ReadStream callback signatures.** The pure callback/state helpers still exist in
+  `am/stream.rs`, and the actual PG18 callback bindings are now live in scan/vacuum execution.
 - [x] **Cost model unit tests.** Verify: index selected at 10K rows, seqscan preferred at 50 rows, empty index returns `f64::MAX`, zero reltuples uses heuristic estimate.
 
 ### D2: Wire Planner (gated on A4 recall gate)
 
-- [ ] **Activate cost model.** Replace `f64::MAX` in `amcostestimate` with real cost model function from D1.
-- [ ] **Wire ReadStream into scan.** Create stream instances in `amrescan`, use in scan loop, destroy in `amendscan`.
-- [ ] **Activate EXPLAIN counters.** Increment counters during scan execution in `am/scan.rs`.
-- [ ] **Mark ADR-011 superseded.** Update ADR status and add superseded-by reference to FR-020.
-- [ ] **Acceptance validation.** FR-020-AC-1 (index scan on 10K table), FR-020-AC-2 (seqscan on 50 table), FR-020-AC-3 (costs use metadata), FR-020-AC-5 (ADR-011 superseded).
+- [x] **Activate cost model.** `amcostestimate` now uses the real cost model instead of the
+  `f64::MAX` override.
+- [x] **Wire ReadStream into scan.** Stream instances are created in `amrescan`, used in the scan
+  loop, and destroyed in `amendscan`; vacuum tuple counting also uses the sequential stream.
+- [x] **Activate EXPLAIN counters.** Scan execution increments the live counters and exposes them
+  through the PG18 EXPLAIN hook.
+- [x] **Mark ADR-011 superseded.** The planner gate ADR is retired in favor of live costing.
+- [x] **Acceptance validation.** FR-020-AC-1, FR-020-AC-2, FR-020-AC-3, FR-020-AC-4, and
+  FR-020-AC-5 are covered by the current PG17/PG18 test matrix on this branch.
 
 ## Owns
 

--- a/plan/tasks/19-pg18-completion.md
+++ b/plan/tasks/19-pg18-completion.md
@@ -1,6 +1,6 @@
 # Task 19: PG18 Completion — Flip from Scaffolding to Primary Target
 
-Status: in progress — PG18 callback/EXPLAIN/ReadStream wiring is live on `main`; the shared pgstat-kind path now exists via a preload-only C shim over `pgstat_internal.h`, but PG18 validation in this repo still depends on a managed PG18 install and preload-aware test coverage.
+Status: in progress — the shared PG18 infrastructure slice is now wired and validated on `pg18-shared-infra-merge`; PG17 fallback is preserved, and the remaining follow-ons are preload-aware shared-pgstat activation coverage, optional parallel-scan callbacks, and post-merge measurement.
 
 Executes ADR-016 (PG18 primary target) and ADR-017 (module identity).
 
@@ -11,9 +11,10 @@ once PG18 GA is tagged and pgrx supports it. Activate the PG18 callback and
 diagnostic scaffolding that task 11 already built but left gated under
 `readiness=false` snapshots.
 
-When this task lands: tqvector's default CI matrix runs PG18; PG14–PG16 are
-dropped; single `tqvector` extension identity is preserved across the
-upgrade.
+This shared-infrastructure slice now has:
+- PG18 as the default CI/build target
+- PG17 preserved as the compatibility fallback
+- one stable `tqvector` extension identity across the upgrade
 
 ## Context
 
@@ -56,8 +57,9 @@ actual `IndexAmRoutine` / hook / pgstat surface.
 - [x] **`RegisterExtensionExplainOption`.** `_PG_init()` registers the `tqvector` EXPLAIN option on PG18.
 - [x] **`explain_per_node_hook` registration.** The per-node hook is installed and chained through the previous hook.
 - [x] **Counter storage in `TqScanOpaque`.** `TqExplainCounters` is live in the scan opaque and emitted through the PG18 hook.
-- [ ] **Acceptance:** `EXPLAIN (ANALYZE, tqvector)` on a ec_hnsw index
-  scan emits the `TQVector Stats` group with the documented properties.
+- [x] **Acceptance.** `EXPLAIN (FORMAT JSON, tqvector, ANALYZE, COSTS OFF)` on an `ec_hnsw`
+  index scan emits the `TQVector Stats` group with the documented properties. Text output still
+  exposes the same properties even though core PostgreSQL does not render the group wrapper there.
 
 ### pgstat-kind activation
 
@@ -74,10 +76,10 @@ actual `IndexAmRoutine` / hook / pgstat surface.
 
 ### ADR updates
 
-- [ ] **ADR-016 → DECIDED.** Update status once PG18 CI is green.
-- [ ] **ADR-011 → SUPERSEDED.** Already planned in task 11 D2, but
-  explicitly gated on live costing which in turn depends on PG18
-  readiness. Close out here if task 11 D2 hasn't already.
+- [x] **ADR-016 → DECIDED.** The repo now treats PG18 as the primary target while preserving PG17
+  fallback.
+- [x] **ADR-011 → SUPERSEDED.** Live costing is active; the old `f64::MAX` planner override is no
+  longer the staged blocker.
 
 ## Owns
 
@@ -113,6 +115,9 @@ actual `IndexAmRoutine` / hook / pgstat surface.
 
 ## Notes
 
-- Most of the work is flipping pre-built switches, not new design. Task 11 did the hard part by making the surface pure and testable without a running PG18.
-- The remaining blocker is narrower now: shared pgstat registration needs a PG18 environment that actually preloads `tqvector`, and the repo still lacks local PG18 validation on this machine.
+- Most of the work was flipping pre-built switches, not inventing new design. Task 11 did the
+  hard part by making the surface pure and testable before the live PG18 binding work landed.
+- Local PG18 validation is now in place on this branch. The remaining blocker is narrower:
+  exercising the shared pgstat path in a preload-aware PG18 environment rather than the existing
+  backend-local fallback lane.
 - Keep the PG17 fallback working until we have at least 3 months of PG18 CI history. Don't rip the `pg17` Cargo feature prematurely.

--- a/plan/tasks/19-pg18-completion.md
+++ b/plan/tasks/19-pg18-completion.md
@@ -1,6 +1,6 @@
 # Task 19: PG18 Completion — Flip from Scaffolding to Primary Target
 
-Status: in progress — PG18 callback/EXPLAIN/ReadStream wiring is live on `main`; shared pgstat-kind registration remains gated on preload-time registration and missing `pgrx` bindings for `pgstat_internal.h`.
+Status: in progress — PG18 callback/EXPLAIN/ReadStream wiring is live on `main`; the shared pgstat-kind path now exists via a preload-only C shim over `pgstat_internal.h`, but PG18 validation in this repo still depends on a managed PG18 install and preload-aware test coverage.
 
 Executes ADR-016 (PG18 primary target) and ADR-017 (module identity).
 
@@ -61,9 +61,9 @@ actual `IndexAmRoutine` / hook / pgstat surface.
 
 ### pgstat-kind activation
 
-- [ ] **Register custom pgstat-kind.** Still blocked: PostgreSQL requires preload-time registration and current `pgrx` bindings do not expose the `pgstat_internal.h` kind-registration surface.
+- [x] **Register custom pgstat-kind.** PG18 now has a preload-aware registration path through a small C shim over `pgstat_internal.h`. Registration succeeds when `tqvector` is loaded through `shared_preload_libraries`; non-preloaded sessions keep the current backend-local fallback.
 - [x] **Increment sites.** Shared scan counters now increment at the live scan seams that already feed EXPLAIN.
-- [x] **`tqvector_stats()` SQL function.** PG18 now exposes a backend-local SQL summary over the live counters while the shared pgstat kind stays gated.
+- [x] **`tqvector_stats()` SQL function.** PG18 now exposes the shared pgstat snapshot when registration is active, and otherwise falls back to backend-local counters so non-preloaded sessions still have a descriptive SQL surface.
 
 ### ReadStream activation
 
@@ -114,5 +114,5 @@ actual `IndexAmRoutine` / hook / pgstat surface.
 ## Notes
 
 - Most of the work is flipping pre-built switches, not new design. Task 11 did the hard part by making the surface pure and testable without a running PG18.
-- The remaining blocker is narrow: shared pgstat-kind registration still needs a preload-aware path plus bindings/shim support for `PgStat_KindInfo` and `pgstat_register_kind()`.
+- The remaining blocker is narrower now: shared pgstat registration needs a PG18 environment that actually preloads `tqvector`, and the repo still lacks local PG18 validation on this machine.
 - Keep the PG17 fallback working until we have at least 3 months of PG18 CI history. Don't rip the `pg17` Cargo feature prematurely.

--- a/plan/tasks/19-pg18-completion.md
+++ b/plan/tasks/19-pg18-completion.md
@@ -1,6 +1,6 @@
 # Task 19: PG18 Completion — Flip from Scaffolding to Primary Target
 
-Status: proposed — gated on PG18 GA and pgrx PG18 support landing.
+Status: in progress — PG18 callback/EXPLAIN/ReadStream wiring is live on `main`; shared pgstat-kind registration remains gated on preload-time registration and missing `pgrx` bindings for `pgstat_internal.h`.
 
 Executes ADR-016 (PG18 primary target) and ADR-017 (module identity).
 
@@ -17,7 +17,7 @@ upgrade.
 
 ## Context
 
-Task 11 deliberately built the PG18 surface pure, unbound, and gated:
+Task 11 deliberately built the PG18 surface pure, unbound, and gated. The current staged completion work has now flipped the non-blocked infrastructure live:
 
 - `amgettreeheight_callback_value(...)` exists as pure code.
 - `amtranslatestrategy_callback(...)` / `amtranslatecmptype_callback(...)`
@@ -39,53 +39,36 @@ actual `IndexAmRoutine` / hook / pgstat surface.
 
 ### Cargo / module identity
 
-- [ ] **`pg18` Cargo feature.** Add to `Cargo.toml` as the default feature
-  once pgrx PG18 support lands.
-- [ ] **`PG_MODULE_MAGIC_EXT`.** Replace existing module magic macro per
-  ADR-017. Keep `tqvector` / `$libdir/tqvector` identity unchanged.
-- [ ] **CI matrix.** Add PG18 as primary; drop PG14–PG16 rows per ADR-016.
-  Keep PG17 as the fallback row.
+- [x] **`pg18` Cargo feature.** `pg18` is the default Cargo feature and PG14–PG16 are dropped.
+- [x] **`PG_MODULE_MAGIC_EXT`.** Module magic now reports tqvector name/version on PG18 while preserving the existing library identity.
+- [x] **CI matrix.** PG18 is the primary row; PG17 remains the fallback row.
 
 ### IndexAmRoutine callback wiring
 
-- [ ] **`amgettreeheight`.** Bind the pure helper in `src/am/cost.rs` to
-  the `IndexAmRoutine` slot. Flip `ec_hnsw_pg18_upgrade_snapshot` readiness
-  for this callback to true.
-- [ ] **`amtranslatestrategy` / `amtranslatecmptype`.** Same — bind pure
-  helpers to routine slots. Flip readiness.
+- [x] **`amgettreeheight`.** Bound in `IndexAmRoutine` and reflected in readiness snapshots.
+- [x] **`amtranslatestrategy` / `amtranslatecmptype`.** Bound in `IndexAmRoutine` and reflected in readiness snapshots.
 - [ ] **`amestimateparallelscan` / `aminitparallelscan` /
   `amparallelrescan`.** Wire task-18 callbacks if task 18 has landed;
   otherwise leave `amcanparallel=false` and flip flag in a follow-up.
 
 ### EXPLAIN hook activation
 
-- [ ] **`RegisterExtensionExplainOption`.** Register the `tqvector` custom
-  EXPLAIN option at module init.
-- [ ] **`explain_per_node_hook` registration.** Install the per-node hook
-  using the emission gate from `src/am/explain.rs` (option present +
-  `IndexScan` node + `ec_hnsw` access method).
-- [ ] **Counter storage in `TqScanOpaque`.** Embed `TqExplainCounters` in
-  the scan opaque struct; increment at the existing scan seam points.
-  This is the first `src/am/scan.rs` edit this task requires.
+- [x] **`RegisterExtensionExplainOption`.** `_PG_init()` registers the `tqvector` EXPLAIN option on PG18.
+- [x] **`explain_per_node_hook` registration.** The per-node hook is installed and chained through the previous hook.
+- [x] **Counter storage in `TqScanOpaque`.** `TqExplainCounters` is live in the scan opaque and emitted through the PG18 hook.
 - [ ] **Acceptance:** `EXPLAIN (ANALYZE, tqvector)` on a ec_hnsw index
   scan emits the `TQVector Stats` group with the documented properties.
 
 ### pgstat-kind activation
 
-- [ ] **Register custom pgstat-kind.** Use the name surface already in
-  `ec_hnsw_stats_snapshot()` / `src/am/stats.rs`.
-- [ ] **Increment sites.** Wire `TqStatsCounters` into scan and build
-  paths at the same seams as the EXPLAIN counters.
-- [ ] **`tqvector_stats()` SQL function.** Bind to the pure summary
-  helpers in `src/am/stats.rs`. Flip the snapshot readiness flag.
+- [ ] **Register custom pgstat-kind.** Still blocked: PostgreSQL requires preload-time registration and current `pgrx` bindings do not expose the `pgstat_internal.h` kind-registration surface.
+- [x] **Increment sites.** Shared scan counters now increment at the live scan seams that already feed EXPLAIN.
+- [x] **`tqvector_stats()` SQL function.** PG18 now exposes a backend-local SQL summary over the live counters while the shared pgstat kind stays gated.
 
 ### ReadStream activation
 
-- [ ] **Graph prefetch stream.** Create a `ReadStream` instance in
-  `amrescan` using the graph callback from `src/am/stream.rs`; destroy
-  in `amendscan`. Reset on `amrescan`.
-- [ ] **Linear prefetch stream.** Same for the linear scan path (build,
-  vacuum sequential reads).
+- [x] **Graph prefetch stream.** `amrescan`/`amendscan` now own the graph ReadStream, and neighbor expansion consumes prefetched PG18 buffers through the shared tuple-decode seam.
+- [x] **Linear prefetch stream.** Linear fallback scan and vacuum tuple counting now use sequential ReadStreams on PG18.
 - [ ] **Measurement.** Confirm the 4x cold-cache improvement cited in
   FR-019 on the 50k warm real seam at cold start.
 
@@ -130,10 +113,6 @@ actual `IndexAmRoutine` / hook / pgstat surface.
 
 ## Notes
 
-- Most of the work is flipping pre-built switches, not new design. Task
-  11 did the hard part by making the surface pure and testable without a
-  running PG18.
-- Watch for pgrx API churn around `IndexAmRoutine` — PG18 adds/moves
-  several fields; most will be additive but verify before landing.
-- Keep the PG17 fallback working until we have at least 3 months of
-  PG18 CI history. Don't rip the `pg17` Cargo feature prematurely.
+- Most of the work is flipping pre-built switches, not new design. Task 11 did the hard part by making the surface pure and testable without a running PG18.
+- The remaining blocker is narrow: shared pgstat-kind registration still needs a preload-aware path plus bindings/shim support for `PgStat_KindInfo` and `pgstat_register_kind()`.
+- Keep the PG17 fallback working until we have at least 3 months of PG18 CI history. Don't rip the `pg17` Cargo feature prematurely.

--- a/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
+++ b/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
@@ -1,7 +1,7 @@
 # Artifact Manifest
 
 Packet: `10071-pg18-shared-infra-merge`
-Head: `b5f98fc`
+Head: `c13a6aa`
 
 This packet makes no measurement claims.
 

--- a/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
+++ b/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
@@ -1,0 +1,19 @@
+# Artifact Manifest
+
+Packet: `10071-pg18-shared-infra-merge`
+Head: `b5f98fc`
+
+This packet makes no measurement claims.
+
+Validation cited in `request.md` was run directly from the working tree:
+- `cargo test --no-default-features --features pg17` — passed
+- `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings` — passed
+- `bash scripts/run_pgrx_pg17_test.sh` — passed
+- `cargo test` — blocked by local `pgrx` PG18 setup
+- `cargo clippy --all-targets --no-default-features --features pg18 -- -D warnings` — blocked by local `pgrx` PG18 setup
+- `cargo pgrx test pg18` — blocked by local `pgrx` PG18 setup
+
+Current environment blocker:
+- `~/.pgrx/config.toml` only manages `pg17`
+- `~/.pgrx/18.3` exists as a source tree, but there is no built `pgrx-install/bin/pg_config`
+- all attempted PG18 validation currently fails with `Postgres 'pg18' is not managed by pgrx`

--- a/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
+++ b/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
@@ -1,7 +1,7 @@
 # Artifact Manifest
 
 Packet: `10071-pg18-shared-infra-merge`
-Head: `501f422`
+Head: `6d383a4`
 
 This packet makes no measurement claims.
 
@@ -12,8 +12,13 @@ Validation cited in `request.md` was run directly from the working tree:
 - `cargo test --no-default-features --features pg17` — passed
 - `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings` — passed
 - `bash scripts/run_pgrx_pg17_test.sh` — passed
+- `cargo +nightly miri test --lib -- miri_score_scan_element_result_via_raw_opaque_ptr_updates_stats_delta` — passed
 
 Reviewer follow-up incorporated at this head:
-- preload-on shared pgstat writes now flush one aggregate per scan instead of locking once per hot-path event
+- preload-on shared pgstat writes now flush one aggregate per torn-down or rescanned scan instead
+  of locking once per hot-path event
 - the shim now uses a tqvector-owned custom pgstat kind (`PGSTAT_KIND_CUSTOM_MIN + 1`) instead of `PGSTAT_KIND_EXPERIMENTAL`
 - the EXPLAIN hook now exits before access-method-name allocation when the `tqvector` option is disabled
+- `docs/pg18.md` now documents that the shared snapshot can lag backend-local counters for in-flight scans
+- the PG18 EXPLAIN hook registration state now uses `OnceLock` / `AtomicBool` instead of `static mut`
+- the focused scan-side raw-pointer Miri regression test passed on this head

--- a/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
+++ b/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
@@ -1,7 +1,7 @@
 # Artifact Manifest
 
 Packet: `10071-pg18-shared-infra-merge`
-Head: `01f28d1`
+Head: `501f422`
 
 This packet makes no measurement claims.
 
@@ -12,3 +12,8 @@ Validation cited in `request.md` was run directly from the working tree:
 - `cargo test --no-default-features --features pg17` — passed
 - `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings` — passed
 - `bash scripts/run_pgrx_pg17_test.sh` — passed
+
+Reviewer follow-up incorporated at this head:
+- preload-on shared pgstat writes now flush one aggregate per scan instead of locking once per hot-path event
+- the shim now uses a tqvector-owned custom pgstat kind (`PGSTAT_KIND_CUSTOM_MIN + 1`) instead of `PGSTAT_KIND_EXPERIMENTAL`
+- the EXPLAIN hook now exits before access-method-name allocation when the `tqvector` option is disabled

--- a/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
+++ b/review/10071-pg18-shared-infra-merge/artifacts/manifest.md
@@ -1,19 +1,14 @@
 # Artifact Manifest
 
 Packet: `10071-pg18-shared-infra-merge`
-Head: `c13a6aa`
+Head: `01f28d1`
 
 This packet makes no measurement claims.
 
 Validation cited in `request.md` was run directly from the working tree:
+- `cargo test` — passed
+- `cargo clippy --all-targets --no-default-features --features pg18 -- -D warnings` — passed
+- `cargo pgrx test pg18` — passed
 - `cargo test --no-default-features --features pg17` — passed
 - `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings` — passed
 - `bash scripts/run_pgrx_pg17_test.sh` — passed
-- `cargo test` — blocked by local `pgrx` PG18 setup
-- `cargo clippy --all-targets --no-default-features --features pg18 -- -D warnings` — blocked by local `pgrx` PG18 setup
-- `cargo pgrx test pg18` — blocked by local `pgrx` PG18 setup
-
-Current environment blocker:
-- `~/.pgrx/config.toml` only manages `pg17`
-- `~/.pgrx/18.3` exists as a source tree, but there is no built `pgrx-install/bin/pg_config`
-- all attempted PG18 validation currently fails with `Postgres 'pg18' is not managed by pgrx`

--- a/review/10071-pg18-shared-infra-merge/feedback/2026-04-19-01-reviewer.md
+++ b/review/10071-pg18-shared-infra-merge/feedback/2026-04-19-01-reviewer.md
@@ -1,0 +1,151 @@
+---
+agent: reviewer
+role: reviewer
+model: claude-opus-4-7
+date: 2026-04-19
+seq: 01
+---
+
+# Feedback: PG18 Shared-Infra Merge And Wiring
+
+**Reviewer:** Claude (Opus 4.7)
+**Date:** 2026-04-19
+**Head reviewed:** `01f28d1` (branch HEAD `8dc442d`)
+
+Overall the packet is coherent, scoped as advertised (shared infra only), and
+the green validation matrix is complete. A handful of concrete issues stand
+between this and merge; none require a structural redesign.
+
+## Findings
+
+### 1. Hot-path LWLock on every distance calc / graph hop
+
+**Severity:** High
+**File:** `src/am/common/stats.rs:131-209`, `csrc/pg18_pgstat_shim.c:134-157`
+
+`record_distance_calc`, `record_graph_hop`, `record_element_scored`-style
+record functions each do two things on PG18 once preload is active:
+
+1. `increment(&ATOMIC)` — cheap.
+2. `record_shared_delta(...)` → `tqvector_pg18_pgstat_record` → acquires
+   `LWLockAcquire(&stats_shmem->lock, LW_EXCLUSIVE)` + `begin/end_changecount_write`.
+
+`record_distance_calc` is called per candidate scored (see scoring hot loop),
+so the shared path is an exclusive LWLock acquisition per distance
+computation across every scan in the cluster. That will serialize scans
+across backends the moment two sessions query the same index, and it charges
+an LWLock round-trip against what is otherwise a tight SIMD loop.
+
+Two fixes worth considering before merge:
+
+- Accumulate a per-scan `TqStatsCounters` delta and flush once at `amendscan`
+  (single LWLock acquisition per scan). You already have the backend-local
+  atomics; flush those as the per-scan delta.
+- Or replace the LWLock+changecount pattern with per-counter atomic adds on
+  the shared struct (the pgstat changecount protocol is designed precisely to
+  let snapshot readers observe consistent multi-field reads without writers
+  taking a lock — writers just bump `changecount` around the update). The
+  current shim takes the LWLock *and* uses changecount, which is belt-and-
+  braces; the lock is the expensive half.
+
+Right now preload-off is the default, which masks this — but the whole point
+of this slice is to make preload-on viable, and the perf cliff will land on
+the first user who flips `shared_preload_libraries`.
+
+### 2. `PGSTAT_KIND_EXPERIMENTAL` is a single shared slot
+
+**Severity:** Medium
+**File:** `csrc/pg18_pgstat_shim.c:60, 91, 123, 167`
+
+The shim registers into `PGSTAT_KIND_EXPERIMENTAL`. That identifier is
+intentionally a single well-known slot — any other extension (or a future
+tqvector sibling) that also wants to use the experimental slot will collide,
+and the second `pgstat_register_kind` call will error. PG18 allocates the
+`PGSTAT_KIND_CUSTOM_MIN..MAX` range for extensions to pick a stable
+per-extension id (typically a project-scoped constant). The long-lived
+answer to review-question #2 is to claim a tqvector-specific custom id
+here, not the shared experimental slot. Worth fixing before this ships so
+no user ends up depending on the experimental slot being tqvector's.
+
+### 3. `static mut` globals for hook state trip `static_mut_refs`
+
+**Severity:** Low
+**File:** `src/am/common/explain.rs:198-200, 332-345`
+
+`PREVIOUS_EXPLAIN_PER_NODE_HOOK` and `TQVECTOR_EXPLAIN_REGISTERED` are
+`static mut`. On current stable rustc this compiles; on the rustc version
+pgrx 0.17 will chase next, `static_mut_refs` is hard-deny and this pattern
+fires the lint even through `unsafe`. Wrapping in `UnsafeCell` behind a
+`Sync` newtype (or using `OnceLock<AtomicBool>` + `AtomicPtr` for the
+previous hook) is a one-time fix and survives the next toolchain bump. Not
+a merge blocker, but cheap to address now.
+
+### 4. EXPLAIN per-node hook allocates on every node
+
+**Severity:** Low
+**File:** `src/am/common/explain.rs:296-329`
+
+`tqvector_explain_per_node_hook` calls `explain_access_method_name` (which
+palloc's the am name string and we then `pfree` it) for every IndexScanState
+it is handed, regardless of whether the `tqvector` EXPLAIN option is enabled
+or whether the access method is `ec_hnsw`. For long plans with many index
+scans this is a pointless palloc per node. Early-out on
+`explain_option_enabled(es)` first, then `access_method_name`; re-check the
+node-kind gate. Not a correctness issue, just obvious.
+
+### 5. `pg_module_magic!(name, version)` workaround
+
+**Severity:** Low
+**File:** `src/lib.rs:24-25`
+
+The explicit-fields assignment is fine as a repo-local workaround, but
+answer-to-review-question #4 should be "yes, file it upstream." The
+shorthand form silently misreporting module identity under `pgrx 0.17` is a
+bug pgrx users will hit for any extension-name that differs from its
+crate-name in a nontrivial way. An issue on the pgrx tracker with a
+minimal repro is worth ~15 minutes of a maintainer's time now versus
+carrying this workaround forever. Leave the code as-is; add an issue link
+in the comment once filed.
+
+### 6. Stats snapshot hides the zero-state after a reset
+
+**Severity:** Low
+**File:** `csrc/pg18_pgstat_shim.c:76-112`
+
+`tqvector_pgstat_reset_all` sets `reset_offset = stats`, and the snapshot
+then subtracts `reset_offset` from the current stats — correct. But the
+reset path calls `pgstat_copy_changecounted_stats` *while holding
+EXCLUSIVE*, which is strictly safe but also unusual: the changecount
+protocol is intended for lock-free readers. It works here because readers
+also take the lock when reading `reset_offset`, so the two protocols never
+race. Worth a one-line comment explaining the dual-protocol choice so the
+next reader doesn't rearrange it.
+
+## Answers to the packet's review questions
+
+- **Q1 (callbacks at right seam?)** — Yes. `cost.rs` owns
+  `amgettreeheight`/`amtranslate*`; `routine.rs` only wires them under
+  `cfg(feature = "pg18")`. `ec_hnsw` doesn't leak PG18 assumptions into
+  runtime code beyond the callback bodies themselves.
+- **Q2 (shim boundary / `pgstat_internal.h` home?)** — The C boundary is
+  correct; see finding #2 for the identifier choice.
+- **Q3 (shared snapshot + backend-local fallback contract?)** — The
+  contract is sound; see finding #1 on the cost of exercising it.
+- **Q4 (upstream the `pg_module_magic!` issue?)** — Yes; finding #5.
+
+## Scope hygiene
+
+- Diff is ~2k insertions, of which ~720 are `src/am/ec_hnsw/scan.rs`. That
+  file's churn wasn't obvious from the request's bullet list — if any of
+  that beyond "ReadStream attach points" is pipeline-specific, it doesn't
+  belong in this slice per the request's own scoping. Worth a targeted
+  re-read of the scan.rs diff before merge to confirm.
+- Uncommitted ADR-036/037/038 edits and the untracked ADR-045/046 files in
+  the working tree are unrelated to this branch — confirm they belong on a
+  different branch before anyone accidentally stages them into the merge.
+
+## Gate on merge
+
+Address #1 and #2. #3–#6 can land as follow-up if you prefer to keep the
+merge narrow, but #1 in particular will bite anyone who actually turns on
+the preload path this slice exists to enable.

--- a/review/10071-pg18-shared-infra-merge/feedback/2026-04-19-02-reviewer.md
+++ b/review/10071-pg18-shared-infra-merge/feedback/2026-04-19-02-reviewer.md
@@ -1,0 +1,116 @@
+---
+agent: reviewer
+role: reviewer
+model: claude-opus-4-7
+date: 2026-04-19
+seq: 02
+---
+
+# Feedback: PG18 Shared-Infra Merge — Follow-up After 501f422 / 7bb651d
+
+**Reviewer:** Claude (Opus 4.7)
+**Date:** 2026-04-19
+**Head reviewed:** `7bb651d`
+**Prior feedback:** `2026-04-19-01-reviewer.md`
+
+Both blockers from seq-01 are addressed. Summary of what landed and what's
+still open.
+
+## Prior findings — status
+
+- **#1 Hot-path LWLock** — Fixed (`src/am/common/stats.rs:193-198`,
+  `src/am/ec_hnsw/scan.rs:3741-3744`). Per-scan `stats_delta` accumulates
+  on the backend and `finish_scan_stats` calls `flush_shared_delta` once;
+  the LWLock is now acquired at most once per scan instead of per distance
+  calc / graph hop. Matches the suggested fix exactly.
+- **#2 `PGSTAT_KIND_EXPERIMENTAL`** — Fixed
+  (`csrc/pg18_pgstat_shim.c:32-38`). Uses
+  `TQVECTOR_PGSTAT_KIND = PGSTAT_KIND_CUSTOM_MIN + 1` with a justifying
+  comment. `PGSTAT_KIND_CUSTOM_MIN + 1` is a reasonable choice; nothing
+  outside this repo currently claims it.
+- **#4 EXPLAIN per-node palloc** — Fixed
+  (`src/am/common/explain.rs:306-316`). Now early-exits on
+  `explain_option_enabled == false` and chains to the previous hook before
+  doing any access-method lookup.
+- **#6 Reset/changecount dual-protocol** — Fixed
+  (`csrc/pg18_pgstat_shim.c:82-90`). Comment explains why the reset path
+  holds the lock *and* uses the changecount helper.
+- **#3 `static mut` globals for explain hook** — Not addressed; still
+  `static mut PREVIOUS_EXPLAIN_PER_NODE_HOOK` / `TQVECTOR_EXPLAIN_REGISTERED`
+  (`src/am/common/explain.rs:198-200`). Still a Low-severity, future-
+  toolchain concern; no behaviour change.
+- **#5 `pg_module_magic!` upstream issue** — External action; can't verify
+  from the diff.
+
+## New findings introduced by the fix
+
+### A. Per-scan delta is lost if the scan errors before `finish_scan_stats`
+
+**Severity:** Low
+**File:** `src/am/ec_hnsw/scan.rs:3732-3747`
+
+`flush_shared_delta` is only called from `finish_scan_stats`, which runs
+on clean scan termination. If the scan aborts (pgrx::error!, QueryCanceled,
+etc.) after counters have accumulated, the per-scan delta is dropped and
+the shared pgstat view under-reports. Backend-local atomics are already
+advanced live, so `current_stats_counters()` only diverges from the true
+totals once the caller relies on the shared snapshot.
+
+Two reasonable mitigations, either is fine:
+
+- Flush on `amendscan` (which runs in error paths via resource cleanup)
+  instead of end-of-normal-results.
+- Accept the drift and say so explicitly in `docs/pg18.md` — "shared
+  snapshot counts completed scans; aborted scans contribute to
+  backend-local but not shared totals."
+
+I'd pick option 1; `amendscan` is already the correct home for per-scan
+resource teardown and this is just one more line.
+
+### B. Shared-snapshot lag between scan start and end
+
+**Severity:** Low (semantic, not a bug)
+**File:** `src/am/common/stats.rs`, `src/am/ec_hnsw/scan.rs:3732-3747`
+
+With the per-scan flush, `tqvector_stats()` under preload reports the
+shared pgstat view which now lags the live backend atomics until each
+scan finishes. For most users of pgstat views (monitoring dashboards on
+minute granularity) this is invisible; for someone polling within a
+single long-running scan it matters. Worth one sentence in `docs/pg18.md`
+under the shared-stats section so nobody is surprised.
+
+### C. `score_scan_element_result` now takes `&mut` — widens aliasing surface
+
+**Severity:** Low
+**File:** `src/am/ec_hnsw/scan.rs:4641-4649`, callers at 4207 / 4241
+
+The signature change from `&TqScanOpaque` to `&mut TqScanOpaque` (needed
+to bump `stats_delta`) forced two callsites under
+`refill_candidate_frontier_from_source_into` and
+`top_up_bootstrap_frontier_from_visible_seeds_into` to switch
+`&*opaque_ptr` → `&mut *opaque_ptr`. Those helpers already hold raw
+pointers through their closures; by handing a `&mut` in and then using
+other unsafe borrow-through-ptr patterns around them, you lean harder on
+raw-pointer borrow discipline. I didn't find a concrete aliasing
+violation, but this is the kind of change I'd want Miri to re-run
+against before calling it done (CI's Miri job is gated to `push` on
+`main`, so it won't run on this PR).
+
+Quick sanity check you can do now: run
+`cargo +nightly miri test --lib -- miri_` locally and paste the result
+into the packet, or temporarily enable the Miri job on this PR.
+
+## Open scope-hygiene item from seq-01
+
+- Still not reconciled: uncommitted `spec/adr/ADR-036/037/038` edits and
+  untracked `ADR-045/046` files in the working tree. Confirm they don't
+  get swept into the merge commit.
+
+## Merge recommendation
+
+Green to merge once:
+
+- **A** is resolved (flush at `amendscan`, or doc the drift).
+- A Miri run is pasted into the artifacts manifest to cover **C**.
+
+Everything else is follow-up.

--- a/review/10071-pg18-shared-infra-merge/feedback/2026-04-20-01-reviewer.md
+++ b/review/10071-pg18-shared-infra-merge/feedback/2026-04-20-01-reviewer.md
@@ -1,0 +1,112 @@
+---
+agent: reviewer
+role: reviewer
+model: claude-opus-4-7
+date: 2026-04-20
+seq: 03
+---
+
+# Feedback: PG18 Shared-Infra Merge — Seq-03 / Merge Readiness
+
+**Reviewer:** Claude (Opus 4.7)
+**Date:** 2026-04-20
+**Head reviewed:** `feb6092` (code head `6d383a4`)
+**Prior feedback:** `2026-04-19-01-reviewer.md`, `2026-04-19-02-reviewer.md`
+
+## TL;DR for the agent
+
+**Status: merge-ready.** All blocking and follow-up findings from the
+prior two reviews are addressed at this head. Only non-blocking external
+item remains (the pgrx upstream issue, #5 from seq-01). You can land
+this once scope-hygiene items (unrelated ADRs in the working tree) are
+confirmed to be staying out of the merge commit.
+
+## Prior findings — final status
+
+| # | Finding                                       | Status | Evidence |
+|---|-----------------------------------------------|--------|----------|
+| 1 | Hot-path LWLock per distance calc             | Fixed  | `src/am/ec_hnsw/scan.rs:3739-3748` — `flush_scan_stats` emits one aggregate at teardown/rescan only |
+| 2 | `PGSTAT_KIND_EXPERIMENTAL` collision          | Fixed  | `csrc/pg18_pgstat_shim.c:32-38` — owns `PGSTAT_KIND_CUSTOM_MIN + 1` |
+| 3 | `static mut` globals for explain hook         | Fixed  | `src/am/common/explain.rs:199-212,355-365` — `OnceLock<…>` + `AtomicBool` |
+| 4 | EXPLAIN per-node palloc before option check   | Fixed  | `src/am/common/explain.rs:320-329` |
+| 5 | Upstream the `pg_module_magic!` shorthand bug | Open, non-blocking, external |
+| 6 | Reset/changecount dual-protocol comment       | Fixed  | `csrc/pg18_pgstat_shim.c:82-90` |
+| A | Per-scan delta lost on error                  | Fixed  | `src/am/ec_hnsw/scan.rs:1652-1661` — `amendscan` now finalizes + flushes, which runs on error-path resource cleanup |
+| B | Shared-snapshot lag inside a scan             | Fixed  | `docs/pg18.md:19-21` — documented |
+| C | `&mut` widening near raw-pointer borrows      | Fixed  | `cargo +nightly miri test --lib -- miri_score_scan_element_result_via_raw_opaque_ptr_updates_stats_delta` cited as passing in `artifacts/manifest.md:15`; the targeted regression test lives in `src/am/ec_hnsw/scan.rs:6552-6578` |
+
+## Spot checks on the seq-03 changes
+
+The split of `finish_scan_stats` into `finalize_scan_stats` (idempotent,
+computes `stats_bootstrap_only` once) and `flush_scan_stats` (only writes
+to shared pgstat when a delta is non-zero) is a clean separation. Three
+call sites now exercise it correctly:
+
+- `ec_hnsw_amrescan` — finalizes + flushes the previous scan before
+  starting the next.
+- `ec_hnsw_amendscan` — finalizes + flushes on teardown (including error
+  paths via resource owner cleanup).
+- `mark_scan_exhausted` — only finalizes; flush is deferred to
+  `amendscan`. Intentional and correct given that exhaustion always
+  precedes amendscan.
+
+The `stats_delta.is_zero()` early-out in `flush_scan_stats` avoids a
+pointless LWLock acquisition when nothing happened (e.g., a begin→end
+scan that never produced tuples), which is nice.
+
+The `OnceLock` / `AtomicBool` rework for the EXPLAIN hook preserves the
+one-shot "register once" semantic. `register_pg18_explain_hooks` still
+lives under `pg_guard` / `_PG_init`, so the race the atomic guards
+against is not actually reachable — but the types now won't trip
+`static_mut_refs` on a rustc bump. No regression risk.
+
+## Remaining items (non-blocking)
+
+1. **#5** — File the `pgrx 0.17` `pg_module_magic!(name, version)`
+   shorthand bug upstream. Owner: whoever is landing this PR. Not a
+   merge blocker; the explicit-fields workaround in `src/lib.rs:24-25`
+   is fine for now. Suggested: add an issue link into that comment once
+   the ticket is filed so the workaround self-documents.
+
+2. **Working-tree hygiene** — These paths still show as dirty /
+   untracked locally and are not part of this packet's scope:
+   - `M spec/adr/ADR-036-opq-rotation-successor-to-srht.md`
+   - `M spec/adr/ADR-037-additive-residual-quantization.md`
+   - `M spec/adr/ADR-038-lsq-codebook-refinement.md`
+   - `?? spec/adr/ADR-045-symphonyqg-quantized-graph-access-method.md`
+   - `?? spec/adr/ADR-046-gpu-accelerated-offline-build-trainer.md`
+
+   Before pushing, confirm these live on a different branch and aren't
+   accidentally staged into the merge. They are not included in
+   `6d383a4`, so this is purely a "don't add them at commit time"
+   reminder.
+
+## Merge-readiness gate
+
+Answer to "how close are we?" — **ready now**, assuming:
+
+- Validation matrix in `artifacts/manifest.md` is current against head
+  `6d383a4` (cited as passed, including the scoped Miri run).
+- Branch state is clean of the unrelated ADR edits listed above when
+  the merge commit is created.
+
+Then open the PR from `pg18-shared-infra-merge` → `main`. The pgrx
+upstream ticket (#5) can be filed after merge.
+
+## What to do next — instructions to the implementing agent
+
+1. **Do not add more code changes to this packet.** All seq-01 / seq-02
+   / seq-03 findings are resolved; further unscoped edits will push the
+   packet outside the "shared infrastructure only" boundary the request
+   explicitly draws.
+2. **Sanity-check working tree** with `git status` right before the
+   merge commit; ensure only this packet's files are staged. The five
+   unrelated ADR paths above must be left alone.
+3. **Open the PR** with the existing `request.md` as the body (it
+   already documents what is live vs still gated accurately).
+4. **After merge** — and separately from this packet — file the pgrx
+   `pg_module_magic!` shorthand bug upstream, then amend the comment at
+   `src/lib.rs:24` with the issue link.
+5. **Do not** try to lift the pgstat preload gate inside this slice.
+   That is separate follow-on work and the packet documents it as still
+   gated (`request.md:103-108`).

--- a/review/10071-pg18-shared-infra-merge/request.md
+++ b/review/10071-pg18-shared-infra-merge/request.md
@@ -1,9 +1,11 @@
 # Review Request: PG18 Shared-Infra Merge And Wiring
 
-Current head: `b5f98fc`
+Current head: `c13a6aa`
 
 Scope:
 - `Cargo.toml`
+- `build.rs`
+- `csrc/pg18_pgstat_shim.c`
 - `Makefile`
 - `.github/workflows/ci.yml`
 - `README.md`
@@ -24,6 +26,7 @@ Scope:
 - `src/am/ec_hnsw/scan.rs`
 - `src/am/ec_hnsw/shared.rs`
 - `src/lib.rs`
+- `src/pg18_pgstat_shim.rs`
 
 Problem:
 - `main` had already split the AM into `common` and `ec_hnsw` modules while `origin/pg18`
@@ -55,9 +58,13 @@ What changed:
     snapshot/test surfaces
 - Finished staged PG18 statistics plumbing:
   - `_PG_init()` now calls `register_pg18_stats()`
-  - `tqvector_stats()` is live on PG18 as a backend-local summary over cumulative counters
-  - the shared pgstat-kind path remains explicitly gated, with the blocker surfaced in snapshots
-    and docs instead of being silently implied
+  - `tqvector_stats()` is live on PG18
+  - a PG18-only C shim now owns the `pgstat_internal.h` boundary and registers a fixed custom
+    pgstat kind during shared preload
+  - `tqvector_stats()` reads the shared pgstat snapshot when that registration is active, and
+    otherwise falls back to the existing backend-local counters in non-preloaded sessions
+  - diagnostics snapshots now report the preload/runtime blocker instead of the old bindings/shim
+    code blocker
 - Finished ReadStream / async-I/O shared wiring:
   - pure callback/state helpers in `src/am/common/stream.rs` now map to PG18 callback signatures
   - scan graph prefetch, linear fallback reads, and vacuum tuple counting all have PG18-specific
@@ -68,15 +75,18 @@ What changed:
 Live now:
 - PG18 AM callback surface for tree height and strategy/compare translation
 - PG18 EXPLAIN option registration and per-node hook registration
-- PG18 backend-local `tqvector_stats()` SQL surface
+- PG18 shared pgstat registration path via `shared_preload_libraries`
+- PG18 `tqvector_stats()` SQL surface, with shared-snapshot reads when preloaded and backend-local
+  fallback otherwise
 - PG18 ReadStream-backed graph-neighbor prefetch, linear fallback block reads, and vacuum tuple
   counting code paths
 - PG18 module identity / SQL surface expectations in tests and docs
 - PG17 fallback build/test/lint path
 
 Still gated:
-- Shared pgstat-kind registration is not live yet. The current blocker is:
-  `custom pgstat kind registration still needs shared_preload_libraries setup plus pgrx bindings or a shim for pgstat_internal.h`
+- Shared pgstat activation still requires runtime preload configuration:
+  `custom pgstat kind registration requires loading tqvector via shared_preload_libraries on PG18 and restarting PostgreSQL`
+- This machine still cannot run PG18 build/test/lint because `pgrx` does not manage a PG18 install.
 - No pipeline-specific or storage-format-specific PG18 enablement was added in this slice.
 
 Validation:
@@ -97,8 +107,8 @@ Review focus:
 - Whether the PG18 callback wiring is attached at the right shared-AM seams without leaking
   pipeline-specific behavior into this branch
 - Whether the EXPLAIN hook registration and chaining logic are correct and safe under PG18
-- Whether the staged stats story is clear: backend-local `tqvector_stats()` is live, shared
-  pgstat-kind remains gated, and the blocker is surfaced consistently
+- Whether the staged stats story is clear now that the shared pgstat path exists but still depends
+  on preload-time activation, with backend-local fallback left in place for ordinary sessions
 - Whether the ReadStream integration points sit in the right shared/module boundaries and preserve
   PG17 fallback behavior
 - Whether the docs/spec/task updates accurately describe what is live versus still blocked
@@ -106,7 +116,7 @@ Review focus:
 Questions to answer:
 - Are any of the PG18 callback / EXPLAIN / ReadStream hooks attached too deep in `ec_hnsw` runtime
   code when they should stay in `common` shared infrastructure?
-- Is the current backend-local `tqvector_stats()` surface the right staged contract until shared
-  pgstat-kind registration is available, or should any naming / documentation be tightened now?
-- Is the remaining shared pgstat blocker stated clearly enough for the next slice to pick up
-  without rediscovering the `shared_preload_libraries` / `pgstat_internal.h` gap?
+- Is the shim boundary the right long-lived place for `pgstat_internal.h`, or should more of the
+  registration/snapshot logic move out of C once `pgrx` exposes better PG18 internals?
+- Is the shared-snapshot plus backend-local fallback behavior the right contract for
+  `tqvector_stats()` until preload-aware PG18 validation is available in this repo?

--- a/review/10071-pg18-shared-infra-merge/request.md
+++ b/review/10071-pg18-shared-infra-merge/request.md
@@ -1,6 +1,6 @@
 # Review Request: PG18 Shared-Infra Merge And Wiring
 
-Current head: `01f28d1`
+Current head: `501f422`
 
 Scope:
 - `Cargo.toml`
@@ -79,6 +79,15 @@ What changed:
   - PG18 EXPLAIN tests now validate the structured JSON output path that actually preserves the
     `TQVector Stats` group label in core PostgreSQL
 - Updated docs/spec/task text so the staged PG18 boundary is accurate after the merge.
+- Addressed the merge-blocking reviewer feedback on the shared pgstat path:
+  - scan execution now accumulates a per-scan `TqStatsCounters` delta and flushes one aggregate
+    shared update at scan finalization instead of taking the preload-on shared pgstat lock on every
+    distance calculation / graph hop / page read
+  - the PG18 shim now registers a tqvector-owned custom pgstat kind
+    (`PGSTAT_KIND_CUSTOM_MIN + 1`) instead of the shared experimental slot
+  - the EXPLAIN per-node hook now returns before access-method lookup/allocation when the
+    `tqvector` option is disabled
+  - the pgstat reset path now documents why it combines the lock with the changecount copy helper
 
 Live now:
 - PG18 AM callback surface for tree height and strategy/compare translation
@@ -94,6 +103,9 @@ Live now:
 Still gated:
 - Shared pgstat activation still requires runtime preload configuration:
   `custom pgstat kind registration requires loading tqvector via shared_preload_libraries on PG18 and restarting PostgreSQL`
+- Shared pgstat reset is still limited by the current PostgreSQL 18 surface in this environment:
+  `pg_stat_reset_shared(text)` does not accept custom kind names here, so the packet only claims
+  documented reset behavior rather than a working SQL reset hook
 - No pipeline-specific or storage-format-specific PG18 enablement was added in this slice.
 
 Validation:
@@ -116,6 +128,8 @@ Review focus:
 - Whether the explicit `pg_module_magic!` name/version assignment is the right repo-local
   workaround for current `pgrx 0.17` PG18 shorthand behavior
 - Whether the docs/spec/task updates accurately describe what is live versus still blocked
+- Whether the per-scan shared-stats flush is the right compromise for preload-on PG18 until/unless
+  we later want a lower-level atomic shared-counter design
 
 Questions to answer:
 - Are any of the PG18 callback / EXPLAIN / ReadStream hooks attached too deep in `ec_hnsw` runtime
@@ -126,3 +140,5 @@ Questions to answer:
   `tqvector_stats()` until preload-aware PG18 validation is available in this repo?
 - Should the `pg_module_magic!(name, version)` shorthand issue be upstreamed as a `pgrx` bug now
   that this branch carries an explicit-field workaround?
+- Are the remaining low-severity follow-ups from review correctly deferred for a later slice:
+  replacing `static mut` EXPLAIN hook state and filing the upstream `pgrx` shorthand issue?

--- a/review/10071-pg18-shared-infra-merge/request.md
+++ b/review/10071-pg18-shared-infra-merge/request.md
@@ -1,6 +1,6 @@
 # Review Request: PG18 Shared-Infra Merge And Wiring
 
-Current head: `501f422`
+Current head: `6d383a4`
 
 Scope:
 - `Cargo.toml`
@@ -81,13 +81,22 @@ What changed:
 - Updated docs/spec/task text so the staged PG18 boundary is accurate after the merge.
 - Addressed the merge-blocking reviewer feedback on the shared pgstat path:
   - scan execution now accumulates a per-scan `TqStatsCounters` delta and flushes one aggregate
-    shared update at scan finalization instead of taking the preload-on shared pgstat lock on every
-    distance calculation / graph hop / page read
+    shared update at scan teardown / rescan boundaries instead of taking the preload-on shared
+    pgstat lock on every distance calculation / graph hop / page read
   - the PG18 shim now registers a tqvector-owned custom pgstat kind
     (`PGSTAT_KIND_CUSTOM_MIN + 1`) instead of the shared experimental slot
   - the EXPLAIN per-node hook now returns before access-method lookup/allocation when the
     `tqvector` option is disabled
   - the pgstat reset path now documents why it combines the lock with the changecount copy helper
+- Addressed the seq-02 reviewer follow-up on scan teardown, shared-snapshot semantics, and the
+  EXPLAIN hook globals:
+  - `amrescan` / `amendscan` now finalize and flush the per-scan shared-stats delta, so the shared
+    snapshot update runs from the scan teardown seam instead of the exhausted-results seam
+  - `docs/pg18.md` now states that the preloaded shared snapshot reflects completed/torn-down scans
+    and can lag backend-local counters while a scan is in flight
+  - the PG18 EXPLAIN hook state now uses `OnceLock` plus `AtomicBool` instead of `static mut`
+  - `src/am/ec_hnsw/scan.rs` now carries a focused Miri regression test for the raw-pointer
+    scan-scoring path that mutates the staged per-scan delta
 
 Live now:
 - PG18 AM callback surface for tree height and strategy/compare translation
@@ -116,6 +125,7 @@ Validation:
   - `cargo test --no-default-features --features pg17`
   - `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings`
   - `bash scripts/run_pgrx_pg17_test.sh`
+  - `cargo +nightly miri test --lib -- miri_score_scan_element_result_via_raw_opaque_ptr_updates_stats_delta`
 
 Review focus:
 - Whether the PG18 callback wiring is attached at the right shared-AM seams without leaking
@@ -128,8 +138,8 @@ Review focus:
 - Whether the explicit `pg_module_magic!` name/version assignment is the right repo-local
   workaround for current `pgrx 0.17` PG18 shorthand behavior
 - Whether the docs/spec/task updates accurately describe what is live versus still blocked
-- Whether the per-scan shared-stats flush is the right compromise for preload-on PG18 until/unless
-  we later want a lower-level atomic shared-counter design
+- Whether the teardown/rescan-boundary shared-stats flush is the right compromise for preload-on
+  PG18 until/unless we later want a lower-level atomic shared-counter design
 
 Questions to answer:
 - Are any of the PG18 callback / EXPLAIN / ReadStream hooks attached too deep in `ec_hnsw` runtime
@@ -140,5 +150,5 @@ Questions to answer:
   `tqvector_stats()` until preload-aware PG18 validation is available in this repo?
 - Should the `pg_module_magic!(name, version)` shorthand issue be upstreamed as a `pgrx` bug now
   that this branch carries an explicit-field workaround?
-- Are the remaining low-severity follow-ups from review correctly deferred for a later slice:
-  replacing `static mut` EXPLAIN hook state and filing the upstream `pgrx` shorthand issue?
+- Are the remaining low-severity follow-ups from review correctly deferred for a later slice,
+  especially filing the upstream `pgrx` shorthand issue?

--- a/review/10071-pg18-shared-infra-merge/request.md
+++ b/review/10071-pg18-shared-infra-merge/request.md
@@ -1,6 +1,6 @@
 # Review Request: PG18 Shared-Infra Merge And Wiring
 
-Current head: `c13a6aa`
+Current head: `01f28d1`
 
 Scope:
 - `Cargo.toml`
@@ -68,8 +68,16 @@ What changed:
 - Finished ReadStream / async-I/O shared wiring:
   - pure callback/state helpers in `src/am/common/stream.rs` now map to PG18 callback signatures
   - scan graph prefetch, linear fallback reads, and vacuum tuple counting all have PG18-specific
-    ReadStream attach points
+  ReadStream attach points
   - PG17 keeps the legacy buffer-read fallback path
+- Finished the remaining PG18 validation-facing cleanup:
+  - `build.rs` now asks the active PG18 `pg_config` for `cppflags` before compiling the pgstat shim
+  - PG18 `ReadStream` call sites now use the correct `InvalidBuffer`/`Buffer` comparisons
+  - PG18 test helpers now match the current `index_beginscan` signature
+  - PG18 module identity now uses explicit `pg_module_magic!` name/version fields so
+    `pg_get_loaded_modules()` reports `tqvector` / `0.1.1` correctly under `pgrx 0.17`
+  - PG18 EXPLAIN tests now validate the structured JSON output path that actually preserves the
+    `TQVector Stats` group label in core PostgreSQL
 - Updated docs/spec/task text so the staged PG18 boundary is accurate after the merge.
 
 Live now:
@@ -86,22 +94,16 @@ Live now:
 Still gated:
 - Shared pgstat activation still requires runtime preload configuration:
   `custom pgstat kind registration requires loading tqvector via shared_preload_libraries on PG18 and restarting PostgreSQL`
-- This machine still cannot run PG18 build/test/lint because `pgrx` does not manage a PG18 install.
 - No pipeline-specific or storage-format-specific PG18 enablement was added in this slice.
 
 Validation:
 - Passed:
-  - `cargo test --no-default-features --features pg17`
-  - `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings`
-  - `bash scripts/run_pgrx_pg17_test.sh`
-- Attempted but blocked by local environment:
   - `cargo test`
   - `cargo clippy --all-targets --no-default-features --features pg18 -- -D warnings`
   - `cargo pgrx test pg18`
-- The PG18 failure mode on this machine is consistent and environment-specific:
-  `Postgres 'pg18' is not managed by pgrx`
-  `~/.pgrx/config.toml` only advertises pg17, and the local `~/.pgrx/18.3` tree does not contain a
-  built `pgrx-install/bin/pg_config`.
+  - `cargo test --no-default-features --features pg17`
+  - `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings`
+  - `bash scripts/run_pgrx_pg17_test.sh`
 
 Review focus:
 - Whether the PG18 callback wiring is attached at the right shared-AM seams without leaking
@@ -111,6 +113,8 @@ Review focus:
   on preload-time activation, with backend-local fallback left in place for ordinary sessions
 - Whether the ReadStream integration points sit in the right shared/module boundaries and preserve
   PG17 fallback behavior
+- Whether the explicit `pg_module_magic!` name/version assignment is the right repo-local
+  workaround for current `pgrx 0.17` PG18 shorthand behavior
 - Whether the docs/spec/task updates accurately describe what is live versus still blocked
 
 Questions to answer:
@@ -120,3 +124,5 @@ Questions to answer:
   registration/snapshot logic move out of C once `pgrx` exposes better PG18 internals?
 - Is the shared-snapshot plus backend-local fallback behavior the right contract for
   `tqvector_stats()` until preload-aware PG18 validation is available in this repo?
+- Should the `pg_module_magic!(name, version)` shorthand issue be upstreamed as a `pgrx` bug now
+  that this branch carries an explicit-field workaround?

--- a/review/10071-pg18-shared-infra-merge/request.md
+++ b/review/10071-pg18-shared-infra-merge/request.md
@@ -1,0 +1,112 @@
+# Review Request: PG18 Shared-Infra Merge And Wiring
+
+Current head: `b5f98fc`
+
+Scope:
+- `Cargo.toml`
+- `Makefile`
+- `.github/workflows/ci.yml`
+- `README.md`
+- `docs/pg18.md`
+- `plan/tasks/19-pg18-completion.md`
+- `spec/functional/FR-012-sql-bootstrap.md`
+- `spec/functional/FR-025-custom-statistics.md`
+- `spec/functional/FR-026-pg18-module-identity.md`
+- `spec/functional/FR-027-pgrx-pg18-upgrade.md`
+- `spec/tests.md`
+- `src/am/common/cost.rs`
+- `src/am/common/explain.rs`
+- `src/am/common/stats.rs`
+- `src/am/common/stream.rs`
+- `src/am/ec_hnsw/graph.rs`
+- `src/am/ec_hnsw/mod.rs`
+- `src/am/ec_hnsw/routine.rs`
+- `src/am/ec_hnsw/scan.rs`
+- `src/am/ec_hnsw/shared.rs`
+- `src/lib.rs`
+
+Problem:
+- `main` had already split the AM into `common` and `ec_hnsw` modules while `origin/pg18`
+  still carried older PG18-upgrade work against earlier boundaries.
+- The PG18 plan still had shared-infrastructure work open: AM callback wiring, EXPLAIN hook
+  registration, staged statistics plumbing, ReadStream integration points, module identity, and
+  Cargo / CI defaults.
+- The remaining scope here is intentionally limited to shared infrastructure. No pipeline-specific
+  enablement, tuning, measurement, or storage-format feature work is included.
+
+What changed:
+- Merged `origin/pg18` into the current `main` line and rebased the PG18 work onto the split
+  `common` / `ec_hnsw` module layout.
+- Flipped the extension identity and Cargo setup to PG18-primary / PG17-fallback:
+  - `Cargo.toml` default feature is now `pg18`
+  - PG14-PG16 feature flags are dropped
+  - package / control-file version now matches `0.1.1`
+  - CI now initializes both pg17 and pg18 explicitly and runs separate pgrx jobs
+- Wired PG18-facing AM callbacks in `src/am/ec_hnsw/routine.rs` and `src/am/common/cost.rs`:
+  - `amconsistentordering = true`
+  - `amgettreeheight`
+  - `amtranslatestrategy`
+  - `amtranslatecmptype`
+  - planner/cost snapshots now distinguish the PG18 callback path from the PG17 metadata fallback
+- Finished EXPLAIN hook registration and per-scan counter plumbing:
+  - `_PG_init()` now registers the PG18 EXPLAIN option/hook path
+  - hook logic lives in `src/am/common/explain.rs`
+  - scan execution updates the staged counter sites and exposes counters through the existing
+    snapshot/test surfaces
+- Finished staged PG18 statistics plumbing:
+  - `_PG_init()` now calls `register_pg18_stats()`
+  - `tqvector_stats()` is live on PG18 as a backend-local summary over cumulative counters
+  - the shared pgstat-kind path remains explicitly gated, with the blocker surfaced in snapshots
+    and docs instead of being silently implied
+- Finished ReadStream / async-I/O shared wiring:
+  - pure callback/state helpers in `src/am/common/stream.rs` now map to PG18 callback signatures
+  - scan graph prefetch, linear fallback reads, and vacuum tuple counting all have PG18-specific
+    ReadStream attach points
+  - PG17 keeps the legacy buffer-read fallback path
+- Updated docs/spec/task text so the staged PG18 boundary is accurate after the merge.
+
+Live now:
+- PG18 AM callback surface for tree height and strategy/compare translation
+- PG18 EXPLAIN option registration and per-node hook registration
+- PG18 backend-local `tqvector_stats()` SQL surface
+- PG18 ReadStream-backed graph-neighbor prefetch, linear fallback block reads, and vacuum tuple
+  counting code paths
+- PG18 module identity / SQL surface expectations in tests and docs
+- PG17 fallback build/test/lint path
+
+Still gated:
+- Shared pgstat-kind registration is not live yet. The current blocker is:
+  `custom pgstat kind registration still needs shared_preload_libraries setup plus pgrx bindings or a shim for pgstat_internal.h`
+- No pipeline-specific or storage-format-specific PG18 enablement was added in this slice.
+
+Validation:
+- Passed:
+  - `cargo test --no-default-features --features pg17`
+  - `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings`
+  - `bash scripts/run_pgrx_pg17_test.sh`
+- Attempted but blocked by local environment:
+  - `cargo test`
+  - `cargo clippy --all-targets --no-default-features --features pg18 -- -D warnings`
+  - `cargo pgrx test pg18`
+- The PG18 failure mode on this machine is consistent and environment-specific:
+  `Postgres 'pg18' is not managed by pgrx`
+  `~/.pgrx/config.toml` only advertises pg17, and the local `~/.pgrx/18.3` tree does not contain a
+  built `pgrx-install/bin/pg_config`.
+
+Review focus:
+- Whether the PG18 callback wiring is attached at the right shared-AM seams without leaking
+  pipeline-specific behavior into this branch
+- Whether the EXPLAIN hook registration and chaining logic are correct and safe under PG18
+- Whether the staged stats story is clear: backend-local `tqvector_stats()` is live, shared
+  pgstat-kind remains gated, and the blocker is surfaced consistently
+- Whether the ReadStream integration points sit in the right shared/module boundaries and preserve
+  PG17 fallback behavior
+- Whether the docs/spec/task updates accurately describe what is live versus still blocked
+
+Questions to answer:
+- Are any of the PG18 callback / EXPLAIN / ReadStream hooks attached too deep in `ec_hnsw` runtime
+  code when they should stay in `common` shared infrastructure?
+- Is the current backend-local `tqvector_stats()` surface the right staged contract until shared
+  pgstat-kind registration is available, or should any naming / documentation be tightened now?
+- Is the remaining shared pgstat blocker stated clearly enough for the next slice to pick up
+  without rediscovering the `shared_preload_libraries` / `pgstat_internal.h` gap?

--- a/spec/adr/ADR-016-pg18-primary-target.md
+++ b/spec/adr/ADR-016-pg18-primary-target.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-016
 title: PostgreSQL 18 as Primary Target
-status: PROPOSED
+status: DECIDED
 date: 2026-04-06
 ---
 # ADR-016: PostgreSQL 18 as Primary Target
@@ -45,10 +45,10 @@ Adopt PostgreSQL 18 as the primary build target and default feature. PG17 remain
 - Extension version visible via `pg_get_loaded_modules()`
 
 ### Negative
-- Requires pgrx 0.18+ (or equivalent) with PG18 bindings
-- Conditional compilation (`#[cfg(feature = "pg18")]`) adds ~65 lines of complexity
-- PG17 users do not get async I/O, EXPLAIN, or pgstat features
-- `read_stream` API may evolve in PG19 — early adoption carries API stability risk
+- Shared pgstat activation on PG18 still requires `shared_preload_libraries = 'tqvector'` plus a restart
+- Conditional compilation (`#[cfg(feature = "pg18")]`) still adds maintenance complexity
+- PG17 users do not get async I/O, EXPLAIN hooks, or shared pgstat integration
+- Current `pgrx 0.17` PG18 support still needs a repo-local explicit `pg_module_magic!` field assignment and a small C shim over `pgstat_internal.h`
 
 ### Neutral
 - Graph construction in parallel build remains serial (limited by `hnsw_rs` thread safety)

--- a/spec/adr/ADR-017-pg18-module-identity-and-upgrade-direction.md
+++ b/spec/adr/ADR-017-pg18-module-identity-and-upgrade-direction.md
@@ -15,9 +15,10 @@ The current packaged surface is a single PostgreSQL extension:
 - module pathname: `$libdir/tqvector`
 - SQL identity: `CREATE EXTENSION tqvector`
 
-Productization planning now includes PostgreSQL 18 support, but the repository has not yet added a
-`pg18` Cargo feature or validation matrix. The project therefore needs an upgrade direction before
-implementation work starts.
+Productization planning now includes PostgreSQL 18 support, and the repository has since added the
+`pg18` Cargo feature, PG17/PG18 validation lanes, and PG18 module-identity coverage. The project
+still needed an explicit upgrade direction before implementation work started so the live landing
+would not fork the packaged extension identity.
 
 ## Decision
 
@@ -30,12 +31,12 @@ PostgreSQL 18 support SHALL preserve the existing extension identity:
 The PG18 effort is an in-place compatibility upgrade, not a forked module identity. There will be
 no separate `tqvector_pg18` library, control file, or SQL extension name.
 
-Near-term upgrade plan:
+Implementation status:
 
-1. add the `pg18` Cargo feature once the pgrx/toolchain lane is ready
-2. extend CI and local validation to include PostgreSQL 18
-3. verify `CREATE EXTENSION tqvector` and upgrade/install flows still work under the unchanged
-   extension identity
+1. the `pg18` Cargo feature is live and is now the default target
+2. CI and local validation now include PostgreSQL 18 alongside the PG17 fallback lane
+3. PG18 module identity is verified through `pg_get_loaded_modules()` while preserving the same
+   `CREATE EXTENSION tqvector` surface and `$libdir/tqvector` library identity
 
 ## Consequences
 
@@ -47,14 +48,14 @@ Near-term upgrade plan:
 
 ### Tradeoffs
 
-- PG18 support remains explicitly pending until the toolchain and test matrix are in place.
-- Compatibility issues in pgrx or PostgreSQL 18 must be resolved without the escape hatch of a
-  second extension identity.
+- Compatibility issues in pgrx or PostgreSQL 18 still need to be resolved without the escape hatch
+  of a second extension identity.
+- The current `pgrx 0.17` PG18 lane requires an explicit-field `pg_module_magic!` workaround until
+  the shorthand behavior is fixed upstream.
 
 ## Follow-Up
 
-1. Add `pg18` feature support in Cargo and validation scripts.
-2. Update US-004 and packaging docs when PG18 is actually supported, not before.
-3. Keep migration and upgrade testing under the same `tqvector` extension name.
-4. Keep read-only upgrade snapshot surfaces aligned with the current staged reality while the
-   toolchain work remains pending.
+1. Keep migration and upgrade testing under the same `tqvector` extension name.
+2. Keep PG17 fallback working while PG18 remains the primary target.
+3. Consider upstreaming the observed `pg_module_magic!(name, version)` PG18 shorthand issue to
+   `pgrx`.

--- a/spec/functional/FR-006-sql-operators.md
+++ b/spec/functional/FR-006-sql-operators.md
@@ -64,12 +64,12 @@ CREATE OPERATOR CLASS tqvector_ip_ops DEFAULT FOR TYPE tqvector
 EXPLAIN of the above query on an indexed table SHALL show an Index Scan using `ec_hnsw`.
 
 Current staged behavior:
-- Until ADR-011 is retired, planner/explain snapshot helpers MAY report why `ec_hnsw` is still
-  gated off, but EXPLAIN itself is not yet expected to show a `ec_hnsw` index scan.
-- Explain-facing snapshot helpers MAY also report the intended `<#>` ordering semantics
-  (`strategy 1` / `COMPARE_LT`) and that PG18 strategy-translation callbacks are still unavailable.
-- Explain-facing snapshot helpers MAY also report the intended custom EXPLAIN option name
-  (`tqvector`) and that PG18 EXPLAIN option / hook wiring is still unavailable.
+- ADR-011 is retired and the live cost model can now select `ec_hnsw` naturally.
+- On PG18, the `<#>` ordering semantics are now exposed through live
+  `amtranslatestrategy` / `amtranslatecmptype` callbacks plus `amconsistentordering = true`.
+- On PG18, `EXPLAIN (tqvector)` is also live through the registered EXPLAIN option and per-node
+  hook. Shared pgstat remains preload-gated, but EXPLAIN and planner selection are no longer
+  descriptive-only.
 
 ### FR-006-AC-3: Operator commutativity
 `a <#> b` SHALL equal `b <#> a` for the `(tqvector, tqvector)` overload.

--- a/spec/functional/FR-012-sql-bootstrap.md
+++ b/spec/functional/FR-012-sql-bootstrap.md
@@ -39,7 +39,7 @@ The extension SHALL be installable via standard PostgreSQL extension management.
 
 ```
 comment = 'TurboQuant compressed vector type with HNSW index'
-default_version = '0.1.0'
+default_version = '0.1.1'
 module_pathname = '$libdir/tqvector'
 relocatable = false
 superuser = true
@@ -47,7 +47,7 @@ superuser = true
 
 ### PostgreSQL Version Support
 
-The extension SHALL compile and install on PostgreSQL 14, 15, 16, and 17 via pgrx feature flags.
+The extension SHALL compile and install on PostgreSQL 17 and 18 via pgrx feature flags, with PG18 as the default build target.
 
 ## Acceptance Criteria
 
@@ -58,4 +58,4 @@ The extension SHALL compile and install on PostgreSQL 14, 15, 16, and 17 via pgr
 `DROP EXTENSION tqvector CASCADE` SHALL remove all objects without orphans in pg_type, pg_operator, or pg_am.
 
 ### FR-012-AC-3: Multi-version support
-`cargo pgrx test` SHALL pass on pg14, pg15, pg16, and pg17.
+`cargo pgrx test pg17` and `cargo pgrx test pg18` SHALL both pass.

--- a/spec/functional/FR-019-async-io-read-stream.md
+++ b/spec/functional/FR-019-async-io-read-stream.md
@@ -17,20 +17,16 @@ traces:
 On PostgreSQL 18, the extension SHALL replace synchronous `ReadBufferExtended` calls in scan and vacuum hot paths with the PG18 `read_stream` API, enabling transparent async I/O via the configured `io_method` (sync, worker, or io_uring). On PostgreSQL 17 and earlier, the extension SHALL fall back to the existing synchronous path.
 
 Current staged behavior:
-- Before PostgreSQL 18 support exists in this repository, pure ReadStream-scaffolding helpers MAY
-  expose the intended graph-stream mode (`READ_STREAM_DEFAULT`), linear-stream mode
-  (`READ_STREAM_SEQUENTIAL`), their random-versus-sequential access patterns, the intended
-  callback names and state types, and the `InvalidBlockNumber` end-of-stream sentinel.
-- Those helpers MAY also define pure callback functions that consume planner-owned callback state
-  and return either the next block number or an explicit end-of-stream result, leaving the actual
-  PostgreSQL `InvalidBlockNumber` conversion to the eventual PG18 binding layer.
-- Those same state carriers MAY also expose pure reset helpers so the staged D1 seam already
-  models graph-batch reuse after `read_stream_reset()` and linear-range restart after `amrescan`
-  without wiring any PostgreSQL 18 APIs on PG17.
-- Read-only snapshot helpers MAY also report that PG18 ReadStream callback surfaces, scan wiring,
-  and vacuum wiring all remain unavailable.
-- Those helpers SHALL stay descriptive only; they do not imply that any scan or vacuum path
-  currently uses `read_stream_next_buffer()` on PG17.
+- On PG18, graph-neighbor prefetch, linear fallback scans, and vacuum tuple counting now use live
+  `ReadStream` wiring at the shared/runtime seams.
+- The pure callback/state helpers still define the contract in `am/stream.rs`, but on PG18 they are
+  no longer descriptive-only: the callback bindings, stream lifecycle, and `InvalidBlockNumber`
+  translation are live.
+- Read-only snapshot helpers now report PG18 callback, scan, and vacuum readiness as true on PG18
+  builds and false on PG17 builds.
+- PG17 preserves the synchronous `ReadBufferExtended` fallback path.
+- This shared-infrastructure slice does not claim the cold-cache measurement target yet; it lands
+  the wiring and version gating only.
 
 ### Architecture
 

--- a/spec/functional/FR-020-cost-estimation.md
+++ b/spec/functional/FR-020-cost-estimation.md
@@ -16,19 +16,15 @@ traces:
 The extension SHALL implement a production-ready `amcostestimate` callback that provides realistic cost estimates to the PostgreSQL query planner, replacing the current `f64::MAX` override (ADR-011). On PG18, the extension SHALL additionally implement `amgettreeheight` to report the HNSW graph height for planner refinement.
 
 Current staged behavior:
-- A pure cost-model helper MAY exist and be unit-tested behind ADR-011 while the live
-  `amcostestimate` callback still returns prohibitive costs to keep planner-visible `ec_hnsw` scans
-  disabled.
-- Read-only planner-cost snapshot helpers MAY expose both the modeled FR-020 estimate and the
-  still-gated live callback contract for inspection, without changing planner behavior.
-- Read-only planner-integration snapshot helpers MAY also expose that the modeled cost surface is
-  ready before the live callback is activated, alongside the remaining runtime and PG18 blockers.
-- Until PostgreSQL 18 support exists in the build/toolchain surface, staged planner-cost helpers
-  MAY source `tree_height` from metadata-page `max_level` explicitly and report that this is a
-  metadata fallback rather than a live `amgettreeheight` callback result.
-- The staged implementation MAY also define a pure `amgettreeheight`-named helper that returns the
-  exact integer callback value (`max_level`) from metadata without wiring the PG18 callback into
-  `IndexAmRoutine` yet.
+- `amcostestimate` now uses the modeled FR-020 cost function instead of ADR-011's prohibitive
+  `f64::MAX` override.
+- Read-only planner-cost and planner-integration snapshots still expose both modeled and live
+  planner state, but the remaining PG18 blocker they report is preload-time shared pgstat
+  activation rather than callback/toolchain bring-up.
+- On PG18, `tree_height` now comes from the live `amgettreeheight` callback. On PG17, snapshot
+  surfaces still report the metadata-fallback contract explicitly.
+- ADR-011 is now superseded; the remaining work in this area is validation/measurement and review,
+  not cost/callback scaffolding.
 
 ### Cost Model
 

--- a/spec/functional/FR-023-strategy-translation.md
+++ b/spec/functional/FR-023-strategy-translation.md
@@ -16,17 +16,12 @@ traces:
 On PG18, the extension SHALL implement `amtranslatestrategy` and `amtranslatecmptype` callbacks and set the `amconsistentordering` flag to enable the optimizer to reason about the `<#>` operator's ordering semantics.
 
 Current staged behavior:
-- Before the repository has PostgreSQL 18 toolchain support, pure helper-level scaffolding MAY
-  encode the intended strategy/CompareType mapping and expose that mapping through read-only
-  planner/explain snapshot helpers.
-- Those same helpers MAY also model the broader generic `CompareType` domain explicitly so reverse
-  mappings to strategy 1 are only accepted for `COMPARE_LT`, while every other compare type falls
-  back to `InvalidStrategy` in pure unit-tested code.
-- The staged implementation MAY also define pure `amtranslatestrategy`-named and
-  `amtranslatecmptype`-named helpers so the callback vocabulary in `am/cost.rs` already matches the
-  eventual PG18 binding surface.
-- Those scaffolds SHALL report that PG18 strategy-translation callbacks are not yet wired, so
-  planner-visible behavior is not implied prematurely.
+- On PG18, `amconsistentordering`, `amtranslatestrategy`, and `amtranslatecmptype` are now bound in
+  the live `IndexAmRoutine`.
+- The pure helper-level mapping still exists for unit coverage and snapshot inspection, including
+  the explicit rejection of non-`COMPARE_LT` reverse mappings, but the callbacks are no longer
+  descriptive-only on PG18.
+- On PG17, the new `IndexAmRoutine` fields remain unset and the fallback behavior is preserved.
 
 ### CompareType Mapping
 

--- a/spec/functional/FR-024-custom-explain.md
+++ b/spec/functional/FR-024-custom-explain.md
@@ -16,25 +16,16 @@ traces:
 On PG18, the extension SHALL register a custom EXPLAIN option `tqvector` that, when enabled, causes EXPLAIN output to include tqvector-specific scan statistics for each Index Scan node using the `ec_hnsw` access method.
 
 Current staged behavior:
-- Before PostgreSQL 18 support exists in this repository, pure explain-scaffolding helpers MAY
-  expose the intended EXPLAIN option name and report that both option registration and
-  `explain_per_node_hook` wiring remain unavailable.
-- Those same helpers MAY also expose the intended counter names, types, and increment conditions
-  while keeping both scan-opaque counter storage and runtime counter wiring explicitly unavailable.
-- The staged implementation MAY also define a reusable counter struct in planner-owned code so the
-  scan lane can embed it in `TqScanOpaque` later without requiring the planner lane to edit
-  `scan.rs` directly.
-- The staged implementation MAY also define pure ExplainProperty-emission helpers that map the
-  reusable counter struct into the eventual `ExplainPropertyInteger` / `ExplainPropertyBool`
-  payloads and a pure gating helper that requires the `tqvector` option, an `IndexScan` node kind,
-  and the `ec_hnsw` access method before any emission occurs.
-- Those same helpers MAY also define the intended EXPLAIN group contract, including the
-  `"TQVector Stats"` label plus the expectation that the eventual hook will bracket emission with
-  `ExplainOpenGroup` and `ExplainCloseGroup`.
-- Read-only diagnostics snapshot helpers MAY also expose the current EXPLAIN-and-pgstat readiness
-  state together so productization work can inspect one consolidated PG18 diagnostics boundary.
-- Those helpers SHALL stay descriptive only; they do not imply that `EXPLAIN (tqvector)` parses or
-  that any PostgreSQL EXPLAIN hook is registered on PG17.
+- On PG18, `_PG_init()` now registers the `tqvector` EXPLAIN option and chains
+  `explain_per_node_hook`.
+- `TqExplainCounters` are now embedded in scan state and incremented at live scan seams; `ec_hnsw`
+  index scans emit them when the option is enabled.
+- Structured EXPLAIN formats preserve the `TQVector Stats` group label. Text output still exposes
+  the same properties even though core PostgreSQL does not render the open/close group wrapper
+  there.
+- Read-only diagnostics snapshot helpers still expose the EXPLAIN-and-pgstat readiness boundary in
+  one place.
+- PG17 still has no EXPLAIN hook registration.
 
 ### Registration
 
@@ -140,12 +131,9 @@ When `tqvector` is not specified in the EXPLAIN options, the hook SHALL return i
 
 ### PG Version Compatibility
 
-On PG17, the custom EXPLAIN API does not exist. During the current staged implementation, the
-counter contract may be exposed through read-only scaffolding helpers, but the actual counter
-fields are not yet wired into `TqScanOpaque`, a planner-owned counter struct may exist for later
-embedding by the scan lane, pure ExplainProperty-emission helpers may exist in `am/explain.rs`,
-the output group contract may also exist in pure form there, a pure hook-context gate may require
-the option plus `IndexScan` plus `ec_hnsw`, and no EXPLAIN hook is registered.
+On PG17, the custom EXPLAIN API does not exist, so no EXPLAIN hook is registered. The reusable
+counter contract and pure emission helpers still exist for shared testing, but the live option and
+per-node hook remain PG18-only.
 
 ## Acceptance Criteria
 
@@ -153,7 +141,9 @@ the option plus `IndexScan` plus `ec_hnsw`, and no EXPLAIN hook is registered.
 `EXPLAIN (tqvector) SELECT ...` SHALL parse without error when the extension is loaded.
 
 ### FR-024-AC-2: Stats emitted
-`EXPLAIN (tqvector) SELECT ... ORDER BY col <#> $q LIMIT 10` on a table with a ec_hnsw index SHALL include "TQVector Stats" section with all defined counters.
+`EXPLAIN (FORMAT JSON, tqvector) SELECT ... ORDER BY col <#> $q LIMIT 10` on a table with an
+`ec_hnsw` index SHALL include a `"TQVector Stats"` group with all defined counters. Text output
+SHALL still expose the same counter properties even though the group label is not guaranteed there.
 
 ### FR-024-AC-3: No output when disabled
 `EXPLAIN SELECT ... ORDER BY col <#> $q LIMIT 10` (without `tqvector` option) SHALL NOT include any tqvector-specific output.

--- a/spec/functional/FR-025-custom-statistics.md
+++ b/spec/functional/FR-025-custom-statistics.md
@@ -27,9 +27,11 @@ Current staged behavior:
   `tqvector_stats()` exists on PG17.
 - Read-only diagnostics snapshot helpers MAY also expose the current EXPLAIN-and-pgstat readiness
   state together so productization work can inspect one consolidated PG18 diagnostics boundary.
-- On the current PG18 branch, the shared scan infrastructure MAY already accumulate backend-local
-  counters and expose them through `tqvector_stats()` while still reporting
-  `pg18_pgstat_kind_ready = false` until the preload-time pgstat registration path is implemented.
+- On the current PG18 branch, the shared scan infrastructure MAY expose backend-local counters
+  through `tqvector_stats()` in ordinary sessions while still reporting
+  `pg18_pgstat_kind_ready = false`. When the library is loaded through
+  `shared_preload_libraries`, the same SQL surface MAY read the shared custom pgstat snapshot
+  instead.
 - Those helpers SHALL stay descriptive about the shared pgstat-kind boundary; they do not imply
   that PostgreSQL's global statistics system is already accumulating tqvector counters.
 
@@ -83,8 +85,9 @@ SELECT * FROM tqvector_stats();
 --   bootstrap_hit_rate    | 0.85
 --   quantizer_cache_rate  | 0.99
 
--- Reset statistics
-SELECT pg_stat_reset_shared('tqvector');
+-- Resetting the custom kind currently requires PostgreSQL's pgstat reset API
+-- for the registered kind. The built-in pg_stat_reset_shared(text) SQL helper
+-- in the local PG18 tree does not yet accept custom kind names.
 ```
 
 ### Counter Increment Points

--- a/spec/functional/FR-025-custom-statistics.md
+++ b/spec/functional/FR-025-custom-statistics.md
@@ -15,25 +15,16 @@ traces:
 On PG18, the extension SHALL register a custom pgstat kind to track aggregate operational metrics across all queries, visible via a SQL function and resettable via standard PostgreSQL statistics reset.
 
 Current staged behavior:
-- Before PostgreSQL 18 support exists in this repository, pure statistics-scaffolding helpers MAY
-  expose the intended SQL function name and report that both pgstat-kind registration and SQL
-  function wiring remain unavailable.
-- The staged implementation MAY also define a reusable cumulative-stats struct in planner-owned
-  code so the runtime lane can increment the intended metrics and the future PG18 pgstat glue can
-  flush them into PostgreSQL's statistics infrastructure without requiring this branch to edit
-  `scan.rs`.
-- Those same helpers MAY also define pure summary logic for the derived SQL-facing rates shown
-  below, including `bootstrap_hit_rate` and `quantizer_cache_rate`, without implying that
-  `tqvector_stats()` exists on PG17.
-- Read-only diagnostics snapshot helpers MAY also expose the current EXPLAIN-and-pgstat readiness
-  state together so productization work can inspect one consolidated PG18 diagnostics boundary.
-- On the current PG18 branch, the shared scan infrastructure MAY expose backend-local counters
-  through `tqvector_stats()` in ordinary sessions while still reporting
-  `pg18_pgstat_kind_ready = false`. When the library is loaded through
-  `shared_preload_libraries`, the same SQL surface MAY read the shared custom pgstat snapshot
-  instead.
-- Those helpers SHALL stay descriptive about the shared pgstat-kind boundary; they do not imply
-  that PostgreSQL's global statistics system is already accumulating tqvector counters.
+- On PG18, `tqvector_stats()` is live.
+- When `tqvector` is loaded through `shared_preload_libraries`, `_PG_init()` registers the custom
+  pgstat kind through the preload-only C shim and the SQL surface reads the shared snapshot.
+- In ordinary non-preloaded PG18 sessions, the same SQL surface falls back to backend-local
+  counters and diagnostics continue to report `pg18_pgstat_kind_ready = false`.
+- Read-only diagnostics snapshot helpers still expose the EXPLAIN-and-pgstat readiness boundary in
+  one place.
+- PG17 still omits both the SQL function and custom pgstat registration.
+- Reset support for custom kinds remains blocked in the local PG18 tree because
+  `pg_stat_reset_shared(text)` does not accept custom kind names.
 
 ### PG18 Custom Statistics API
 
@@ -68,7 +59,9 @@ static TQVECTOR_STATS_KIND: PgStat_KindInfo = PgStat_KindInfo {
     // ... callbacks
 };
 
-pgstat_register_kind(PGSTAT_KIND_EXPERIMENTAL, &TQVECTOR_STATS_KIND);
+const TQVECTOR_PGSTAT_KIND: PgStat_Kind = PGSTAT_KIND_CUSTOM_MIN + 1;
+
+pgstat_register_kind(TQVECTOR_PGSTAT_KIND, &TQVECTOR_STATS_KIND);
 ```
 
 ### SQL Interface
@@ -105,9 +98,9 @@ SELECT * FROM tqvector_stats();
 ### PG Version Compatibility
 
 On PG17, the custom statistics API does not exist. The extension SHALL not register any pgstat
-kind. The `tqvector_stats()` function SHALL NOT be defined. Counter increments SHALL be compiled
-out. During the current staged implementation, PG18 may expose backend-local SQL-visible counters
-before the shared pgstat-kind path lands, but no PostgreSQL global pgstat kind is registered yet.
+kind, `tqvector_stats()` SHALL NOT be defined, and counter increments SHALL be compiled out. On
+PG18, the shared pgstat path requires preload-time activation; without preload, the SQL surface
+falls back to backend-local counters.
 
 ## Acceptance Criteria
 
@@ -117,8 +110,10 @@ On PG18, `SELECT * FROM tqvector_stats()` SHALL return a row with all defined co
 ### FR-025-AC-2: Counters increment
 After running 10 HNSW scan queries, `total_scans_started` SHALL be ≥ 10 and `total_distance_calcs` SHALL be > 0.
 
-### FR-025-AC-3: Reset works
-After `SELECT pg_stat_reset_shared('tqvector')`, all counters SHALL be zero.
+### FR-025-AC-3: Reset blocker documented
+Until PostgreSQL exposes a reset surface for custom pgstat kinds in this environment, tqvector
+SHALL document the limitation rather than claim that `pg_stat_reset_shared(text)` can reset the
+custom kind directly.
 
 ### FR-025-AC-4: Persistence within session
 Counters SHALL accumulate across queries within a session. They SHALL NOT reset between queries.

--- a/spec/functional/FR-025-custom-statistics.md
+++ b/spec/functional/FR-025-custom-statistics.md
@@ -27,8 +27,11 @@ Current staged behavior:
   `tqvector_stats()` exists on PG17.
 - Read-only diagnostics snapshot helpers MAY also expose the current EXPLAIN-and-pgstat readiness
   state together so productization work can inspect one consolidated PG18 diagnostics boundary.
-- Those helpers SHALL stay descriptive only; they do not imply that `tqvector_stats()` exists on
-  PG17 or that any counters are being accumulated through PostgreSQL's statistics system.
+- On the current PG18 branch, the shared scan infrastructure MAY already accumulate backend-local
+  counters and expose them through `tqvector_stats()` while still reporting
+  `pg18_pgstat_kind_ready = false` until the preload-time pgstat registration path is implemented.
+- Those helpers SHALL stay descriptive about the shared pgstat-kind boundary; they do not imply
+  that PostgreSQL's global statistics system is already accumulating tqvector counters.
 
 ### PG18 Custom Statistics API
 
@@ -98,10 +101,10 @@ SELECT pg_stat_reset_shared('tqvector');
 
 ### PG Version Compatibility
 
-On PG17, the custom statistics API does not exist. The extension SHALL not register any pgstat kind. The `tqvector_stats()` function SHALL NOT be defined. Counter increments SHALL be compiled out.
-During the current staged implementation, a reusable planner-owned counter struct may exist in
-`am/stats.rs`, pure summary helpers for the intended derived rates may also exist there, but no
-PostgreSQL pgstat kind is registered and no SQL-visible cumulative statistics are exposed.
+On PG17, the custom statistics API does not exist. The extension SHALL not register any pgstat
+kind. The `tqvector_stats()` function SHALL NOT be defined. Counter increments SHALL be compiled
+out. During the current staged implementation, PG18 may expose backend-local SQL-visible counters
+before the shared pgstat-kind path lands, but no PostgreSQL global pgstat kind is registered yet.
 
 ## Acceptance Criteria
 

--- a/spec/functional/FR-026-pg18-module-identity.md
+++ b/spec/functional/FR-026-pg18-module-identity.md
@@ -39,7 +39,7 @@ PG_MODULE_MAGIC;
 ```sql
 SELECT * FROM pg_get_loaded_modules() WHERE name = 'tqvector';
 -- name     | version
--- tqvector | 0.1.0
+-- tqvector | 0.1.1
 ```
 
 ### PG Version Compatibility

--- a/spec/functional/FR-026-pg18-module-identity.md
+++ b/spec/functional/FR-026-pg18-module-identity.md
@@ -15,11 +15,11 @@ traces:
 On PG18, the extension SHALL use `PG_MODULE_MAGIC_EXT` to declare its name and version, making this information available via `pg_get_loaded_modules()` for diagnostics and version tracking.
 
 Current staged behavior:
-- Before PostgreSQL 18 support exists in this repository, read-only upgrade snapshot helpers MAY
-  expose the intended extension identity (`tqvector`, `$libdir/tqvector`) and report that
-  `PG_MODULE_MAGIC_EXT` wiring is still unavailable.
-- Those helpers SHALL stay descriptive only; they do not imply that `pg_get_loaded_modules()` can
-  already report tqvector name/version on PG17.
+- On PG18, module identity and version reporting are now live via explicit `pg_module_magic!`
+  name/version fields, preserving the single `tqvector` extension identity.
+- The explicit-field form is used as a repo-local workaround for current `pgrx 0.17` PG18
+  shorthand behavior.
+- PG17 still uses the standard module magic surface without name/version reporting.
 
 ### Implementation
 
@@ -37,8 +37,8 @@ PG_MODULE_MAGIC;
 ### Observable Behavior
 
 ```sql
-SELECT * FROM pg_get_loaded_modules() WHERE name = 'tqvector';
--- name     | version
+SELECT * FROM pg_get_loaded_modules() WHERE module_name = 'tqvector';
+-- module_name | version
 -- tqvector | 0.1.1
 ```
 
@@ -49,7 +49,8 @@ On PG17, the standard `PG_MODULE_MAGIC` macro is used. The extension name and ve
 ## Acceptance Criteria
 
 ### FR-026-AC-1: Module visible
-On PG18, `SELECT name, version FROM pg_get_loaded_modules() WHERE name = 'tqvector'` SHALL return one row with the correct version.
+On PG18, `SELECT module_name, version FROM pg_get_loaded_modules() WHERE module_name = 'tqvector'`
+SHALL return one row with the correct version.
 
 ### FR-026-AC-2: Version matches Cargo.toml
 The reported version SHALL match the `version` field in `Cargo.toml`.

--- a/spec/functional/FR-027-pgrx-pg18-upgrade.md
+++ b/spec/functional/FR-027-pgrx-pg18-upgrade.md
@@ -36,7 +36,7 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 
 [dependencies]
-pgrx = "0.18"   # or whichever version adds pg18 support
+pgrx = "0.17"
 ```
 
 ### Conditional Compilation Strategy
@@ -87,7 +87,7 @@ pub unsafe extern "C-unwind" fn _PG_init() {
     #[cfg(feature = "pg18")]
     {
         register_explain_option();
-        register_pgstat_kind();
+        register_pg18_stats();
     }
 }
 ```
@@ -104,4 +104,4 @@ pub unsafe extern "C-unwind" fn _PG_init() {
 `cargo pgrx test pg17` and `cargo pgrx test pg18` SHALL both pass.
 
 ### FR-027-AC-4: _PG_init called
-On PG18, `CREATE EXTENSION tqvector` SHALL invoke `_PG_init`, registering the EXPLAIN option and pgstat kind.
+On PG18, `CREATE EXTENSION tqvector` SHALL invoke `_PG_init`, registering the EXPLAIN option and any PG18 diagnostics setup that is not still blocked on preload-time pgstat wiring.

--- a/spec/functional/FR-027-pgrx-pg18-upgrade.md
+++ b/spec/functional/FR-027-pgrx-pg18-upgrade.md
@@ -15,15 +15,14 @@ traces:
 The extension SHALL add PostgreSQL 18 as a supported target via pgrx feature flags, making PG18 the default build target while maintaining PG17 compatibility.
 
 Current staged behavior:
-- Before the pgrx/toolchain upgrade lands, read-only upgrade snapshot helpers MAY report the
-  current default feature, whether a `pg18` Cargo feature exists, and whether PG18 default-build
-  readiness is still pending.
-- Read-only diagnostics snapshot helpers MAY also report consolidated EXPLAIN/pgstat readiness so
-  the broader PG18 productization boundary is queryable before toolchain work lands.
-- Read-only ReadStream snapshot helpers MAY also report the intended graph-versus-linear stream
-  modes and keep callback/scan/vacuum readiness explicitly false until PG18 support lands.
-- Those helpers SHALL stay descriptive only; they do not imply that PG18 builds, tests, or default
-  feature selection already work.
+- PG18 is now the default Cargo feature and PG17 remains the supported fallback.
+- Local validation now covers both versions (`cargo test`, `cargo pgrx test pg18`,
+  `cargo pgrx test pg17`, and version-specific clippy lanes), and CI initializes both pg17 and
+  pg18 explicitly.
+- `_PG_init()` now registers the PG18 EXPLAIN hooks and shared-stats setup. Shared pgstat
+  activation still depends on preload-time configuration.
+- The upgrade/diagnostics/read-stream snapshot helpers now describe live wired state rather than
+  pure scaffolding.
 
 ### Cargo.toml Changes
 

--- a/spec/tests.md
+++ b/spec/tests.md
@@ -233,7 +233,7 @@ Bidirectional traceability between requirements and test cases.
 | TC-226 | Module version matches Cargo.toml | FR-026-AC-2 | Compare reported version to Cargo.toml version field |
 | TC-227 | PG18 build succeeds | FR-027-AC-1 | `cargo pgrx build --features pg18 --release` exits 0 |
 | TC-228 | PG17 build succeeds | FR-027-AC-2 | `cargo pgrx build --features pg17 --release` exits 0 |
-| TC-229 | _PG_init registers hooks | FR-027-AC-4 | After CREATE EXTENSION, verify EXPLAIN option and pgstat kind are registered |
+| TC-229 | _PG_init registers PG18 diagnostics | FR-027-AC-4 | After CREATE EXTENSION, verify the EXPLAIN option is registered and the remaining pgstat-kind blocker is explicit |
 | TC-230 | ADR-011 f64::MAX override removed | FR-020-AC-5 | Inspect source: no `f64::MAX` in cost.rs; ADR-011 status is SUPERSEDED |
 | TC-231 | CREATE INDEX CONCURRENTLY with parallel workers | FR-021-AC-4 | `SET max_parallel_maintenance_workers = 2; CREATE INDEX CONCURRENTLY ... USING ec_hnsw ...` succeeds, index is usable |
 | TC-232 | Parallel build uses GenericXLog | FR-021-AC-6 | Inspect source: all page writes in leader graph serialization use GenericXLogStart/Finish |

--- a/src/am/common/cost.rs
+++ b/src/am/common/cost.rs
@@ -100,11 +100,28 @@ pub(crate) unsafe fn current_planner_cost_constants() -> PlannerCostConstants {
     }
 }
 
+#[cfg_attr(feature = "pg18", allow(dead_code))]
 pub(crate) fn metadata_fallback_tree_height(max_level: u8) -> PlannerTreeHeightInput {
     PlannerTreeHeightInput {
         tree_height: f64::from(max_level),
         source: "metadata_fallback",
         pg18_callback_ready: false,
+    }
+}
+
+pub(crate) fn resolved_tree_height_input(max_level: u8) -> PlannerTreeHeightInput {
+    #[cfg(feature = "pg18")]
+    {
+        PlannerTreeHeightInput {
+            tree_height: f64::from(amgettreeheight_callback_value(max_level)),
+            source: "amgettreeheight_callback",
+            pg18_callback_ready: true,
+        }
+    }
+
+    #[cfg(not(feature = "pg18"))]
+    {
+        metadata_fallback_tree_height(max_level)
     }
 }
 
@@ -137,7 +154,59 @@ pub(crate) fn strategy_translation_snapshot() -> StrategyTranslationSnapshot {
     StrategyTranslationSnapshot {
         ordering_strategy: 1,
         ordering_compare_type: amtranslatestrategy_callback(1),
-        pg18_callback_ready: false,
+        pg18_callback_ready: cfg!(feature = "pg18"),
+    }
+}
+
+#[cfg(feature = "pg18")]
+pub(crate) unsafe extern "C-unwind" fn ec_hnsw_amgettreeheight(rel: pg_sys::Relation) -> i32 {
+    unsafe {
+        pgrx::pgrx_extern_c_guard(|| {
+            let metadata = shared::read_metadata_page(rel);
+            amgettreeheight_callback_value(metadata.max_level)
+        })
+    }
+}
+
+#[cfg(feature = "pg18")]
+pub(crate) unsafe extern "C-unwind" fn ec_hnsw_amtranslatestrategy(
+    strategy: pg_sys::StrategyNumber,
+    _opfamily: pg_sys::Oid,
+) -> pg_sys::CompareType::Type {
+    unsafe {
+        pgrx::pgrx_extern_c_guard(|| match amtranslatestrategy_callback(i32::from(strategy)) {
+            PlannerCompareType::Invalid => pg_sys::CompareType::COMPARE_INVALID,
+            PlannerCompareType::Lt => pg_sys::CompareType::COMPARE_LT,
+            PlannerCompareType::Le => pg_sys::CompareType::COMPARE_LE,
+            PlannerCompareType::Eq => pg_sys::CompareType::COMPARE_EQ,
+            PlannerCompareType::Ge => pg_sys::CompareType::COMPARE_GE,
+            PlannerCompareType::Gt => pg_sys::CompareType::COMPARE_GT,
+            PlannerCompareType::Ne => pg_sys::CompareType::COMPARE_NE,
+            PlannerCompareType::Overlap => pg_sys::CompareType::COMPARE_OVERLAP,
+            PlannerCompareType::ContainedBy => pg_sys::CompareType::COMPARE_CONTAINED_BY,
+        })
+    }
+}
+
+#[cfg(feature = "pg18")]
+pub(crate) unsafe extern "C-unwind" fn ec_hnsw_amtranslatecmptype(
+    compare_type: pg_sys::CompareType::Type,
+    _opfamily: pg_sys::Oid,
+) -> pg_sys::StrategyNumber {
+    unsafe {
+        pgrx::pgrx_extern_c_guard(|| {
+            amtranslatecmptype_callback(match compare_type {
+                pg_sys::CompareType::COMPARE_LT => PlannerCompareType::Lt,
+                pg_sys::CompareType::COMPARE_LE => PlannerCompareType::Le,
+                pg_sys::CompareType::COMPARE_EQ => PlannerCompareType::Eq,
+                pg_sys::CompareType::COMPARE_GE => PlannerCompareType::Ge,
+                pg_sys::CompareType::COMPARE_GT => PlannerCompareType::Gt,
+                pg_sys::CompareType::COMPARE_NE => PlannerCompareType::Ne,
+                pg_sys::CompareType::COMPARE_OVERLAP => PlannerCompareType::Overlap,
+                pg_sys::CompareType::COMPARE_CONTAINED_BY => PlannerCompareType::ContainedBy,
+                _ => PlannerCompareType::Invalid,
+            }) as pg_sys::StrategyNumber
+        })
     }
 }
 
@@ -213,7 +282,7 @@ pub(crate) unsafe extern "C-unwind" fn ec_hnsw_amcostestimate(
             let index_info = (*path).indexinfo;
             let index_oid = (*index_info).indexoid;
             let index_relation = pg_sys::index_open(index_oid, pg_sys::NoLock as pg_sys::LOCKMODE);
-            let estimate = compute_amcostestimate(index_relation);
+            let estimate = compute_amcostestimate(index_relation, index_info);
             pg_sys::index_close(index_relation, pg_sys::NoLock as pg_sys::LOCKMODE);
 
             *index_startup_cost = estimate.startup_cost;
@@ -225,7 +294,35 @@ pub(crate) unsafe extern "C-unwind" fn ec_hnsw_amcostestimate(
     }
 }
 
-unsafe fn compute_amcostestimate(index_relation: pg_sys::Relation) -> PlannerCostEstimate {
+unsafe fn planner_tree_height_from_index_info(
+    index_info: *mut pg_sys::IndexOptInfo,
+    max_level: u8,
+) -> PlannerTreeHeightInput {
+    #[cfg(feature = "pg18")]
+    {
+        let planner_tree_height = unsafe { (*index_info).tree_height };
+        if planner_tree_height > 0 {
+            return PlannerTreeHeightInput {
+                tree_height: f64::from(planner_tree_height),
+                source: "amgettreeheight_callback",
+                pg18_callback_ready: true,
+            };
+        }
+
+        return resolved_tree_height_input(max_level);
+    }
+
+    #[cfg(not(feature = "pg18"))]
+    {
+        let _ = index_info;
+        metadata_fallback_tree_height(max_level)
+    }
+}
+
+unsafe fn compute_amcostestimate(
+    index_relation: pg_sys::Relation,
+    index_info: *mut pg_sys::IndexOptInfo,
+) -> PlannerCostEstimate {
     let relation_options = unsafe { options::relation_options(index_relation) };
     let tuning = options::resolve_scan_tuning(&relation_options);
     let block_count = unsafe {
@@ -241,7 +338,7 @@ unsafe fn compute_amcostestimate(index_relation: pg_sys::Relation) -> PlannerCos
     }
     let reltuples = unsafe { (*(*index_relation).rd_rel).reltuples } as f64;
     let metadata = unsafe { shared::read_metadata_page(index_relation) };
-    let tree_height = metadata_fallback_tree_height(metadata.max_level);
+    let tree_height = unsafe { planner_tree_height_from_index_info(index_info, metadata.max_level) };
     let constants = unsafe { current_planner_cost_constants() };
 
     estimate_planner_cost(
@@ -261,7 +358,8 @@ unsafe fn compute_amcostestimate(index_relation: pg_sys::Relation) -> PlannerCos
 mod tests {
     use super::{
         amgettreeheight_callback_value, amtranslatecmptype_callback, amtranslatestrategy_callback,
-        estimate_planner_cost, metadata_fallback_tree_height, strategy_translation_snapshot,
+        estimate_planner_cost, metadata_fallback_tree_height, resolved_tree_height_input,
+        strategy_translation_snapshot,
         PlannerCompareType, PlannerCostConstants, PlannerCostEstimate, PlannerCostInputs,
         PlannerTreeHeightInput, StrategyTranslationSnapshot, LUT_CPU_DIMENSION_SCALE,
     };
@@ -410,25 +508,39 @@ mod tests {
     }
 
     #[test]
-    fn planner_cost_tree_height_defaults_to_metadata_until_pg18_callback_exists() {
+    fn planner_cost_tree_height_snapshot_matches_build_target() {
         assert_eq!(
-            metadata_fallback_tree_height(4),
+            resolved_tree_height_input(4),
             PlannerTreeHeightInput {
                 tree_height: 4.0,
-                source: "metadata_fallback",
-                pg18_callback_ready: false,
+                source: if cfg!(feature = "pg18") {
+                    "amgettreeheight_callback"
+                } else {
+                    "metadata_fallback"
+                },
+                pg18_callback_ready: cfg!(feature = "pg18"),
             }
         );
+        if !cfg!(feature = "pg18") {
+            assert_eq!(
+                metadata_fallback_tree_height(4),
+                PlannerTreeHeightInput {
+                    tree_height: 4.0,
+                    source: "metadata_fallback",
+                    pg18_callback_ready: false,
+                }
+            );
+        }
     }
 
     #[test]
-    fn strategy_translation_snapshot_stays_explicitly_unwired_until_pg18_support_exists() {
+    fn strategy_translation_snapshot_matches_build_target() {
         assert_eq!(
             strategy_translation_snapshot(),
             StrategyTranslationSnapshot {
                 ordering_strategy: 1,
                 ordering_compare_type: PlannerCompareType::Lt,
-                pg18_callback_ready: false,
+                pg18_callback_ready: cfg!(feature = "pg18"),
             }
         );
     }

--- a/src/am/common/cost.rs
+++ b/src/am/common/cost.rs
@@ -309,7 +309,7 @@ unsafe fn planner_tree_height_from_index_info(
             };
         }
 
-        return resolved_tree_height_input(max_level);
+        resolved_tree_height_input(max_level)
     }
 
     #[cfg(not(feature = "pg18"))]

--- a/src/am/common/cost.rs
+++ b/src/am/common/cost.rs
@@ -338,7 +338,8 @@ unsafe fn compute_amcostestimate(
     }
     let reltuples = unsafe { (*(*index_relation).rd_rel).reltuples } as f64;
     let metadata = unsafe { shared::read_metadata_page(index_relation) };
-    let tree_height = unsafe { planner_tree_height_from_index_info(index_info, metadata.max_level) };
+    let tree_height =
+        unsafe { planner_tree_height_from_index_info(index_info, metadata.max_level) };
     let constants = unsafe { current_planner_cost_constants() };
 
     estimate_planner_cost(
@@ -359,9 +360,9 @@ mod tests {
     use super::{
         amgettreeheight_callback_value, amtranslatecmptype_callback, amtranslatestrategy_callback,
         estimate_planner_cost, metadata_fallback_tree_height, resolved_tree_height_input,
-        strategy_translation_snapshot,
-        PlannerCompareType, PlannerCostConstants, PlannerCostEstimate, PlannerCostInputs,
-        PlannerTreeHeightInput, StrategyTranslationSnapshot, LUT_CPU_DIMENSION_SCALE,
+        strategy_translation_snapshot, PlannerCompareType, PlannerCostConstants,
+        PlannerCostEstimate, PlannerCostInputs, PlannerTreeHeightInput,
+        StrategyTranslationSnapshot, LUT_CPU_DIMENSION_SCALE,
     };
 
     fn default_constants() -> PlannerCostConstants {

--- a/src/am/common/explain.rs
+++ b/src/am/common/explain.rs
@@ -1,3 +1,11 @@
+#[cfg(feature = "pg18")]
+use std::ffi::{c_void, CStr, CString};
+#[cfg(feature = "pg18")]
+use std::ptr;
+
+#[cfg(feature = "pg18")]
+use pgrx::pg_sys;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ExplainOptionSnapshot {
     pub option_name: &'static str,
@@ -528,10 +536,3 @@ mod tests {
         }));
     }
 }
-#[cfg(feature = "pg18")]
-use std::ffi::{c_void, CStr, CString};
-#[cfg(feature = "pg18")]
-use std::ptr;
-
-#[cfg(feature = "pg18")]
-use pgrx::pg_sys;

--- a/src/am/common/explain.rs
+++ b/src/am/common/explain.rs
@@ -235,10 +235,7 @@ unsafe fn explain_access_method_name(index_state: *mut pg_sys::IndexScanState) -
 }
 
 #[cfg(feature = "pg18")]
-unsafe fn emit_explain_properties(
-    es: *mut pg_sys::ExplainState,
-    counters: TqExplainCounters,
-) {
+unsafe fn emit_explain_properties(es: *mut pg_sys::ExplainState, counters: TqExplainCounters) {
     let group = explain_output_group();
     let group_label = CString::new(group.group_label).expect("group label should not contain NUL");
     unsafe {

--- a/src/am/common/explain.rs
+++ b/src/am/common/explain.rs
@@ -96,8 +96,8 @@ const EXPLAIN_COUNTER_DEFINITIONS: [ExplainCounterDefinition; 7] = [
 pub(crate) fn explain_option_snapshot() -> ExplainOptionSnapshot {
     ExplainOptionSnapshot {
         option_name: "tqvector",
-        pg18_custom_explain_option_ready: false,
-        pg18_explain_per_node_hook_ready: false,
+        pg18_custom_explain_option_ready: cfg!(feature = "pg18"),
+        pg18_explain_per_node_hook_ready: cfg!(feature = "pg18"),
     }
 }
 
@@ -186,6 +186,160 @@ impl TqExplainCounters {
     }
 }
 
+#[cfg(feature = "pg18")]
+static mut PREVIOUS_EXPLAIN_PER_NODE_HOOK: pg_sys::explain_per_node_hook_type = None;
+#[cfg(feature = "pg18")]
+static mut TQVECTOR_EXPLAIN_REGISTERED: bool = false;
+
+#[cfg(feature = "pg18")]
+fn explain_extension_id() -> i32 {
+    unsafe { pg_sys::GetExplainExtensionId(c"tqvector".as_ptr()) }
+}
+
+#[cfg(feature = "pg18")]
+unsafe fn explain_option_enabled(es: *mut pg_sys::ExplainState) -> bool {
+    let state = unsafe { pg_sys::GetExplainExtensionState(es, explain_extension_id()) };
+    if state.is_null() {
+        return false;
+    }
+
+    unsafe { *(state.cast::<bool>()) }
+}
+
+#[cfg(feature = "pg18")]
+unsafe fn explain_node_kind(planstate: *mut pg_sys::PlanState) -> ExplainNodeKind {
+    match unsafe { (*planstate).type_ } {
+        pg_sys::NodeTag::T_IndexScanState => ExplainNodeKind::IndexScan,
+        _ => ExplainNodeKind::Other,
+    }
+}
+
+#[cfg(feature = "pg18")]
+unsafe fn explain_access_method_name(index_state: *mut pg_sys::IndexScanState) -> Option<String> {
+    let index_relation = unsafe { (*index_state).iss_RelationDesc };
+    if index_relation.is_null() {
+        return None;
+    }
+
+    let am_oid = unsafe { (*(*index_relation).rd_rel).relam };
+    let am_name_ptr = unsafe { pg_sys::get_am_name(am_oid) };
+    if am_name_ptr.is_null() {
+        return None;
+    }
+
+    let name = unsafe { CStr::from_ptr(am_name_ptr) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { pg_sys::pfree(am_name_ptr.cast()) };
+    Some(name)
+}
+
+#[cfg(feature = "pg18")]
+unsafe fn emit_explain_properties(
+    es: *mut pg_sys::ExplainState,
+    counters: TqExplainCounters,
+) {
+    let group = explain_output_group();
+    let group_label = CString::new(group.group_label).expect("group label should not contain NUL");
+    unsafe {
+        pg_sys::ExplainOpenGroup(group_label.as_ptr(), group_label.as_ptr(), true, es);
+    }
+
+    for property in counters.explain_properties() {
+        let property_name =
+            CString::new(property.property_name).expect("property name should not contain NUL");
+        unsafe {
+            match property.value {
+                ExplainPropertyValue::Integer(value) => pg_sys::ExplainPropertyInteger(
+                    property_name.as_ptr(),
+                    ptr::null(),
+                    i64::from(value),
+                    es,
+                ),
+                ExplainPropertyValue::Bool(value) => {
+                    pg_sys::ExplainPropertyBool(property_name.as_ptr(), value, es)
+                }
+            }
+        }
+    }
+
+    unsafe {
+        pg_sys::ExplainCloseGroup(group_label.as_ptr(), group_label.as_ptr(), true, es);
+    }
+}
+
+#[cfg(feature = "pg18")]
+unsafe extern "C-unwind" fn tqvector_explain_option_handler(
+    es: *mut pg_sys::ExplainState,
+    opt: *mut pg_sys::DefElem,
+    _pstate: *mut pg_sys::ParseState,
+) {
+    unsafe {
+        pgrx::pgrx_extern_c_guard(|| {
+            let enabled = pg_sys::defGetBoolean(opt);
+            let state = pg_sys::palloc0(std::mem::size_of::<bool>()).cast::<bool>();
+            if state.is_null() {
+                pgrx::error!("tqvector failed to allocate EXPLAIN option state");
+            }
+            *state = enabled;
+            pg_sys::SetExplainExtensionState(es, explain_extension_id(), state.cast::<c_void>());
+        })
+    }
+}
+
+#[cfg(feature = "pg18")]
+unsafe extern "C-unwind" fn tqvector_explain_per_node_hook(
+    planstate: *mut pg_sys::PlanState,
+    ancestors: *mut pg_sys::List,
+    relationship: *const std::ffi::c_char,
+    plan_name: *const std::ffi::c_char,
+    es: *mut pg_sys::ExplainState,
+) {
+    unsafe {
+        pgrx::pgrx_extern_c_guard(|| {
+            if !planstate.is_null()
+                && !es.is_null()
+                && (*planstate).type_ == pg_sys::NodeTag::T_IndexScanState
+            {
+                let index_state = planstate.cast::<pg_sys::IndexScanState>();
+                let access_method_name = explain_access_method_name(index_state)
+                    .unwrap_or_else(|| "<unknown>".to_owned());
+                let context = ExplainHookContext {
+                    explain_option_enabled: explain_option_enabled(es),
+                    node_kind: explain_node_kind(planstate),
+                    access_method_name: access_method_name.as_str(),
+                };
+                if should_emit_explain_properties(context) {
+                    let counters =
+                        crate::am::ec_hnsw::explain_counters_from_index_scan_state(index_state);
+                    emit_explain_properties(es, counters);
+                }
+            }
+
+            if let Some(previous_hook) = PREVIOUS_EXPLAIN_PER_NODE_HOOK {
+                previous_hook(planstate, ancestors, relationship, plan_name, es);
+            }
+        })
+    }
+}
+
+#[cfg(feature = "pg18")]
+pub(crate) unsafe fn register_pg18_explain_hooks() {
+    unsafe {
+        if TQVECTOR_EXPLAIN_REGISTERED {
+            return;
+        }
+
+        pg_sys::RegisterExtensionExplainOption(
+            c"tqvector".as_ptr(),
+            Some(tqvector_explain_option_handler),
+        );
+        PREVIOUS_EXPLAIN_PER_NODE_HOOK = pg_sys::explain_per_node_hook;
+        pg_sys::explain_per_node_hook = Some(tqvector_explain_per_node_hook);
+        TQVECTOR_EXPLAIN_REGISTERED = true;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -196,13 +350,13 @@ mod tests {
     };
 
     #[test]
-    fn explain_option_snapshot_stays_explicitly_unwired_until_pg18_support_exists() {
+    fn explain_option_snapshot_matches_build_target() {
         assert_eq!(
             explain_option_snapshot(),
             ExplainOptionSnapshot {
                 option_name: "tqvector",
-                pg18_custom_explain_option_ready: false,
-                pg18_explain_per_node_hook_ready: false,
+                pg18_custom_explain_option_ready: cfg!(feature = "pg18"),
+                pg18_explain_per_node_hook_ready: cfg!(feature = "pg18"),
             }
         );
     }
@@ -377,3 +531,10 @@ mod tests {
         }));
     }
 }
+#[cfg(feature = "pg18")]
+use std::ffi::{c_void, CStr, CString};
+#[cfg(feature = "pg18")]
+use std::ptr;
+
+#[cfg(feature = "pg18")]
+use pgrx::pg_sys;

--- a/src/am/common/explain.rs
+++ b/src/am/common/explain.rs
@@ -2,6 +2,10 @@
 use std::ffi::{c_void, CStr, CString};
 #[cfg(feature = "pg18")]
 use std::ptr;
+#[cfg(feature = "pg18")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "pg18")]
+use std::sync::OnceLock;
 
 #[cfg(feature = "pg18")]
 use pgrx::pg_sys;
@@ -195,9 +199,18 @@ impl TqExplainCounters {
 }
 
 #[cfg(feature = "pg18")]
-static mut PREVIOUS_EXPLAIN_PER_NODE_HOOK: pg_sys::explain_per_node_hook_type = None;
+static PREVIOUS_EXPLAIN_PER_NODE_HOOK: OnceLock<pg_sys::explain_per_node_hook_type> =
+    OnceLock::new();
 #[cfg(feature = "pg18")]
-static mut TQVECTOR_EXPLAIN_REGISTERED: bool = false;
+static TQVECTOR_EXPLAIN_REGISTERED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(feature = "pg18")]
+fn previous_explain_per_node_hook() -> pg_sys::explain_per_node_hook_type {
+    PREVIOUS_EXPLAIN_PER_NODE_HOOK
+        .get()
+        .copied()
+        .unwrap_or(None)
+}
 
 #[cfg(feature = "pg18")]
 fn explain_extension_id() -> i32 {
@@ -308,7 +321,7 @@ unsafe extern "C-unwind" fn tqvector_explain_per_node_hook(
             {
                 let explain_option_enabled = explain_option_enabled(es);
                 if !explain_option_enabled {
-                    if let Some(previous_hook) = PREVIOUS_EXPLAIN_PER_NODE_HOOK {
+                    if let Some(previous_hook) = previous_explain_per_node_hook() {
                         previous_hook(planstate, ancestors, relationship, plan_name, es);
                     }
                     return;
@@ -329,7 +342,7 @@ unsafe extern "C-unwind" fn tqvector_explain_per_node_hook(
                 }
             }
 
-            if let Some(previous_hook) = PREVIOUS_EXPLAIN_PER_NODE_HOOK {
+            if let Some(previous_hook) = previous_explain_per_node_hook() {
                 previous_hook(planstate, ancestors, relationship, plan_name, es);
             }
         })
@@ -339,7 +352,7 @@ unsafe extern "C-unwind" fn tqvector_explain_per_node_hook(
 #[cfg(feature = "pg18")]
 pub(crate) unsafe fn register_pg18_explain_hooks() {
     unsafe {
-        if TQVECTOR_EXPLAIN_REGISTERED {
+        if TQVECTOR_EXPLAIN_REGISTERED.load(Ordering::Acquire) {
             return;
         }
 
@@ -347,9 +360,9 @@ pub(crate) unsafe fn register_pg18_explain_hooks() {
             c"tqvector".as_ptr(),
             Some(tqvector_explain_option_handler),
         );
-        PREVIOUS_EXPLAIN_PER_NODE_HOOK = pg_sys::explain_per_node_hook;
+        let _ = PREVIOUS_EXPLAIN_PER_NODE_HOOK.set(pg_sys::explain_per_node_hook);
         pg_sys::explain_per_node_hook = Some(tqvector_explain_per_node_hook);
-        TQVECTOR_EXPLAIN_REGISTERED = true;
+        TQVECTOR_EXPLAIN_REGISTERED.store(true, Ordering::Release);
     }
 }
 

--- a/src/am/common/explain.rs
+++ b/src/am/common/explain.rs
@@ -306,11 +306,19 @@ unsafe extern "C-unwind" fn tqvector_explain_per_node_hook(
                 && !es.is_null()
                 && (*planstate).type_ == pg_sys::NodeTag::T_IndexScanState
             {
+                let explain_option_enabled = explain_option_enabled(es);
+                if !explain_option_enabled {
+                    if let Some(previous_hook) = PREVIOUS_EXPLAIN_PER_NODE_HOOK {
+                        previous_hook(planstate, ancestors, relationship, plan_name, es);
+                    }
+                    return;
+                }
+
                 let index_state = planstate.cast::<pg_sys::IndexScanState>();
                 let access_method_name = explain_access_method_name(index_state)
                     .unwrap_or_else(|| "<unknown>".to_owned());
                 let context = ExplainHookContext {
-                    explain_option_enabled: explain_option_enabled(es),
+                    explain_option_enabled,
                     node_kind: explain_node_kind(planstate),
                     access_method_name: access_method_name.as_str(),
                 };

--- a/src/am/common/stats.rs
+++ b/src/am/common/stats.rs
@@ -89,6 +89,9 @@ fn record_shared_delta(delta: TqStatsCounters) {
     }
 }
 
+#[cfg(not(feature = "pg18"))]
+fn record_shared_delta(_delta: TqStatsCounters) {}
+
 #[cfg(feature = "pg18")]
 fn pgstat_kind_ready() -> bool {
     unsafe { pg18_pgstat_shim::is_registered() }
@@ -130,10 +133,6 @@ pub(crate) fn current_stats_counters() -> TqStatsCounters {
 #[cfg(feature = "pg18")]
 pub(crate) fn record_distance_calc() {
     increment(&TOTAL_DISTANCE_CALCS);
-    record_shared_delta(TqStatsCounters {
-        total_distance_calcs: 1,
-        ..TqStatsCounters::default()
-    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -142,10 +141,6 @@ pub(crate) fn record_distance_calc() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_graph_hop() {
     increment(&TOTAL_GRAPH_HOPS);
-    record_shared_delta(TqStatsCounters {
-        total_graph_hops: 1,
-        ..TqStatsCounters::default()
-    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -154,10 +149,6 @@ pub(crate) fn record_graph_hop() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_linear_page() {
     increment(&TOTAL_LINEAR_PAGES);
-    record_shared_delta(TqStatsCounters {
-        total_linear_pages: 1,
-        ..TqStatsCounters::default()
-    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -166,10 +157,6 @@ pub(crate) fn record_linear_page() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_scan_started() {
     increment(&TOTAL_SCANS_STARTED);
-    record_shared_delta(TqStatsCounters {
-        total_scans_started: 1,
-        ..TqStatsCounters::default()
-    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -178,10 +165,6 @@ pub(crate) fn record_scan_started() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_bootstrap_only_scan() {
     increment(&TOTAL_SCANS_BOOTSTRAP_ONLY);
-    record_shared_delta(TqStatsCounters {
-        total_scans_bootstrap_only: 1,
-        ..TqStatsCounters::default()
-    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -190,10 +173,6 @@ pub(crate) fn record_bootstrap_only_scan() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_quantizer_cache_hit() {
     increment(&QUANTIZER_CACHE_HITS);
-    record_shared_delta(TqStatsCounters {
-        quantizer_cache_hits: 1,
-        ..TqStatsCounters::default()
-    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -202,10 +181,6 @@ pub(crate) fn record_quantizer_cache_hit() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_quantizer_cache_miss() {
     increment(&QUANTIZER_CACHE_MISSES);
-    record_shared_delta(TqStatsCounters {
-        quantizer_cache_misses: 1,
-        ..TqStatsCounters::default()
-    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -215,6 +190,12 @@ pub(crate) fn record_quantizer_cache_miss() {}
 pub(crate) unsafe fn register_pg18_stats() {
     unsafe {
         let _ = pg18_pgstat_shim::register_kind();
+    }
+}
+
+pub(crate) fn flush_shared_delta(delta: TqStatsCounters) {
+    if !delta.is_zero() {
+        record_shared_delta(delta);
     }
 }
 
@@ -249,6 +230,10 @@ impl TqStatsCounters {
 
     pub(crate) fn reset(&mut self) {
         *self = Self::default();
+    }
+
+    pub(crate) fn is_zero(self) -> bool {
+        self == Self::default()
     }
 
     pub(crate) fn summary(self) -> TqStatsSummary {

--- a/src/am/common/stats.rs
+++ b/src/am/common/stats.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "pg18")]
+use crate::pg18_pgstat_shim;
+#[cfg(feature = "pg18")]
 use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8,6 +10,7 @@ pub(crate) struct StatsSnapshot {
     pub pg18_sql_function_ready: bool,
 }
 
+#[repr(C)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct TqStatsCounters {
     pub total_distance_calcs: u64,
@@ -35,7 +38,7 @@ pub(crate) struct TqStatsSummary {
 pub(crate) fn stats_snapshot() -> StatsSnapshot {
     StatsSnapshot {
         function_name: "tqvector_stats",
-        pg18_pgstat_kind_ready: false,
+        pg18_pgstat_kind_ready: pgstat_kind_ready(),
         pg18_sql_function_ready: cfg!(feature = "pg18"),
     }
 }
@@ -59,7 +62,7 @@ pub(crate) fn pgstat_kind_blocker() -> Option<&'static str> {
     #[cfg(feature = "pg18")]
     {
         Some(
-            "custom pgstat kind registration still needs shared_preload_libraries setup plus pgrx bindings or a shim for pgstat_internal.h",
+            "custom pgstat kind registration requires loading tqvector via shared_preload_libraries on PG18 and restarting PostgreSQL",
         )
     }
 
@@ -77,6 +80,23 @@ fn load_counter(counter: &AtomicU64) -> u64 {
 #[cfg(feature = "pg18")]
 fn increment(counter: &AtomicU64) {
     counter.fetch_add(1, Ordering::Relaxed);
+}
+
+#[cfg(feature = "pg18")]
+fn record_shared_delta(delta: TqStatsCounters) {
+    unsafe {
+        let _ = pg18_pgstat_shim::record(&delta);
+    }
+}
+
+#[cfg(feature = "pg18")]
+fn pgstat_kind_ready() -> bool {
+    unsafe { pg18_pgstat_shim::is_registered() }
+}
+
+#[cfg(not(feature = "pg18"))]
+fn pgstat_kind_ready() -> bool {
+    false
 }
 
 #[cfg(feature = "pg18")]
@@ -98,8 +118,22 @@ pub(crate) fn current_backend_stats_counters() -> TqStatsCounters {
 }
 
 #[cfg(feature = "pg18")]
+pub(crate) fn current_stats_counters() -> TqStatsCounters {
+    unsafe { pg18_pgstat_shim::snapshot().unwrap_or_else(current_backend_stats_counters) }
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn current_stats_counters() -> TqStatsCounters {
+    current_backend_stats_counters()
+}
+
+#[cfg(feature = "pg18")]
 pub(crate) fn record_distance_calc() {
     increment(&TOTAL_DISTANCE_CALCS);
+    record_shared_delta(TqStatsCounters {
+        total_distance_calcs: 1,
+        ..TqStatsCounters::default()
+    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -108,6 +142,10 @@ pub(crate) fn record_distance_calc() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_graph_hop() {
     increment(&TOTAL_GRAPH_HOPS);
+    record_shared_delta(TqStatsCounters {
+        total_graph_hops: 1,
+        ..TqStatsCounters::default()
+    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -116,6 +154,10 @@ pub(crate) fn record_graph_hop() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_linear_page() {
     increment(&TOTAL_LINEAR_PAGES);
+    record_shared_delta(TqStatsCounters {
+        total_linear_pages: 1,
+        ..TqStatsCounters::default()
+    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -124,6 +166,10 @@ pub(crate) fn record_linear_page() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_scan_started() {
     increment(&TOTAL_SCANS_STARTED);
+    record_shared_delta(TqStatsCounters {
+        total_scans_started: 1,
+        ..TqStatsCounters::default()
+    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -132,6 +178,10 @@ pub(crate) fn record_scan_started() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_bootstrap_only_scan() {
     increment(&TOTAL_SCANS_BOOTSTRAP_ONLY);
+    record_shared_delta(TqStatsCounters {
+        total_scans_bootstrap_only: 1,
+        ..TqStatsCounters::default()
+    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -140,6 +190,10 @@ pub(crate) fn record_bootstrap_only_scan() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_quantizer_cache_hit() {
     increment(&QUANTIZER_CACHE_HITS);
+    record_shared_delta(TqStatsCounters {
+        quantizer_cache_hits: 1,
+        ..TqStatsCounters::default()
+    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -148,6 +202,10 @@ pub(crate) fn record_quantizer_cache_hit() {}
 #[cfg(feature = "pg18")]
 pub(crate) fn record_quantizer_cache_miss() {
     increment(&QUANTIZER_CACHE_MISSES);
+    record_shared_delta(TqStatsCounters {
+        quantizer_cache_misses: 1,
+        ..TqStatsCounters::default()
+    });
 }
 
 #[cfg(not(feature = "pg18"))]
@@ -155,9 +213,8 @@ pub(crate) fn record_quantizer_cache_miss() {}
 
 #[cfg(feature = "pg18")]
 pub(crate) unsafe fn register_pg18_stats() {
-    if let Some(_blocker) = pgstat_kind_blocker() {
-        // `_PG_init()` still centralizes PG18 diagnostics setup so the blocker
-        // stays explicit until shared-preload registration is implemented.
+    unsafe {
+        let _ = pg18_pgstat_shim::register_kind();
     }
 }
 

--- a/src/am/common/stats.rs
+++ b/src/am/common/stats.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "pg18")]
+use std::sync::atomic::{AtomicU64, Ordering};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct StatsSnapshot {
     pub function_name: &'static str,
@@ -33,7 +36,128 @@ pub(crate) fn stats_snapshot() -> StatsSnapshot {
     StatsSnapshot {
         function_name: "tqvector_stats",
         pg18_pgstat_kind_ready: false,
-        pg18_sql_function_ready: false,
+        pg18_sql_function_ready: cfg!(feature = "pg18"),
+    }
+}
+
+#[cfg(feature = "pg18")]
+static TOTAL_DISTANCE_CALCS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "pg18")]
+static TOTAL_GRAPH_HOPS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "pg18")]
+static TOTAL_LINEAR_PAGES: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "pg18")]
+static TOTAL_SCANS_STARTED: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "pg18")]
+static TOTAL_SCANS_BOOTSTRAP_ONLY: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "pg18")]
+static QUANTIZER_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "pg18")]
+static QUANTIZER_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn pgstat_kind_blocker() -> Option<&'static str> {
+    #[cfg(feature = "pg18")]
+    {
+        Some(
+            "custom pgstat kind registration still needs shared_preload_libraries setup plus pgrx bindings or a shim for pgstat_internal.h",
+        )
+    }
+
+    #[cfg(not(feature = "pg18"))]
+    {
+        None
+    }
+}
+
+#[cfg(feature = "pg18")]
+fn load_counter(counter: &AtomicU64) -> u64 {
+    counter.load(Ordering::Relaxed)
+}
+
+#[cfg(feature = "pg18")]
+fn increment(counter: &AtomicU64) {
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+#[cfg(feature = "pg18")]
+pub(crate) fn current_backend_stats_counters() -> TqStatsCounters {
+    TqStatsCounters {
+        total_distance_calcs: load_counter(&TOTAL_DISTANCE_CALCS),
+        total_graph_hops: load_counter(&TOTAL_GRAPH_HOPS),
+        total_linear_pages: load_counter(&TOTAL_LINEAR_PAGES),
+        total_scans_started: load_counter(&TOTAL_SCANS_STARTED),
+        total_scans_bootstrap_only: load_counter(&TOTAL_SCANS_BOOTSTRAP_ONLY),
+        quantizer_cache_hits: load_counter(&QUANTIZER_CACHE_HITS),
+        quantizer_cache_misses: load_counter(&QUANTIZER_CACHE_MISSES),
+    }
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn current_backend_stats_counters() -> TqStatsCounters {
+    TqStatsCounters::default()
+}
+
+#[cfg(feature = "pg18")]
+pub(crate) fn record_distance_calc() {
+    increment(&TOTAL_DISTANCE_CALCS);
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn record_distance_calc() {}
+
+#[cfg(feature = "pg18")]
+pub(crate) fn record_graph_hop() {
+    increment(&TOTAL_GRAPH_HOPS);
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn record_graph_hop() {}
+
+#[cfg(feature = "pg18")]
+pub(crate) fn record_linear_page() {
+    increment(&TOTAL_LINEAR_PAGES);
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn record_linear_page() {}
+
+#[cfg(feature = "pg18")]
+pub(crate) fn record_scan_started() {
+    increment(&TOTAL_SCANS_STARTED);
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn record_scan_started() {}
+
+#[cfg(feature = "pg18")]
+pub(crate) fn record_bootstrap_only_scan() {
+    increment(&TOTAL_SCANS_BOOTSTRAP_ONLY);
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn record_bootstrap_only_scan() {}
+
+#[cfg(feature = "pg18")]
+pub(crate) fn record_quantizer_cache_hit() {
+    increment(&QUANTIZER_CACHE_HITS);
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn record_quantizer_cache_hit() {}
+
+#[cfg(feature = "pg18")]
+pub(crate) fn record_quantizer_cache_miss() {
+    increment(&QUANTIZER_CACHE_MISSES);
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn record_quantizer_cache_miss() {}
+
+#[cfg(feature = "pg18")]
+pub(crate) unsafe fn register_pg18_stats() {
+    if let Some(_blocker) = pgstat_kind_blocker() {
+        // `_PG_init()` still centralizes PG18 diagnostics setup so the blocker
+        // stays explicit until shared-preload registration is implemented.
     }
 }
 
@@ -102,13 +226,13 @@ mod tests {
     use super::{stats_snapshot, StatsSnapshot, TqStatsCounters, TqStatsSummary};
 
     #[test]
-    fn stats_snapshot_stays_explicitly_unwired_until_pg18_support_exists() {
+    fn stats_snapshot_matches_build_target() {
         assert_eq!(
             stats_snapshot(),
             StatsSnapshot {
                 function_name: "tqvector_stats",
                 pg18_pgstat_kind_ready: false,
-                pg18_sql_function_ready: false,
+                pg18_sql_function_ready: cfg!(feature = "pg18"),
             }
         );
     }

--- a/src/am/common/stream.rs
+++ b/src/am/common/stream.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "pg18")]
+use pgrx::pg_sys;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GraphPrefetchState {
     blocks: Vec<u32>,
@@ -314,5 +317,3 @@ mod tests {
         );
     }
 }
-#[cfg(feature = "pg18")]
-use pgrx::pg_sys;

--- a/src/am/common/stream.rs
+++ b/src/am/common/stream.rs
@@ -122,9 +122,59 @@ pub(crate) fn stream_snapshot() -> ReadStreamSnapshot {
         linear_stream_mode: linear.stream_mode,
         graph_stream_access_pattern: graph.access_pattern,
         linear_stream_access_pattern: linear.access_pattern,
-        pg18_callback_surface_ready: false,
-        pg18_scan_wiring_ready: false,
-        pg18_vacuum_wiring_ready: false,
+        pg18_callback_surface_ready: cfg!(feature = "pg18"),
+        pg18_scan_wiring_ready: cfg!(feature = "pg18"),
+        pg18_vacuum_wiring_ready: cfg!(feature = "pg18"),
+    }
+}
+
+#[cfg(feature = "pg18")]
+unsafe fn write_stream_block(per_buffer_data: *mut std::ffi::c_void, block_number: u32) {
+    let block_slot = per_buffer_data.cast::<pg_sys::BlockNumber>();
+    if !block_slot.is_null() {
+        unsafe {
+            *block_slot = block_number;
+        }
+    }
+}
+
+#[cfg(feature = "pg18")]
+pub(crate) unsafe extern "C-unwind" fn graph_prefetch_cb(
+    _stream: *mut pg_sys::ReadStream,
+    callback_private_data: *mut std::ffi::c_void,
+    per_buffer_data: *mut std::ffi::c_void,
+) -> pg_sys::BlockNumber {
+    unsafe {
+        pgrx::pgrx_extern_c_guard(|| {
+            let state = &mut *callback_private_data.cast::<GraphPrefetchState>();
+            match graph_prefetch_callback(state) {
+                ReadStreamCallbackResult::Block(block_number) => {
+                    write_stream_block(per_buffer_data, block_number);
+                    block_number
+                }
+                ReadStreamCallbackResult::EndOfStream => pg_sys::InvalidBlockNumber,
+            }
+        })
+    }
+}
+
+#[cfg(feature = "pg18")]
+pub(crate) unsafe extern "C-unwind" fn linear_prefetch_cb(
+    _stream: *mut pg_sys::ReadStream,
+    callback_private_data: *mut std::ffi::c_void,
+    per_buffer_data: *mut std::ffi::c_void,
+) -> pg_sys::BlockNumber {
+    unsafe {
+        pgrx::pgrx_extern_c_guard(|| {
+            let state = &mut *callback_private_data.cast::<LinearPrefetchState>();
+            match linear_prefetch_callback(state) {
+                ReadStreamCallbackResult::Block(block_number) => {
+                    write_stream_block(per_buffer_data, block_number);
+                    block_number
+                }
+                ReadStreamCallbackResult::EndOfStream => pg_sys::InvalidBlockNumber,
+            }
+        })
     }
 }
 
@@ -137,7 +187,7 @@ mod tests {
     };
 
     #[test]
-    fn stream_snapshot_stays_explicitly_unwired_until_pg18_support_exists() {
+    fn stream_snapshot_matches_build_target() {
         assert_eq!(
             stream_snapshot(),
             ReadStreamSnapshot {
@@ -145,9 +195,9 @@ mod tests {
                 linear_stream_mode: "READ_STREAM_SEQUENTIAL",
                 graph_stream_access_pattern: "random",
                 linear_stream_access_pattern: "sequential",
-                pg18_callback_surface_ready: false,
-                pg18_scan_wiring_ready: false,
-                pg18_vacuum_wiring_ready: false,
+                pg18_callback_surface_ready: cfg!(feature = "pg18"),
+                pg18_scan_wiring_ready: cfg!(feature = "pg18"),
+                pg18_vacuum_wiring_ready: cfg!(feature = "pg18"),
             }
         );
     }
@@ -264,3 +314,5 @@ mod tests {
         );
     }
 }
+#[cfg(feature = "pg18")]
+use pgrx::pg_sys;

--- a/src/am/ec_hnsw/graph.rs
+++ b/src/am/ec_hnsw/graph.rs
@@ -529,16 +529,16 @@ where
         GraphStorageDescriptor::TurboQuant { code_len } => unsafe {
             read_page_tuple_from_buffer(buffer, element_tid, "element", |tuple_bytes| {
                 Ok(f(GraphTupleRef::Scalar(page::TqElementTupleRef::decode(
-                    tuple_bytes, code_len,
+                    tuple_bytes,
+                    code_len,
                 )?)))
             })
         },
         GraphStorageDescriptor::TurboQuantHotCold(layout) => unsafe {
             read_page_tuple_from_buffer(buffer, element_tid, "turbo hot", |tuple_bytes| {
-                Ok(f(GraphTupleRef::TurboHot(page::TqTurboHotTupleRef::decode(
-                    tuple_bytes,
-                    layout.binary_word_count,
-                )?)))
+                Ok(f(GraphTupleRef::TurboHot(
+                    page::TqTurboHotTupleRef::decode(tuple_bytes, layout.binary_word_count)?,
+                )))
             })
         },
         GraphStorageDescriptor::PqFastScan(layout) => unsafe {

--- a/src/am/ec_hnsw/graph.rs
+++ b/src/am/ec_hnsw/graph.rs
@@ -515,6 +515,47 @@ where
     }
 }
 
+#[cfg(feature = "pg18")]
+pub(crate) unsafe fn with_graph_storage_tuple_from_buffer<R, F>(
+    buffer: pg_sys::Buffer,
+    element_tid: page::ItemPointer,
+    storage: GraphStorageDescriptor,
+    f: F,
+) -> R
+where
+    F: FnOnce(GraphTupleRef<'_>) -> R,
+{
+    match storage {
+        GraphStorageDescriptor::TurboQuant { code_len } => unsafe {
+            read_page_tuple_from_buffer(buffer, element_tid, "element", |tuple_bytes| {
+                Ok(f(GraphTupleRef::Scalar(page::TqElementTupleRef::decode(
+                    tuple_bytes, code_len,
+                )?)))
+            })
+        },
+        GraphStorageDescriptor::TurboQuantHotCold(layout) => unsafe {
+            read_page_tuple_from_buffer(buffer, element_tid, "turbo hot", |tuple_bytes| {
+                Ok(f(GraphTupleRef::TurboHot(page::TqTurboHotTupleRef::decode(
+                    tuple_bytes,
+                    layout.binary_word_count,
+                )?)))
+            })
+        },
+        GraphStorageDescriptor::PqFastScan(layout) => unsafe {
+            read_page_tuple_from_buffer(buffer, element_tid, "grouped hot", |tuple_bytes| {
+                Ok(f(GraphTupleRef::GroupedHot(
+                    page::TqGroupedHotTupleRef::decode(
+                        tuple_bytes,
+                        layout.binary_word_count,
+                        layout.search_code_len,
+                    )?,
+                )))
+            })
+        },
+    }
+    .unwrap_or_else(|e| pgrx::error!("ec_hnsw failed to decode graph element tuple: {e}"))
+}
+
 #[cfg_attr(not(any(test, feature = "pg_test")), allow(dead_code))]
 pub(crate) unsafe fn with_grouped_rerank_tuple<R, F>(
     index_relation: pg_sys::Relation,
@@ -1605,6 +1646,45 @@ where
     let decoded = decode(tuple_bytes);
     unsafe { pg_sys::UnlockReleaseBuffer(buffer) };
     decoded
+}
+
+#[cfg(feature = "pg18")]
+unsafe fn read_page_tuple_from_buffer<T, DecodeFn>(
+    buffer: pg_sys::Buffer,
+    tuple_tid: page::ItemPointer,
+    tuple_kind: &str,
+    decode: DecodeFn,
+) -> Result<T, String>
+where
+    DecodeFn: FnOnce(&[u8]) -> Result<T, String>,
+{
+    let page_ptr = unsafe { pg_sys::BufferGetPage(buffer) }.cast::<u8>();
+    let page_size = unsafe { pg_sys::BufferGetPageSize(buffer) as usize };
+    let line_pointer_count = super::shared::page_line_pointer_count(page_ptr);
+    if tuple_tid.offset_number == 0 || tuple_tid.offset_number > line_pointer_count {
+        pgrx::error!(
+            "ec_hnsw graph read found {tuple_kind} tuple offset {} out of range on block {}",
+            tuple_tid.offset_number,
+            tuple_tid.block_number
+        );
+    }
+
+    let item_id = unsafe { &*super::shared::page_item_id(page_ptr, tuple_tid.offset_number) };
+    if item_id.lp_flags() == 0 {
+        pgrx::error!("ec_hnsw graph read found unused {tuple_kind} tuple slot");
+    }
+
+    let tuple_offset = item_id.lp_off() as usize;
+    let tuple_len = item_id.lp_len() as usize;
+    if tuple_offset + tuple_len > page_size {
+        pgrx::error!(
+            "ec_hnsw found invalid {tuple_kind} tuple bounds on block {}",
+            tuple_tid.block_number
+        );
+    }
+
+    let tuple_bytes = unsafe { std::slice::from_raw_parts(page_ptr.add(tuple_offset), tuple_len) };
+    decode(tuple_bytes)
 }
 
 #[cfg(test)]

--- a/src/am/ec_hnsw/mod.rs
+++ b/src/am/ec_hnsw/mod.rs
@@ -57,6 +57,12 @@ pub(crate) unsafe fn planner_integration_snapshot(
     unsafe { shared::planner_integration_snapshot(index_relation) }
 }
 
+pub(crate) unsafe fn explain_counters_from_index_scan_state(
+    index_state: *mut pgrx::pg_sys::IndexScanState,
+) -> explain::TqExplainCounters {
+    unsafe { scan::explain_counters_from_index_scan_state(index_state) }
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[allow(unused_imports)]
 pub(crate) use self::shared::{

--- a/src/am/ec_hnsw/routine.rs
+++ b/src/am/ec_hnsw/routine.rs
@@ -14,6 +14,10 @@ fn build_ec_hnsw_routine() -> PgBox<pg_sys::IndexAmRoutine, AllocatedByRust> {
 
     amroutine.amcanorder = false;
     amroutine.amcanorderbyop = true;
+    #[cfg(feature = "pg18")]
+    {
+        amroutine.amconsistentordering = true;
+    }
     amroutine.amcanbackward = false;
     amroutine.amcanunique = false;
     amroutine.amcanmulticol = false;
@@ -39,6 +43,10 @@ fn build_ec_hnsw_routine() -> PgBox<pg_sys::IndexAmRoutine, AllocatedByRust> {
     amroutine.amvacuumcleanup = Some(vacuum::ec_hnsw_amvacuumcleanup);
     amroutine.amcanreturn = None;
     amroutine.amcostestimate = Some(cost::ec_hnsw_amcostestimate);
+    #[cfg(feature = "pg18")]
+    {
+        amroutine.amgettreeheight = Some(cost::ec_hnsw_amgettreeheight);
+    }
     amroutine.amoptions = Some(options::ec_hnsw_amoptions);
     amroutine.amproperty = None;
     amroutine.ambuildphasename = None;
@@ -54,6 +62,11 @@ fn build_ec_hnsw_routine() -> PgBox<pg_sys::IndexAmRoutine, AllocatedByRust> {
     amroutine.amestimateparallelscan = None;
     amroutine.aminitparallelscan = None;
     amroutine.amparallelrescan = None;
+    #[cfg(feature = "pg18")]
+    {
+        amroutine.amtranslatestrategy = Some(cost::ec_hnsw_amtranslatestrategy);
+        amroutine.amtranslatecmptype = Some(cost::ec_hnsw_amtranslatecmptype);
+    }
 
     amroutine
 }

--- a/src/am/ec_hnsw/scan.rs
+++ b/src/am/ec_hnsw/scan.rs
@@ -17,6 +17,7 @@ use super::graph;
 use super::page;
 use super::search;
 use super::source;
+use super::stats::TqStatsCounters;
 use super::stream::{GraphPrefetchState, LinearPrefetchState};
 
 const MAX_BOOTSTRAP_FRONTIER_CANDIDATES: usize = 3;
@@ -992,7 +993,9 @@ pub(super) unsafe extern "C-unwind" fn ec_hnsw_amrescan(
             let store_query_elapsed_us = 0;
             record_store_query_elapsed(opaque, store_query_elapsed_us);
             opaque.explain_counters.reset();
+            opaque.stats_delta.reset();
             super::stats::record_scan_started();
+            opaque.stats_delta.record_scan_started();
             #[cfg(any(test, feature = "pg_test"))]
             let prepare_started = Instant::now();
             store_scan_prepared_query(opaque, &query, &metadata);
@@ -1816,8 +1819,10 @@ fn store_scan_prepared_query(
     if cache_hit {
         opaque.explain_counters.record_quantizer_cache_hit();
         super::stats::record_quantizer_cache_hit();
+        opaque.stats_delta.record_quantizer_cache_hit();
     } else {
         super::stats::record_quantizer_cache_miss();
+        opaque.stats_delta.record_quantizer_cache_miss();
     }
 }
 
@@ -3428,6 +3433,7 @@ unsafe fn prefetch_next_graph_result_from_frontier(
         mark_expanded_source(opaque, candidate.node);
         opaque.explain_counters.record_bootstrap_expansion();
         super::stats::record_graph_hop();
+        opaque.stats_delta.record_graph_hop();
         #[cfg(any(test, feature = "pg_test"))]
         let materialize_started = Instant::now();
         if unsafe {
@@ -3479,6 +3485,7 @@ unsafe fn prefetch_next_grouped_windowed_graph_result(
         mark_expanded_source(opaque, candidate.node);
         opaque.explain_counters.record_bootstrap_expansion();
         super::stats::record_graph_hop();
+        opaque.stats_delta.record_graph_hop();
         #[cfg(any(test, feature = "pg_test"))]
         let materialize_started = Instant::now();
         unsafe { buffer_grouped_graph_result_candidate(index_relation, opaque, candidate) };
@@ -3725,7 +3732,11 @@ fn finish_scan_stats(opaque: &mut TqScanOpaque) {
     }
     if !opaque.stats_used_linear_fallback {
         super::stats::record_bootstrap_only_scan();
+        opaque.stats_delta.record_bootstrap_only_scan();
     }
+    // Keep preload-on shared stats off the hot path by flushing one aggregate per scan.
+    super::stats::flush_shared_delta(opaque.stats_delta);
+    opaque.stats_delta.reset();
     opaque.stats_scan_finalized = true;
 }
 
@@ -4193,7 +4204,7 @@ unsafe fn refill_candidate_frontier_from_source_into(
                 |neighbor_tid| !visited_contains_element(&*opaque_ptr, neighbor_tid),
                 |neighbor| {
                     Some(score_scan_element_result(
-                        &*opaque_ptr,
+                        &mut *opaque_ptr,
                         neighbor.gamma,
                         &neighbor.code,
                     ))
@@ -4227,7 +4238,7 @@ unsafe fn top_up_bootstrap_frontier_from_visible_seeds_into(
                     |neighbor_tid| !visited_contains_element(&*opaque_ptr, neighbor_tid),
                     |neighbor| {
                         Some(score_scan_element_result(
-                            &*opaque_ptr,
+                            &mut *opaque_ptr,
                             neighbor.gamma,
                             &neighbor.code,
                         ))
@@ -4527,6 +4538,7 @@ unsafe fn select_linear_scan_result_from_buffer(
     unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32) };
     opaque.explain_counters.record_linear_page_read();
     super::stats::record_linear_page();
+    opaque.stats_delta.record_linear_page();
     let page_ptr = unsafe { pg_sys::BufferGetPage(buffer) }.cast::<u8>();
     let page_size = unsafe { pg_sys::BufferGetPageSize(buffer) as usize };
     let line_pointer_count = super::shared::page_line_pointer_count(page_ptr);
@@ -4626,12 +4638,17 @@ where
     candidates
 }
 
-unsafe fn score_scan_element_result(opaque: &TqScanOpaque, gamma: f32, code_bytes: &[u8]) -> f32 {
+unsafe fn score_scan_element_result(
+    opaque: &mut TqScanOpaque,
+    gamma: f32,
+    code_bytes: &[u8],
+) -> f32 {
     if opaque.cached_quantizer.is_null() {
         pgrx::error!("ec_hnsw scan scoring requires a cached quantizer");
     }
 
     super::stats::record_distance_calc();
+    opaque.stats_delta.record_distance_calc();
     let quantizer = unsafe { &*opaque.cached_quantizer };
     match opaque.turboquant_exact_score_mode {
         TurboQuantExactScoreMode::Exact => {}
@@ -5103,6 +5120,7 @@ pub(super) struct TqScanOpaque {
     pub(super) graph_prefetch_state: *mut GraphPrefetchState,
     pub(super) linear_prefetch_state: LinearPrefetchState,
     pub(super) explain_counters: TqExplainCounters,
+    pub(super) stats_delta: TqStatsCounters,
     stats_used_linear_fallback: bool,
     stats_scan_finalized: bool,
     #[cfg(any(test, feature = "pg_test"))]
@@ -5177,6 +5195,7 @@ impl Default for TqScanOpaque {
                 page::FIRST_DATA_BLOCK_NUMBER,
             ),
             explain_counters: TqExplainCounters::default(),
+            stats_delta: TqStatsCounters::default(),
             stats_used_linear_fallback: false,
             stats_scan_finalized: false,
             #[cfg(any(test, feature = "pg_test"))]

--- a/src/am/ec_hnsw/scan.rs
+++ b/src/am/ec_hnsw/scan.rs
@@ -916,7 +916,8 @@ pub(super) unsafe extern "C-unwind" fn ec_hnsw_amrescan(
             let index_options = super::options::relation_options((*scan).indexRelation);
             let opaque = &mut *(*scan).opaque.cast::<TqScanOpaque>();
             if opaque.rescan_called {
-                finish_scan_stats(opaque);
+                finalize_scan_stats(opaque);
+                flush_scan_stats(opaque);
             }
             opaque.rescan_called = true;
             opaque.scan_dimensions = metadata.dimensions;
@@ -1651,7 +1652,8 @@ pub(super) unsafe extern "C-unwind" fn ec_hnsw_amendscan(scan: pg_sys::IndexScan
             let opaque_ptr = (*scan).opaque;
             if !opaque_ptr.is_null() {
                 let opaque = &mut *opaque_ptr.cast::<TqScanOpaque>();
-                finish_scan_stats(opaque);
+                finalize_scan_stats(opaque);
+                flush_scan_stats(opaque);
                 #[cfg(feature = "pg18")]
                 {
                     end_read_stream(&mut opaque.graph_read_stream);
@@ -3613,7 +3615,7 @@ fn mark_scan_exhausted(opaque: &mut TqScanOpaque) {
     opaque.result_state.clear();
     opaque.fallback_result_state.clear();
     opaque.execution_phase = ScanExecutionPhase::Exhausted;
-    finish_scan_stats(opaque);
+    finalize_scan_stats(opaque);
 }
 
 fn reset_bootstrap_expansion_state(opaque: &mut TqScanOpaque, ef_search: usize) {
@@ -3726,7 +3728,7 @@ fn ensure_linear_read_stream(
     opaque.linear_read_stream
 }
 
-fn finish_scan_stats(opaque: &mut TqScanOpaque) {
+fn finalize_scan_stats(opaque: &mut TqScanOpaque) {
     if opaque.stats_scan_finalized || !opaque.rescan_called {
         return;
     }
@@ -3734,10 +3736,16 @@ fn finish_scan_stats(opaque: &mut TqScanOpaque) {
         super::stats::record_bootstrap_only_scan();
         opaque.stats_delta.record_bootstrap_only_scan();
     }
-    // Keep preload-on shared stats off the hot path by flushing one aggregate per scan.
+    opaque.stats_scan_finalized = true;
+}
+
+fn flush_scan_stats(opaque: &mut TqScanOpaque) {
+    if !opaque.rescan_called || opaque.stats_delta.is_zero() {
+        return;
+    }
+    // Shared pgstat snapshots are updated during scan teardown/rescan, not mid-scan.
     super::stats::flush_shared_delta(opaque.stats_delta);
     opaque.stats_delta.reset();
-    opaque.stats_scan_finalized = true;
 }
 
 type VisibleCandidateFrontierState = search::VisibleFrontier<page::ItemPointer>;
@@ -6539,6 +6547,34 @@ mod tests {
             -quantizer.score_ip_from_parts(&prepared, encoded.gamma, &payload.rerank_code);
 
         assert_eq!(observed, expected);
+    }
+
+    #[test]
+    fn miri_score_scan_element_result_via_raw_opaque_ptr_updates_stats_delta() {
+        let vector = vec![0.1_f32];
+        let query = vec![0.25_f32];
+        let quantizer = Arc::new(ProdQuantizer::new(vector.len(), 4, 42));
+        let prepared_query = Box::new(quantizer.prepare_ip_query(&query));
+        let encoded = quantizer.encode(&vector);
+        let mut code_bytes = encoded.mse_packed.clone();
+        code_bytes.extend_from_slice(&encoded.qjl_packed);
+        let cached_quantizer = Arc::into_raw(quantizer);
+        let prepared_query = Box::into_raw(prepared_query);
+
+        let mut opaque = TqScanOpaque {
+            cached_quantizer,
+            prepared_query,
+            ..TqScanOpaque::default()
+        };
+        let opaque_ptr = &mut opaque as *mut TqScanOpaque;
+
+        let score =
+            unsafe { score_scan_element_result(&mut *opaque_ptr, encoded.gamma, &code_bytes) };
+
+        assert!(score.is_finite());
+        assert_eq!(unsafe { (*opaque_ptr).stats_delta.total_distance_calcs }, 1);
+
+        free_scan_prepared_query(&mut opaque);
     }
 
     #[test]

--- a/src/am/ec_hnsw/scan.rs
+++ b/src/am/ec_hnsw/scan.rs
@@ -914,6 +914,9 @@ pub(super) unsafe extern "C-unwind" fn ec_hnsw_amrescan(
 
             let index_options = super::options::relation_options((*scan).indexRelation);
             let opaque = &mut *(*scan).opaque.cast::<TqScanOpaque>();
+            if opaque.rescan_called {
+                finish_scan_stats(opaque);
+            }
             opaque.rescan_called = true;
             opaque.scan_dimensions = metadata.dimensions;
             opaque.scan_m = metadata.m;
@@ -989,6 +992,7 @@ pub(super) unsafe extern "C-unwind" fn ec_hnsw_amrescan(
             let store_query_elapsed_us = 0;
             record_store_query_elapsed(opaque, store_query_elapsed_us);
             opaque.explain_counters.reset();
+            super::stats::record_scan_started();
             #[cfg(any(test, feature = "pg_test"))]
             let prepare_started = Instant::now();
             store_scan_prepared_query(opaque, &query, &metadata);
@@ -1004,6 +1008,13 @@ pub(super) unsafe extern "C-unwind" fn ec_hnsw_amrescan(
             reset_scan_position(opaque);
             reset_linear_prefetch_state(opaque);
             reset_graph_prefetch_state(opaque);
+            #[cfg(feature = "pg18")]
+            {
+                let graph_stream = ensure_graph_read_stream((*scan).indexRelation, opaque);
+                let linear_stream = ensure_linear_read_stream((*scan).indexRelation, opaque);
+                pg_sys::read_stream_reset(graph_stream);
+                pg_sys::read_stream_reset(linear_stream);
+            }
             #[cfg(any(test, feature = "pg_test"))]
             let reset_elapsed_us = u64::try_from(reset_started.elapsed().as_micros())
                 .expect("timing should fit in u64");
@@ -1637,6 +1648,12 @@ pub(super) unsafe extern "C-unwind" fn ec_hnsw_amendscan(scan: pg_sys::IndexScan
             let opaque_ptr = (*scan).opaque;
             if !opaque_ptr.is_null() {
                 let opaque = &mut *opaque_ptr.cast::<TqScanOpaque>();
+                finish_scan_stats(opaque);
+                #[cfg(feature = "pg18")]
+                {
+                    end_read_stream(&mut opaque.graph_read_stream);
+                    end_read_stream(&mut opaque.linear_read_stream);
+                }
                 free_graph_prefetch_state(opaque);
                 free_scan_graph_cache(opaque);
                 free_scan_score_cache(opaque);
@@ -1653,6 +1670,26 @@ pub(super) unsafe extern "C-unwind" fn ec_hnsw_amendscan(scan: pg_sys::IndexScan
             }
         })
     }
+}
+
+pub(crate) unsafe fn explain_counters_from_index_scan_state(
+    index_state: *mut pg_sys::IndexScanState,
+) -> TqExplainCounters {
+    if index_state.is_null() {
+        return TqExplainCounters::default();
+    }
+
+    let scan_desc = unsafe { (*index_state).iss_ScanDesc };
+    if scan_desc.is_null() {
+        return TqExplainCounters::default();
+    }
+
+    let opaque = unsafe { (*scan_desc).opaque };
+    if opaque.is_null() {
+        return TqExplainCounters::default();
+    }
+
+    unsafe { (*opaque.cast::<TqScanOpaque>()).explain_counters }
 }
 
 unsafe fn store_scan_query(opaque: &mut TqScanOpaque, query: &[f32]) {
@@ -1778,6 +1815,9 @@ fn store_scan_prepared_query(
     opaque.cached_quantizer = Arc::into_raw(quantizer);
     if cache_hit {
         opaque.explain_counters.record_quantizer_cache_hit();
+        super::stats::record_quantizer_cache_hit();
+    } else {
+        super::stats::record_quantizer_cache_miss();
     }
 }
 
@@ -1880,6 +1920,8 @@ fn reset_scan_position(opaque: &mut TqScanOpaque) {
     opaque.next_block_number = page::FIRST_DATA_BLOCK_NUMBER;
     opaque.next_offset_number = 1;
     opaque.execution_phase = ScanExecutionPhase::GraphTraversal;
+    opaque.stats_used_linear_fallback = false;
+    opaque.stats_scan_finalized = false;
     clear_last_emitted_scan_scores(opaque);
     clear_grouped_live_rerank_buffer(opaque);
     clear_scan_candidate_state(opaque);
@@ -2030,6 +2072,52 @@ unsafe fn score_and_cache_scan_element(
     score
 }
 
+fn build_cached_graph_element(
+    opaque_ref: &mut TqScanOpaque,
+    element_tid: page::ItemPointer,
+    element: graph::GraphTupleRef<'_>,
+) -> (CachedGraphElement, LoadedElementState) {
+    let binary_query_active = binary_sign_query(opaque_ref).is_some();
+    let live_element = !element.deleted() && element.heaptid_count() > 0;
+    let binary_words = if binary_query_active {
+        if !super::options::force_binary_derivation() && element.binary_word_count() > 0 {
+            CachedBinaryWords::from_vec(element.collect_binary_words())
+        } else {
+            match element.exact_payload() {
+                Some((_gamma, code_bytes)) => {
+                    let quantizer = unsafe { &*opaque_ref.cached_quantizer };
+                    CachedBinaryWords::from_vec(
+                        quantizer.binary_sign_words_from_packed_no_qjl_4bit(code_bytes),
+                    )
+                }
+                None => CachedBinaryWords::empty(),
+            }
+        }
+    } else {
+        CachedBinaryWords::empty()
+    };
+
+    let mut loaded_state = LoadedElementState::None;
+    if live_element {
+        loaded_state = match (opaque_ref.scan_graph_storage, element.exact_payload()) {
+            (graph::GraphStorageDescriptor::TurboQuantHotCold(_), None) => LoadedElementState::None,
+            (_, exact_payload) => unsafe {
+                live_loaded_state_from_exact_payload(
+                    opaque_ref,
+                    element_tid,
+                    binary_query_active,
+                    exact_payload,
+                )
+            },
+        };
+    }
+
+    (
+        CachedGraphElement::from_graph_tuple_ref(element_tid, element, binary_words),
+        loaded_state,
+    )
+}
+
 unsafe fn cached_graph_element(
     index_relation: pg_sys::Relation,
     opaque: *mut TqScanOpaque,
@@ -2045,51 +2133,15 @@ unsafe fn cached_graph_element(
 
     #[cfg(any(test, feature = "pg_test"))]
     let started = Instant::now();
-    let binary_query_active = binary_sign_query(opaque_ref).is_some();
-    let mut loaded_state = LoadedElementState::None;
-    let element = Arc::new(unsafe {
+    let (element, loaded_state) = unsafe {
         graph::with_graph_storage_tuple(
             index_relation,
             element_tid,
             opaque_ref.scan_graph_storage,
-            |element| {
-                let live_element = !element.deleted() && element.heaptid_count() > 0;
-                let binary_words = if binary_query_active {
-                    if !super::options::force_binary_derivation() && element.binary_word_count() > 0
-                    {
-                        CachedBinaryWords::from_vec(element.collect_binary_words())
-                    } else {
-                        match element.exact_payload() {
-                            Some((_gamma, code_bytes)) => {
-                                let quantizer = &*opaque_ref.cached_quantizer;
-                                CachedBinaryWords::from_vec(
-                                    quantizer.binary_sign_words_from_packed_no_qjl_4bit(code_bytes),
-                                )
-                            }
-                            None => CachedBinaryWords::empty(),
-                        }
-                    }
-                } else {
-                    CachedBinaryWords::empty()
-                };
-
-                if live_element {
-                    loaded_state = match (opaque_ref.scan_graph_storage, element.exact_payload()) {
-                        (graph::GraphStorageDescriptor::TurboQuantHotCold(_), None) => {
-                            LoadedElementState::None
-                        }
-                        (_, exact_payload) => live_loaded_state_from_exact_payload(
-                            opaque_ref,
-                            element_tid,
-                            binary_query_active,
-                            exact_payload,
-                        ),
-                    };
-                }
-                CachedGraphElement::from_graph_tuple_ref(element_tid, element, binary_words)
-            },
+            |element| build_cached_graph_element(opaque_ref, element_tid, element),
         )
-    });
+    };
+    let element = Arc::new(element);
     #[cfg(any(test, feature = "pg_test"))]
     let elapsed_us =
         u64::try_from(started.elapsed().as_micros()).expect("timing should fit in u64");
@@ -2107,6 +2159,41 @@ unsafe fn cached_graph_element(
             || !matches!(loaded_state, LoadedElementState::None),
         "live graph elements should populate exact-score or binary-prefilter state on load"
     );
+    (element, loaded_state)
+}
+
+#[cfg(feature = "pg18")]
+unsafe fn cached_graph_element_from_buffer(
+    opaque: *mut TqScanOpaque,
+    buffer: pg_sys::Buffer,
+    element_tid: page::ItemPointer,
+) -> (Arc<CachedGraphElement>, LoadedElementState) {
+    let opaque_ref = unsafe { &mut *opaque };
+    if !opaque_ref.graph_element_cache.is_null() {
+        if let Some(element) = unsafe { &*opaque_ref.graph_element_cache }.get(&element_tid) {
+            record_graph_element_cache_hit(opaque_ref);
+            return (Arc::clone(element), LoadedElementState::None);
+        }
+    }
+
+    #[cfg(any(test, feature = "pg_test"))]
+    let started = Instant::now();
+    let (element, loaded_state) = unsafe {
+        graph::with_graph_storage_tuple_from_buffer(
+            buffer,
+            element_tid,
+            opaque_ref.scan_graph_storage,
+            |element| build_cached_graph_element(opaque_ref, element_tid, element),
+        )
+    };
+    let element = Arc::new(element);
+    #[cfg(any(test, feature = "pg_test"))]
+    let elapsed_us =
+        u64::try_from(started.elapsed().as_micros()).expect("timing should fit in u64");
+    #[cfg(not(any(test, feature = "pg_test")))]
+    let elapsed_us = 0;
+    record_graph_element_cache_miss_load(opaque_ref, elapsed_us);
+    graph_element_cache_mut(opaque_ref).insert(element_tid, Arc::clone(&element));
     (element, loaded_state)
 }
 
@@ -2682,6 +2769,89 @@ unsafe fn cached_graph_adjacency(
     (element, neighbors)
 }
 
+#[cfg(feature = "pg18")]
+unsafe fn prefetch_graph_buffers(
+    index_relation: pg_sys::Relation,
+    opaque: &mut TqScanOpaque,
+    neighbor_tids: &[page::ItemPointer],
+) -> HashMap<u32, pg_sys::Buffer> {
+    let mut blocks = Vec::new();
+    let mut seen_blocks = HashSet::new();
+    for neighbor_tid in neighbor_tids.iter().copied() {
+        if neighbor_tid == page::ItemPointer::INVALID {
+            continue;
+        }
+        if seen_blocks.insert(neighbor_tid.block_number) {
+            blocks.push(neighbor_tid.block_number);
+        }
+    }
+
+    if blocks.is_empty() {
+        return HashMap::new();
+    }
+
+    reset_graph_prefetch_blocks(opaque, blocks);
+    let stream = ensure_graph_read_stream(index_relation, opaque);
+    unsafe { pg_sys::read_stream_reset(stream) };
+
+    let mut prefetched_buffers = HashMap::new();
+    loop {
+        let mut per_buffer_data = ptr::null_mut();
+        let buffer = unsafe { pg_sys::read_stream_next_buffer(stream, &mut per_buffer_data) };
+        if buffer == pg_sys::InvalidBuffer {
+            break;
+        }
+        let block_number = if per_buffer_data.is_null() {
+            unsafe { pg_sys::ReleaseBuffer(buffer) };
+            continue;
+        } else {
+            unsafe { *per_buffer_data.cast::<pg_sys::BlockNumber>() }
+        };
+        prefetched_buffers.insert(block_number, buffer);
+    }
+
+    prefetched_buffers
+}
+
+#[cfg(feature = "pg18")]
+fn release_prefetched_graph_buffers(prefetched_buffers: HashMap<u32, pg_sys::Buffer>) {
+    for buffer in prefetched_buffers.into_values() {
+        unsafe { pg_sys::ReleaseBuffer(buffer) };
+    }
+}
+
+fn release_prefetched_graph_buffers_if_any(
+    prefetched_buffers: Option<HashMap<u32, pg_sys::Buffer>>,
+) {
+    #[cfg(feature = "pg18")]
+    if let Some(prefetched_buffers) = prefetched_buffers {
+        release_prefetched_graph_buffers(prefetched_buffers);
+    }
+
+    #[cfg(not(feature = "pg18"))]
+    let _ = prefetched_buffers;
+}
+
+unsafe fn cached_graph_element_with_prefetch(
+    index_relation: pg_sys::Relation,
+    opaque: *mut TqScanOpaque,
+    #[cfg_attr(not(feature = "pg18"), allow(unused_variables))]
+    prefetched_buffers: Option<&HashMap<u32, pg_sys::Buffer>>,
+    element_tid: page::ItemPointer,
+) -> (Arc<CachedGraphElement>, LoadedElementState) {
+    #[cfg(feature = "pg18")]
+    if let Some(prefetched_buffers) = prefetched_buffers {
+        if let Some(buffer) = prefetched_buffers.get(&element_tid.block_number).copied() {
+            unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32) };
+            let loaded = unsafe { cached_graph_element_from_buffer(opaque, buffer, element_tid) };
+            unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_UNLOCK as i32) };
+            return loaded;
+        }
+    }
+
+    unsafe { cached_graph_element(index_relation, opaque, element_tid) }
+}
+
 unsafe fn cached_scan_successor_candidates_for_layer<KeepFn>(
     index_relation: pg_sys::Relation,
     opaque: *mut TqScanOpaque,
@@ -2705,31 +2875,60 @@ where
         })
         .unwrap_or(0);
     let mut candidates = Vec::with_capacity(capacity);
+    let neighbor_tids =
+        graph::valid_neighbor_tids_for_layer(&neighbors.tids, element.level, scan_m, layer);
+    #[cfg(feature = "pg18")]
+    let prefetched_buffers = Some(unsafe {
+        prefetch_graph_buffers(index_relation, unsafe { &mut *opaque }, &neighbor_tids)
+    });
+    #[cfg(not(feature = "pg18"))]
+    let prefetched_buffers: Option<HashMap<u32, pg_sys::Buffer>> = None;
 
     let binary_query = unsafe { (*opaque).binary_sign_query.as_ref() };
     if binary_query.is_none() {
         let mut grouped_candidates = exact_budget.map(|_| Vec::with_capacity(capacity));
-        graph::for_each_valid_neighbor_tid_for_layer(
-            &neighbors.tids,
-            element.level,
-            scan_m,
-            layer,
-            |neighbor_tid| {
-                if keep_neighbor_tid(neighbor_tid) {
-                    let (neighbor, loaded_state) =
-                        unsafe { cached_graph_element(index_relation, opaque, neighbor_tid) };
-                    if neighbor.deleted || neighbor.heaptids.is_empty() {
-                        return;
+        for neighbor_tid in neighbor_tids.iter().copied() {
+            if keep_neighbor_tid(neighbor_tid) {
+                let (neighbor, loaded_state) = unsafe {
+                    cached_graph_element_with_prefetch(
+                        index_relation,
+                        opaque,
+                        prefetched_buffers.as_ref(),
+                        neighbor_tid,
+                    )
+                };
+                if neighbor.deleted || neighbor.heaptids.is_empty() {
+                    continue;
+                }
+                match candidate_score_dispatch(scan_graph_storage, &neighbor, loaded_state) {
+                    CandidateScoreDispatch::Exact(loaded_state) => {
+                        let score = unsafe {
+                            exact_score_cached_graph_element(
+                                index_relation,
+                                opaque,
+                                neighbor.tid,
+                                loaded_state,
+                            )
+                        };
+                        candidates.push(search::BeamCandidate::with_source(
+                            neighbor.tid,
+                            score,
+                            source_tid,
+                        ));
                     }
-                    match candidate_score_dispatch(scan_graph_storage, &neighbor, loaded_state) {
-                        CandidateScoreDispatch::Exact(loaded_state) => {
+                    CandidateScoreDispatch::Grouped(grouped) => {
+                        if let Some(grouped_candidates) = grouped_candidates.as_mut() {
+                            let approx_score =
+                                unsafe { score_grouped_candidate_context_approx(opaque, grouped) };
+                            let ordinal = grouped_candidates.len();
+                            grouped_candidates.push(GroupedTraversalCandidate {
+                                ordinal,
+                                element: neighbor,
+                                approx_score,
+                            });
+                        } else {
                             let score = unsafe {
-                                exact_score_cached_graph_element(
-                                    index_relation,
-                                    opaque,
-                                    neighbor.tid,
-                                    loaded_state,
-                                )
+                                score_grouped_candidate_context(index_relation, opaque, grouped, layer)
                             };
                             candidates.push(search::BeamCandidate::with_source(
                                 neighbor.tid,
@@ -2737,37 +2936,10 @@ where
                                 source_tid,
                             ));
                         }
-                        CandidateScoreDispatch::Grouped(grouped) => {
-                            if let Some(grouped_candidates) = grouped_candidates.as_mut() {
-                                let approx_score = unsafe {
-                                    score_grouped_candidate_context_approx(opaque, grouped)
-                                };
-                                let ordinal = grouped_candidates.len();
-                                grouped_candidates.push(GroupedTraversalCandidate {
-                                    ordinal,
-                                    element: neighbor,
-                                    approx_score,
-                                });
-                            } else {
-                                let score = unsafe {
-                                    score_grouped_candidate_context(
-                                        index_relation,
-                                        opaque,
-                                        grouped,
-                                        layer,
-                                    )
-                                };
-                                candidates.push(search::BeamCandidate::with_source(
-                                    neighbor.tid,
-                                    score,
-                                    source_tid,
-                                ));
-                            }
-                        }
                     }
                 }
-            },
-        );
+            }
+        }
 
         if let Some(grouped_candidates) = grouped_candidates {
             candidates.extend(unsafe {
@@ -2781,6 +2953,7 @@ where
             });
         }
 
+        release_prefetched_graph_buffers_if_any(prefetched_buffers);
         return candidates;
     }
 
@@ -2788,50 +2961,50 @@ where
     let quantizer = unsafe { &*(*opaque).cached_quantizer };
     let mut approx_candidates = Vec::with_capacity(capacity);
 
-    graph::for_each_valid_neighbor_tid_for_layer(
-        &neighbors.tids,
-        element.level,
-        scan_m,
-        layer,
-        |neighbor_tid| {
-            if keep_neighbor_tid(neighbor_tid) {
-                let (neighbor, loaded_state) =
-                    unsafe { cached_graph_element(index_relation, opaque, neighbor_tid) };
-                if neighbor.deleted || neighbor.heaptids.is_empty() {
-                    return;
-                }
-
-                if let Some(score) = cached_scan_element_score(unsafe { &*opaque }, neighbor.tid) {
-                    record_score_cache_hit(unsafe { &mut *opaque });
-                    candidates.push(search::BeamCandidate::with_source(
-                        neighbor.tid,
-                        score,
-                        source_tid,
-                    ));
-                    return;
-                }
-
-                #[cfg(any(test, feature = "pg_test"))]
-                let binary_started = Instant::now();
-                let approx_score = -quantizer.score_binary_sign_words_no_qjl_4bit(
-                    binary_query,
-                    neighbor.binary_words.as_slice(),
-                );
-                #[cfg(any(test, feature = "pg_test"))]
-                let binary_elapsed_us = u64::try_from(binary_started.elapsed().as_micros())
-                    .expect("timing should fit in u64");
-                #[cfg(not(any(test, feature = "pg_test")))]
-                let binary_elapsed_us = 0;
-                record_binary_prefilter_score_elapsed(unsafe { &mut *opaque }, binary_elapsed_us);
-                approx_candidates.push(BinaryPrefilterCandidate {
-                    ordinal: approx_candidates.len(),
-                    element: neighbor,
-                    approx_score,
-                    loaded_state,
-                });
+    for neighbor_tid in neighbor_tids.iter().copied() {
+        if keep_neighbor_tid(neighbor_tid) {
+            let (neighbor, loaded_state) = unsafe {
+                cached_graph_element_with_prefetch(
+                    index_relation,
+                    opaque,
+                    prefetched_buffers.as_ref(),
+                    neighbor_tid,
+                )
+            };
+            if neighbor.deleted || neighbor.heaptids.is_empty() {
+                continue;
             }
-        },
-    );
+
+            if let Some(score) = cached_scan_element_score(unsafe { &*opaque }, neighbor.tid) {
+                record_score_cache_hit(unsafe { &mut *opaque });
+                candidates.push(search::BeamCandidate::with_source(
+                    neighbor.tid,
+                    score,
+                    source_tid,
+                ));
+                continue;
+            }
+
+            #[cfg(any(test, feature = "pg_test"))]
+            let binary_started = Instant::now();
+            let approx_score = -quantizer.score_binary_sign_words_no_qjl_4bit(
+                binary_query,
+                neighbor.binary_words.as_slice(),
+            );
+            #[cfg(any(test, feature = "pg_test"))]
+            let binary_elapsed_us = u64::try_from(binary_started.elapsed().as_micros())
+                .expect("timing should fit in u64");
+            #[cfg(not(any(test, feature = "pg_test")))]
+            let binary_elapsed_us = 0;
+            record_binary_prefilter_score_elapsed(unsafe { &mut *opaque }, binary_elapsed_us);
+            approx_candidates.push(BinaryPrefilterCandidate {
+                ordinal: approx_candidates.len(),
+                element: neighbor,
+                approx_score,
+                loaded_state,
+            });
+        }
+    }
 
     let survivor_budget = binary_prefilter_survivor_budget(approx_candidates.len());
     if survivor_budget < approx_candidates.len() {
@@ -2914,6 +3087,7 @@ where
         });
     }
 
+    release_prefetched_graph_buffers_if_any(prefetched_buffers);
     candidates
 }
 
@@ -3248,6 +3422,7 @@ unsafe fn prefetch_next_graph_result_from_frontier(
 
         mark_expanded_source(opaque, candidate.node);
         opaque.explain_counters.record_bootstrap_expansion();
+        super::stats::record_graph_hop();
         #[cfg(any(test, feature = "pg_test"))]
         let materialize_started = Instant::now();
         if unsafe {
@@ -3298,6 +3473,7 @@ unsafe fn prefetch_next_grouped_windowed_graph_result(
 
         mark_expanded_source(opaque, candidate.node);
         opaque.explain_counters.record_bootstrap_expansion();
+        super::stats::record_graph_hop();
         #[cfg(any(test, feature = "pg_test"))]
         let materialize_started = Instant::now();
         unsafe { buffer_grouped_graph_result_candidate(index_relation, opaque, candidate) };
@@ -3417,6 +3593,7 @@ fn enter_linear_fallback_phase(opaque: &mut TqScanOpaque) {
     clear_graph_traversal_state(opaque);
     opaque.fallback_result_state.clear();
     opaque.execution_phase = ScanExecutionPhase::LinearFallback;
+    opaque.stats_used_linear_fallback = true;
 }
 
 fn mark_scan_exhausted(opaque: &mut TqScanOpaque) {
@@ -3424,6 +3601,7 @@ fn mark_scan_exhausted(opaque: &mut TqScanOpaque) {
     opaque.result_state.clear();
     opaque.fallback_result_state.clear();
     opaque.execution_phase = ScanExecutionPhase::Exhausted;
+    finish_scan_stats(opaque);
 }
 
 fn reset_bootstrap_expansion_state(opaque: &mut TqScanOpaque, ef_search: usize) {
@@ -3468,10 +3646,82 @@ fn reset_graph_prefetch_state(opaque: &mut TqScanOpaque) {
     }
 }
 
+#[cfg(feature = "pg18")]
+fn reset_graph_prefetch_blocks(opaque: &mut TqScanOpaque, blocks: Vec<u32>) {
+    if opaque.graph_prefetch_state.is_null() {
+        opaque.graph_prefetch_state = Box::into_raw(Box::new(GraphPrefetchState::new(blocks)));
+    } else {
+        unsafe { &mut *opaque.graph_prefetch_state }.reset(blocks);
+    }
+}
+
 fn reset_linear_prefetch_state(opaque: &mut TqScanOpaque) {
     let first = page::FIRST_DATA_BLOCK_NUMBER;
     let max_block = opaque.scan_block_count.saturating_sub(1).max(first);
     opaque.linear_prefetch_state.reset(first, max_block);
+}
+
+#[cfg(feature = "pg18")]
+fn end_read_stream(stream: &mut *mut pg_sys::ReadStream) {
+    if !(*stream).is_null() {
+        unsafe { pg_sys::read_stream_end(*stream) };
+        *stream = ptr::null_mut();
+    }
+}
+
+#[cfg(feature = "pg18")]
+fn ensure_graph_read_stream(
+    index_relation: pg_sys::Relation,
+    opaque: &mut TqScanOpaque,
+) -> *mut pg_sys::ReadStream {
+    if opaque.graph_prefetch_state.is_null() {
+        reset_graph_prefetch_state(opaque);
+    }
+    if opaque.graph_read_stream.is_null() {
+        opaque.graph_read_stream = unsafe {
+            pg_sys::read_stream_begin_relation(
+                pg_sys::READ_STREAM_DEFAULT as i32,
+                ptr::null_mut(),
+                index_relation,
+                pg_sys::ForkNumber::MAIN_FORKNUM,
+                Some(super::stream::graph_prefetch_cb),
+                opaque.graph_prefetch_state.cast(),
+                std::mem::size_of::<pg_sys::BlockNumber>(),
+            )
+        };
+    }
+    opaque.graph_read_stream
+}
+
+#[cfg(feature = "pg18")]
+fn ensure_linear_read_stream(
+    index_relation: pg_sys::Relation,
+    opaque: &mut TqScanOpaque,
+) -> *mut pg_sys::ReadStream {
+    if opaque.linear_read_stream.is_null() {
+        opaque.linear_read_stream = unsafe {
+            pg_sys::read_stream_begin_relation(
+                pg_sys::READ_STREAM_SEQUENTIAL as i32,
+                ptr::null_mut(),
+                index_relation,
+                pg_sys::ForkNumber::MAIN_FORKNUM,
+                Some(super::stream::linear_prefetch_cb),
+                (&mut opaque.linear_prefetch_state as *mut LinearPrefetchState).cast(),
+                std::mem::size_of::<pg_sys::BlockNumber>(),
+            )
+        };
+    }
+    opaque.linear_read_stream
+}
+
+fn finish_scan_stats(opaque: &mut TqScanOpaque) {
+    if opaque.stats_scan_finalized || !opaque.rescan_called {
+        return;
+    }
+    if !opaque.stats_used_linear_fallback {
+        super::stats::record_bootstrap_only_scan();
+    }
+    opaque.stats_scan_finalized = true;
 }
 
 type VisibleCandidateFrontierState = search::VisibleFrontier<page::ItemPointer>;
@@ -4202,94 +4452,137 @@ unsafe fn select_next_linear_scan_result(
         return None;
     }
 
-    let max_block = opaque.scan_block_count.saturating_sub(1);
-    opaque
-        .linear_prefetch_state
-        .reset(opaque.next_block_number, max_block);
-    while let Some(block_number) = opaque.linear_prefetch_state.next_block() {
-        let buffer = unsafe {
-            pg_sys::ReadBufferExtended(
-                index_relation,
-                pg_sys::ForkNumber::MAIN_FORKNUM,
-                block_number,
-                pg_sys::ReadBufferMode::RBM_NORMAL,
-                ptr::null_mut(),
-            )
-        };
-        unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32) };
-        opaque.explain_counters.record_linear_page_read();
-        let page_ptr = unsafe { pg_sys::BufferGetPage(buffer) }.cast::<u8>();
-        let page_size = unsafe { pg_sys::BufferGetPageSize(buffer) as usize };
-        let line_pointer_count = super::shared::page_line_pointer_count(page_ptr);
-        let offset_start = if block_number == opaque.next_block_number {
-            opaque.next_offset_number.max(1)
-        } else {
-            1
-        };
+    #[cfg(feature = "pg18")]
+    {
+        let max_block = opaque.scan_block_count.saturating_sub(1);
+        opaque
+            .linear_prefetch_state
+            .reset(opaque.next_block_number, max_block);
+        let stream = ensure_linear_read_stream(index_relation, opaque);
+        unsafe { pg_sys::read_stream_reset(stream) };
 
-        for offset in offset_start..=line_pointer_count {
-            let item_id = unsafe { &*super::shared::page_item_id(page_ptr, offset) };
-            if item_id.lp_flags() == 0 {
-                opaque.explain_counters.record_element_skipped();
-                continue;
+        loop {
+            let mut per_buffer_data = ptr::null_mut();
+            let buffer = unsafe { pg_sys::read_stream_next_buffer(stream, &mut per_buffer_data) };
+            if buffer == pg_sys::InvalidBuffer {
+                break;
             }
 
-            let tuple_offset = item_id.lp_off() as usize;
-            let tuple_len = item_id.lp_len() as usize;
-            if tuple_offset + tuple_len > page_size {
-                pgrx::error!(
-                    "ec_hnsw found invalid tuple bounds while scanning block {block_number}"
-                );
-            }
-
-            let tuple_bytes =
-                unsafe { std::slice::from_raw_parts(page_ptr.add(tuple_offset), tuple_len) };
-            if tuple_bytes.first().copied() != Some(page::TQ_ELEMENT_TAG) {
-                opaque.explain_counters.record_element_skipped();
-                continue;
-            }
-
-            let element = page::TqElementTuple::decode(tuple_bytes, code_len).unwrap_or_else(|e| {
-                pgrx::error!("ec_hnsw failed to decode scan element tuple: {e}")
-            });
-            if element.deleted || element.heaptids.is_empty() {
-                opaque.explain_counters.record_element_skipped();
-                continue;
-            }
-
-            opaque.next_block_number = block_number;
-            debug_assert!(
-                offset < u16::MAX,
-                "scan offset should fit in page-local u16 range"
-            );
-            opaque.next_offset_number = offset + 1;
-            let element_tid = page::ItemPointer {
-                block_number,
-                offset_number: offset,
+            let block_number = if per_buffer_data.is_null() {
+                opaque.next_block_number
+            } else {
+                unsafe { *per_buffer_data.cast::<pg_sys::BlockNumber>() }
             };
-            if emitted_contains_element(opaque, element_tid) {
-                opaque.explain_counters.record_element_skipped();
-                continue;
-            }
+            let selected =
+                unsafe { select_linear_scan_result_from_buffer(opaque, code_len, buffer, block_number) };
             unsafe { pg_sys::UnlockReleaseBuffer(buffer) };
-            opaque.explain_counters.record_element_scored();
-            let score = score_scan_element_result(opaque, element.gamma, &element.code);
-            return Some(SelectedScanResult {
-                element_tid,
-                score,
-                approx_score: None,
-                approx_rank_base: None,
-                comparison_score: None,
-                heap_tids: CachedHeapTids::from_iter(element.heaptids.iter().copied()),
-            });
+            if selected.is_some() {
+                return selected;
+            }
         }
+    }
 
-        unsafe { pg_sys::UnlockReleaseBuffer(buffer) };
-        opaque.next_block_number = block_number + 1;
-        opaque.next_offset_number = 1;
+    #[cfg(not(feature = "pg18"))]
+    {
+        let max_block = opaque.scan_block_count.saturating_sub(1);
+        opaque
+            .linear_prefetch_state
+            .reset(opaque.next_block_number, max_block);
+        while let Some(block_number) = opaque.linear_prefetch_state.next_block() {
+            let buffer = unsafe {
+                pg_sys::ReadBufferExtended(
+                    index_relation,
+                    pg_sys::ForkNumber::MAIN_FORKNUM,
+                    block_number,
+                    pg_sys::ReadBufferMode::RBM_NORMAL,
+                    ptr::null_mut(),
+                )
+            };
+            let selected = unsafe {
+                select_linear_scan_result_from_buffer(opaque, code_len, buffer, block_number)
+            };
+            unsafe { pg_sys::UnlockReleaseBuffer(buffer) };
+            if selected.is_some() {
+                return selected;
+            }
+        }
     }
 
     mark_scan_exhausted(opaque);
+    None
+}
+
+unsafe fn select_linear_scan_result_from_buffer(
+    opaque: &mut TqScanOpaque,
+    code_len: usize,
+    buffer: pg_sys::Buffer,
+    block_number: u32,
+) -> Option<SelectedScanResult> {
+    unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32) };
+    opaque.explain_counters.record_linear_page_read();
+    super::stats::record_linear_page();
+    let page_ptr = unsafe { pg_sys::BufferGetPage(buffer) }.cast::<u8>();
+    let page_size = unsafe { pg_sys::BufferGetPageSize(buffer) as usize };
+    let line_pointer_count = super::shared::page_line_pointer_count(page_ptr);
+    let offset_start = if block_number == opaque.next_block_number {
+        opaque.next_offset_number.max(1)
+    } else {
+        1
+    };
+
+    for offset in offset_start..=line_pointer_count {
+        let item_id = unsafe { &*super::shared::page_item_id(page_ptr, offset) };
+        if item_id.lp_flags() == 0 {
+            opaque.explain_counters.record_element_skipped();
+            continue;
+        }
+
+        let tuple_offset = item_id.lp_off() as usize;
+        let tuple_len = item_id.lp_len() as usize;
+        if tuple_offset + tuple_len > page_size {
+            pgrx::error!("ec_hnsw found invalid tuple bounds while scanning block {block_number}");
+        }
+
+        let tuple_bytes = unsafe { std::slice::from_raw_parts(page_ptr.add(tuple_offset), tuple_len) };
+        if tuple_bytes.first().copied() != Some(page::TQ_ELEMENT_TAG) {
+            opaque.explain_counters.record_element_skipped();
+            continue;
+        }
+
+        let element = page::TqElementTuple::decode(tuple_bytes, code_len)
+            .unwrap_or_else(|e| pgrx::error!("ec_hnsw failed to decode scan element tuple: {e}"));
+        if element.deleted || element.heaptids.is_empty() {
+            opaque.explain_counters.record_element_skipped();
+            continue;
+        }
+
+        opaque.next_block_number = block_number;
+        debug_assert!(offset < u16::MAX, "scan offset should fit in page-local u16 range");
+        opaque.next_offset_number = offset + 1;
+        let element_tid = page::ItemPointer {
+            block_number,
+            offset_number: offset,
+        };
+        if emitted_contains_element(opaque, element_tid) {
+            opaque.explain_counters.record_element_skipped();
+            continue;
+        }
+        unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_UNLOCK as i32) };
+        opaque.explain_counters.record_element_scored();
+        let score = score_scan_element_result(opaque, element.gamma, &element.code);
+        return Some(SelectedScanResult {
+            element_tid,
+            score,
+            approx_score: None,
+            approx_rank_base: None,
+            comparison_score: None,
+            heap_tids: CachedHeapTids::from_iter(element.heaptids.iter().copied()),
+        });
+    }
+
+    unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_UNLOCK as i32) };
+    opaque.next_block_number = block_number + 1;
+    opaque.next_offset_number = 1;
     None
 }
 
@@ -4328,6 +4621,7 @@ unsafe fn score_scan_element_result(opaque: &TqScanOpaque, gamma: f32, code_byte
         pgrx::error!("ec_hnsw scan scoring requires a cached quantizer");
     }
 
+    super::stats::record_distance_calc();
     let quantizer = unsafe { &*opaque.cached_quantizer };
     match opaque.turboquant_exact_score_mode {
         TurboQuantExactScoreMode::Exact => {}
@@ -4792,9 +5086,15 @@ pub(super) struct TqScanOpaque {
     pub(super) last_emitted_approx_rank_valid: bool,
     pub(super) last_emitted_comparison_score: f32,
     pub(super) last_emitted_comparison_score_valid: bool,
+    #[cfg(feature = "pg18")]
+    graph_read_stream: *mut pg_sys::ReadStream,
+    #[cfg(feature = "pg18")]
+    linear_read_stream: *mut pg_sys::ReadStream,
     pub(super) graph_prefetch_state: *mut GraphPrefetchState,
     pub(super) linear_prefetch_state: LinearPrefetchState,
     pub(super) explain_counters: TqExplainCounters,
+    stats_used_linear_fallback: bool,
+    stats_scan_finalized: bool,
     #[cfg(any(test, feature = "pg_test"))]
     pub(super) debug_profile: ScanDebugProfile,
 }
@@ -4857,12 +5157,18 @@ impl Default for TqScanOpaque {
             last_emitted_approx_rank_valid: false,
             last_emitted_comparison_score: 0.0,
             last_emitted_comparison_score_valid: false,
+            #[cfg(feature = "pg18")]
+            graph_read_stream: ptr::null_mut(),
+            #[cfg(feature = "pg18")]
+            linear_read_stream: ptr::null_mut(),
             graph_prefetch_state: ptr::null_mut(),
             linear_prefetch_state: LinearPrefetchState::new(
                 page::FIRST_DATA_BLOCK_NUMBER,
                 page::FIRST_DATA_BLOCK_NUMBER,
             ),
             explain_counters: TqExplainCounters::default(),
+            stats_used_linear_fallback: false,
+            stats_scan_finalized: false,
             #[cfg(any(test, feature = "pg_test"))]
             debug_profile: ScanDebugProfile::default(),
         }

--- a/src/am/ec_hnsw/scan.rs
+++ b/src/am/ec_hnsw/scan.rs
@@ -2835,8 +2835,9 @@ fn release_prefetched_graph_buffers_if_any(
 unsafe fn cached_graph_element_with_prefetch(
     index_relation: pg_sys::Relation,
     opaque: *mut TqScanOpaque,
-    #[cfg_attr(not(feature = "pg18"), allow(unused_variables))]
-    prefetched_buffers: Option<&HashMap<u32, pg_sys::Buffer>>,
+    #[cfg_attr(not(feature = "pg18"), allow(unused_variables))] prefetched_buffers: Option<
+        &HashMap<u32, pg_sys::Buffer>,
+    >,
     element_tid: page::ItemPointer,
 ) -> (Arc<CachedGraphElement>, LoadedElementState) {
     #[cfg(feature = "pg18")]
@@ -2928,7 +2929,12 @@ where
                             });
                         } else {
                             let score = unsafe {
-                                score_grouped_candidate_context(index_relation, opaque, grouped, layer)
+                                score_grouped_candidate_context(
+                                    index_relation,
+                                    opaque,
+                                    grouped,
+                                    layer,
+                                )
                             };
                             candidates.push(search::BeamCandidate::with_source(
                                 neighbor.tid,
@@ -4473,8 +4479,9 @@ unsafe fn select_next_linear_scan_result(
             } else {
                 unsafe { *per_buffer_data.cast::<pg_sys::BlockNumber>() }
             };
-            let selected =
-                unsafe { select_linear_scan_result_from_buffer(opaque, code_len, buffer, block_number) };
+            let selected = unsafe {
+                select_linear_scan_result_from_buffer(opaque, code_len, buffer, block_number)
+            };
             unsafe { pg_sys::UnlockReleaseBuffer(buffer) };
             if selected.is_some() {
                 return selected;
@@ -4543,7 +4550,8 @@ unsafe fn select_linear_scan_result_from_buffer(
             pgrx::error!("ec_hnsw found invalid tuple bounds while scanning block {block_number}");
         }
 
-        let tuple_bytes = unsafe { std::slice::from_raw_parts(page_ptr.add(tuple_offset), tuple_len) };
+        let tuple_bytes =
+            unsafe { std::slice::from_raw_parts(page_ptr.add(tuple_offset), tuple_len) };
         if tuple_bytes.first().copied() != Some(page::TQ_ELEMENT_TAG) {
             opaque.explain_counters.record_element_skipped();
             continue;
@@ -4557,7 +4565,10 @@ unsafe fn select_linear_scan_result_from_buffer(
         }
 
         opaque.next_block_number = block_number;
-        debug_assert!(offset < u16::MAX, "scan offset should fit in page-local u16 range");
+        debug_assert!(
+            offset < u16::MAX,
+            "scan offset should fit in page-local u16 range"
+        );
         opaque.next_offset_number = offset + 1;
         let element_tid = page::ItemPointer {
             block_number,

--- a/src/am/ec_hnsw/scan.rs
+++ b/src/am/ec_hnsw/scan.rs
@@ -2798,7 +2798,7 @@ unsafe fn prefetch_graph_buffers(
     loop {
         let mut per_buffer_data = ptr::null_mut();
         let buffer = unsafe { pg_sys::read_stream_next_buffer(stream, &mut per_buffer_data) };
-        if buffer == pg_sys::InvalidBuffer {
+        if buffer == pg_sys::InvalidBuffer as pg_sys::Buffer {
             break;
         }
         let block_number = if per_buffer_data.is_null() {
@@ -2879,9 +2879,8 @@ where
     let neighbor_tids =
         graph::valid_neighbor_tids_for_layer(&neighbors.tids, element.level, scan_m, layer);
     #[cfg(feature = "pg18")]
-    let prefetched_buffers = Some(unsafe {
-        prefetch_graph_buffers(index_relation, unsafe { &mut *opaque }, &neighbor_tids)
-    });
+    let prefetched_buffers =
+        Some(unsafe { prefetch_graph_buffers(index_relation, &mut *opaque, &neighbor_tids) });
     #[cfg(not(feature = "pg18"))]
     let prefetched_buffers: Option<HashMap<u32, pg_sys::Buffer>> = None;
 
@@ -4470,7 +4469,7 @@ unsafe fn select_next_linear_scan_result(
         loop {
             let mut per_buffer_data = ptr::null_mut();
             let buffer = unsafe { pg_sys::read_stream_next_buffer(stream, &mut per_buffer_data) };
-            if buffer == pg_sys::InvalidBuffer {
+            if buffer == pg_sys::InvalidBuffer as pg_sys::Buffer {
                 break;
             }
 

--- a/src/am/ec_hnsw/scan_debug.rs
+++ b/src/am/ec_hnsw/scan_debug.rs
@@ -493,6 +493,18 @@ unsafe fn debug_begin_heap_backed_scan(index_oid: pg_sys::Oid) -> DebugHeapBacke
     let pushed_registered_snapshot = true;
     let snapshot = registered_snapshot;
 
+    #[cfg(feature = "pg18")]
+    let scan = unsafe {
+        pg_sys::index_beginscan(
+            heap_relation,
+            index_relation,
+            snapshot,
+            std::ptr::null_mut(),
+            0,
+            1,
+        )
+    };
+    #[cfg(not(feature = "pg18"))]
     let scan = unsafe { pg_sys::index_beginscan(heap_relation, index_relation, snapshot, 0, 1) };
     if scan.is_null() {
         unsafe {
@@ -1025,6 +1037,18 @@ pub(crate) unsafe fn debug_profile_ordered_scan_with_heap_fetch(
         pgrx::error!("debug heap-fetch profile failed to allocate tuple slot");
     }
 
+    #[cfg(feature = "pg18")]
+    let scan = unsafe {
+        pg_sys::index_beginscan(
+            heap_relation,
+            index_relation,
+            snapshot,
+            std::ptr::null_mut(),
+            0,
+            1,
+        )
+    };
+    #[cfg(not(feature = "pg18"))]
     let scan = unsafe { pg_sys::index_beginscan(heap_relation, index_relation, snapshot, 0, 1) };
     if scan.is_null() {
         unsafe {

--- a/src/am/ec_hnsw/shared.rs
+++ b/src/am/ec_hnsw/shared.rs
@@ -170,7 +170,9 @@ pub(super) unsafe fn count_element_tuples(index_relation: pg_sys::Relation) -> u
     {
         let mut linear_state = stream::LinearPrefetchState::new(
             page::FIRST_DATA_BLOCK_NUMBER,
-            block_count.saturating_sub(1).max(page::FIRST_DATA_BLOCK_NUMBER),
+            block_count
+                .saturating_sub(1)
+                .max(page::FIRST_DATA_BLOCK_NUMBER),
         );
         let stream = unsafe {
             pg_sys::read_stream_begin_relation(
@@ -247,13 +249,16 @@ unsafe fn count_live_elements_on_buffer(
             );
         }
 
-        let tuple_bytes = unsafe { std::slice::from_raw_parts(page_ptr.add(tuple_offset), tuple_len) };
+        let tuple_bytes =
+            unsafe { std::slice::from_raw_parts(page_ptr.add(tuple_offset), tuple_len) };
         match storage {
             graph::GraphStorageDescriptor::TurboQuant { code_len } => {
                 if tuple_bytes.first().copied() == Some(page::TQ_ELEMENT_TAG) {
                     let element = page::TqElementTuple::decode(tuple_bytes, code_len)
                         .unwrap_or_else(|e| {
-                            pgrx::error!("ec_hnsw failed to decode element tuple while counting: {e}")
+                            pgrx::error!(
+                                "ec_hnsw failed to decode element tuple while counting: {e}"
+                            )
                         });
                     if !element.deleted && !element.heaptids.is_empty() {
                         count += 1;
@@ -262,10 +267,15 @@ unsafe fn count_live_elements_on_buffer(
             }
             graph::GraphStorageDescriptor::TurboQuantHotCold(layout) => {
                 if tuple_bytes.first().copied() == Some(page::TQ_TURBO_HOT_TAG) {
-                    let element = page::TqTurboHotTuple::decode(tuple_bytes, layout.binary_word_count)
-                        .unwrap_or_else(|e| {
-                            pgrx::error!("ec_hnsw failed to decode TurboQuant V3 tuple while counting: {e}")
-                        });
+                    let element = page::TqTurboHotTuple::decode(
+                        tuple_bytes,
+                        layout.binary_word_count,
+                    )
+                    .unwrap_or_else(|e| {
+                        pgrx::error!(
+                            "ec_hnsw failed to decode TurboQuant V3 tuple while counting: {e}"
+                        )
+                    });
                     if !element.deleted && !element.heaptids.is_empty() {
                         count += 1;
                     }
@@ -279,7 +289,9 @@ unsafe fn count_live_elements_on_buffer(
                         layout.search_code_len,
                     )
                     .unwrap_or_else(|e| {
-                        pgrx::error!("ec_hnsw failed to decode grouped hot tuple while counting: {e}")
+                        pgrx::error!(
+                            "ec_hnsw failed to decode grouped hot tuple while counting: {e}"
+                        )
                     });
                     if !element.deleted && !element.heaptids.is_empty() {
                         count += 1;
@@ -786,9 +798,8 @@ pub(crate) unsafe fn planner_integration_snapshot(
         next_pg18_blocker: if diagnostics.pg18_pgstat_kind_ready {
             "no merged PG18 blocker remains on main"
         } else {
-            super::stats::pgstat_kind_blocker().unwrap_or(
-                "custom pgstat kind registration remains gated outside this build",
-            )
+            super::stats::pgstat_kind_blocker()
+                .unwrap_or("custom pgstat kind registration remains gated outside this build")
         },
     }
 }

--- a/src/am/ec_hnsw/shared.rs
+++ b/src/am/ec_hnsw/shared.rs
@@ -189,7 +189,7 @@ pub(super) unsafe fn count_element_tuples(index_relation: pg_sys::Relation) -> u
         loop {
             let mut per_buffer_data = ptr::null_mut();
             let buffer = unsafe { pg_sys::read_stream_next_buffer(stream, &mut per_buffer_data) };
-            if buffer == pg_sys::InvalidBuffer {
+            if buffer == pg_sys::InvalidBuffer as pg_sys::Buffer {
                 break;
             }
             let block_number = if per_buffer_data.is_null() {
@@ -267,15 +267,13 @@ unsafe fn count_live_elements_on_buffer(
             }
             graph::GraphStorageDescriptor::TurboQuantHotCold(layout) => {
                 if tuple_bytes.first().copied() == Some(page::TQ_TURBO_HOT_TAG) {
-                    let element = page::TqTurboHotTuple::decode(
-                        tuple_bytes,
-                        layout.binary_word_count,
-                    )
-                    .unwrap_or_else(|e| {
-                        pgrx::error!(
+                    let element =
+                        page::TqTurboHotTuple::decode(tuple_bytes, layout.binary_word_count)
+                            .unwrap_or_else(|e| {
+                                pgrx::error!(
                             "ec_hnsw failed to decode TurboQuant V3 tuple while counting: {e}"
                         )
-                    });
+                            });
                     if !element.deleted && !element.heaptids.is_empty() {
                         count += 1;
                     }

--- a/src/am/ec_hnsw/shared.rs
+++ b/src/am/ec_hnsw/shared.rs
@@ -2,6 +2,8 @@ use std::ptr;
 
 use pgrx::{itemptr::item_pointer_get_both, pg_sys, PgBox};
 
+#[cfg(feature = "pg18")]
+use super::stream;
 use super::{graph, options, page, EC_HNSW_PLANNER_SCAN_ENABLED, P_NEW};
 use crate::storage::wal;
 
@@ -159,88 +161,132 @@ pub(super) unsafe fn count_element_tuples(index_relation: pg_sys::Relation) -> u
     let block_count = unsafe {
         pg_sys::RelationGetNumberOfBlocksInFork(index_relation, pg_sys::ForkNumber::MAIN_FORKNUM)
     };
+    if block_count <= page::FIRST_DATA_BLOCK_NUMBER {
+        return 0;
+    }
     let mut count = 0_usize;
 
-    for block_number in page::FIRST_DATA_BLOCK_NUMBER..block_count {
-        let buffer = unsafe {
-            pg_sys::ReadBufferExtended(
+    #[cfg(feature = "pg18")]
+    {
+        let mut linear_state = stream::LinearPrefetchState::new(
+            page::FIRST_DATA_BLOCK_NUMBER,
+            block_count.saturating_sub(1).max(page::FIRST_DATA_BLOCK_NUMBER),
+        );
+        let stream = unsafe {
+            pg_sys::read_stream_begin_relation(
+                pg_sys::READ_STREAM_SEQUENTIAL as i32,
+                ptr::null_mut(),
                 index_relation,
                 pg_sys::ForkNumber::MAIN_FORKNUM,
-                block_number,
-                pg_sys::ReadBufferMode::RBM_NORMAL,
-                ptr::null_mut(),
+                Some(stream::linear_prefetch_cb),
+                (&mut linear_state as *mut stream::LinearPrefetchState).cast(),
+                std::mem::size_of::<pg_sys::BlockNumber>(),
             )
         };
-        unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32) };
-        let page_ptr = unsafe { pg_sys::BufferGetPage(buffer) }.cast::<u8>();
-        let page_size = unsafe { pg_sys::BufferGetPageSize(buffer) as usize };
-        let line_pointer_count = page_line_pointer_count(page_ptr);
-
-        for offset in 1..=line_pointer_count {
-            let item_id = unsafe { &*page_item_id(page_ptr, offset) };
-            if item_id.lp_flags() == 0 {
-                continue;
+        unsafe { pg_sys::read_stream_reset(stream) };
+        loop {
+            let mut per_buffer_data = ptr::null_mut();
+            let buffer = unsafe { pg_sys::read_stream_next_buffer(stream, &mut per_buffer_data) };
+            if buffer == pg_sys::InvalidBuffer {
+                break;
             }
+            let block_number = if per_buffer_data.is_null() {
+                page::FIRST_DATA_BLOCK_NUMBER
+            } else {
+                unsafe { *per_buffer_data.cast::<pg_sys::BlockNumber>() }
+            };
+            unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32) };
+            count += unsafe { count_live_elements_on_buffer(storage, buffer, block_number) };
+            unsafe { pg_sys::UnlockReleaseBuffer(buffer) };
+        }
+        unsafe { pg_sys::read_stream_end(stream) };
+    }
 
-            let tuple_offset = item_id.lp_off() as usize;
-            let tuple_len = item_id.lp_len() as usize;
-            if tuple_offset + tuple_len > page_size {
-                pgrx::error!(
-                    "ec_hnsw found invalid tuple bounds while counting vacuum tuples on block {block_number}"
-                );
-            }
+    #[cfg(not(feature = "pg18"))]
+    {
+        for block_number in page::FIRST_DATA_BLOCK_NUMBER..block_count {
+            let buffer = unsafe {
+                pg_sys::ReadBufferExtended(
+                    index_relation,
+                    pg_sys::ForkNumber::MAIN_FORKNUM,
+                    block_number,
+                    pg_sys::ReadBufferMode::RBM_NORMAL,
+                    ptr::null_mut(),
+                )
+            };
+            unsafe { pg_sys::LockBuffer(buffer, pg_sys::BUFFER_LOCK_SHARE as i32) };
+            count += unsafe { count_live_elements_on_buffer(storage, buffer, block_number) };
+            unsafe { pg_sys::UnlockReleaseBuffer(buffer) };
+        }
+    }
 
-            let tuple_bytes =
-                unsafe { std::slice::from_raw_parts(page_ptr.add(tuple_offset), tuple_len) };
-            match storage {
-                graph::GraphStorageDescriptor::TurboQuant { code_len } => {
-                    if tuple_bytes.first().copied() == Some(page::TQ_ELEMENT_TAG) {
-                        let element = page::TqElementTuple::decode(tuple_bytes, code_len)
-                            .unwrap_or_else(|e| {
-                                pgrx::error!(
-                                    "ec_hnsw failed to decode element tuple while counting: {e}"
-                                )
-                            });
-                        if !element.deleted && !element.heaptids.is_empty() {
-                            count += 1;
-                        }
-                    }
-                }
-                graph::GraphStorageDescriptor::TurboQuantHotCold(layout) => {
-                    if tuple_bytes.first().copied() == Some(page::TQ_TURBO_HOT_TAG) {
-                        let element =
-                            page::TqTurboHotTuple::decode(tuple_bytes, layout.binary_word_count)
-                                .unwrap_or_else(|e| {
-                                    pgrx::error!(
-                                "ec_hnsw failed to decode TurboQuant V3 tuple while counting: {e}"
-                            )
-                                });
-                        if !element.deleted && !element.heaptids.is_empty() {
-                            count += 1;
-                        }
-                    }
-                }
-                graph::GraphStorageDescriptor::PqFastScan(layout) => {
-                    if tuple_bytes.first().copied() == Some(page::TQ_GROUPED_HOT_TAG) {
-                        let element = page::TqGroupedHotTuple::decode(
-                            tuple_bytes,
-                            layout.binary_word_count,
-                            layout.search_code_len,
-                        )
+    count
+}
+
+unsafe fn count_live_elements_on_buffer(
+    storage: graph::GraphStorageDescriptor,
+    buffer: pg_sys::Buffer,
+    block_number: u32,
+) -> usize {
+    let page_ptr = unsafe { pg_sys::BufferGetPage(buffer) }.cast::<u8>();
+    let page_size = unsafe { pg_sys::BufferGetPageSize(buffer) as usize };
+    let line_pointer_count = page_line_pointer_count(page_ptr);
+    let mut count = 0_usize;
+
+    for offset in 1..=line_pointer_count {
+        let item_id = unsafe { &*page_item_id(page_ptr, offset) };
+        if item_id.lp_flags() == 0 {
+            continue;
+        }
+
+        let tuple_offset = item_id.lp_off() as usize;
+        let tuple_len = item_id.lp_len() as usize;
+        if tuple_offset + tuple_len > page_size {
+            pgrx::error!(
+                "ec_hnsw found invalid tuple bounds while counting vacuum tuples on block {block_number}"
+            );
+        }
+
+        let tuple_bytes = unsafe { std::slice::from_raw_parts(page_ptr.add(tuple_offset), tuple_len) };
+        match storage {
+            graph::GraphStorageDescriptor::TurboQuant { code_len } => {
+                if tuple_bytes.first().copied() == Some(page::TQ_ELEMENT_TAG) {
+                    let element = page::TqElementTuple::decode(tuple_bytes, code_len)
                         .unwrap_or_else(|e| {
-                            pgrx::error!(
-                                "ec_hnsw failed to decode grouped hot tuple while counting: {e}"
-                            )
+                            pgrx::error!("ec_hnsw failed to decode element tuple while counting: {e}")
                         });
-                        if !element.deleted && !element.heaptids.is_empty() {
-                            count += 1;
-                        }
+                    if !element.deleted && !element.heaptids.is_empty() {
+                        count += 1;
+                    }
+                }
+            }
+            graph::GraphStorageDescriptor::TurboQuantHotCold(layout) => {
+                if tuple_bytes.first().copied() == Some(page::TQ_TURBO_HOT_TAG) {
+                    let element = page::TqTurboHotTuple::decode(tuple_bytes, layout.binary_word_count)
+                        .unwrap_or_else(|e| {
+                            pgrx::error!("ec_hnsw failed to decode TurboQuant V3 tuple while counting: {e}")
+                        });
+                    if !element.deleted && !element.heaptids.is_empty() {
+                        count += 1;
+                    }
+                }
+            }
+            graph::GraphStorageDescriptor::PqFastScan(layout) => {
+                if tuple_bytes.first().copied() == Some(page::TQ_GROUPED_HOT_TAG) {
+                    let element = page::TqGroupedHotTuple::decode(
+                        tuple_bytes,
+                        layout.binary_word_count,
+                        layout.search_code_len,
+                    )
+                    .unwrap_or_else(|e| {
+                        pgrx::error!("ec_hnsw failed to decode grouped hot tuple while counting: {e}")
+                    });
+                    if !element.deleted && !element.heaptids.is_empty() {
+                        count += 1;
                     }
                 }
             }
         }
-
-        unsafe { pg_sys::UnlockReleaseBuffer(buffer) };
     }
 
     count
@@ -627,7 +673,7 @@ pub(crate) unsafe fn index_cost_snapshot(index_relation: pg_sys::Relation) -> In
     };
     let index_pages = f64::from(block_count);
     let reltuples = unsafe { (*(*index_relation).rd_rel).reltuples } as f64;
-    let tree_height = super::cost::metadata_fallback_tree_height(metadata.max_level);
+    let tree_height = super::cost::resolved_tree_height_input(metadata.max_level);
     let constants = unsafe { super::cost::current_planner_cost_constants() };
     // Block 0 is always the metadata page; an empty index has block_count == 1.
     // FR-020's "Empty index (0 data pages)" gate must trip on
@@ -737,8 +783,13 @@ pub(crate) unsafe fn planner_integration_snapshot(
         planner_gate_reason: explain.planner_gate_reason,
         next_runtime_blocker:
             "no merged runtime blocker remains on main; post-vacuum benchmark/reporting is next",
-        next_pg18_blocker:
-            "pgrx pg18 feature support and callback bindings are not yet implemented",
+        next_pg18_blocker: if diagnostics.pg18_pgstat_kind_ready {
+            "no merged PG18 blocker remains on main"
+        } else {
+            super::stats::pgstat_kind_blocker().unwrap_or(
+                "custom pgstat kind registration remains gated outside this build",
+            )
+        },
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pgrx::pg_module_magic!(name, version);
 
 #[allow(dead_code)]
 mod am;
+#[cfg(feature = "pg18")]
+mod pg18_pgstat_shim;
 mod quant;
 #[cfg(all(test, target_arch = "x86_64", target_os = "linux"))]
 mod standalone_pg_backend_stubs;
@@ -768,7 +770,7 @@ fn tqvector_stats() -> TableIterator<
         name!(quantizer_cache_rate, f64),
     ),
 > {
-    let summary = am::stats::current_backend_stats_counters().summary();
+    let summary = am::stats::current_stats_counters().summary();
     TableIterator::once((
         i64::try_from(summary.total_distance_calcs)
             .expect("distance calc counter should fit in i64"),
@@ -2776,7 +2778,7 @@ mod tests {
             .expect("snapshot query should succeed")
             .expect("pg18 blocker should be non-null"),
             if cfg!(feature = "pg18") {
-                "custom pgstat kind registration still needs shared_preload_libraries setup plus pgrx bindings or a shim for pgstat_internal.h"
+                "custom pgstat kind registration requires loading tqvector via shared_preload_libraries on PG18 and restarting PostgreSQL"
             } else {
                 "custom pgstat kind registration remains gated outside this build"
             }
@@ -2803,8 +2805,10 @@ mod tests {
     #[cfg(feature = "pg18")]
     #[pg_test]
     fn test_pg18_tqvector_stats_reports_backend_local_counters() {
-        Spi::run("CREATE TABLE pg18_tqvector_stats_fixture (id bigint primary key, embedding ecvector)")
-            .expect("table creation should succeed");
+        Spi::run(
+            "CREATE TABLE pg18_tqvector_stats_fixture (id bigint primary key, embedding ecvector)",
+        )
+        .expect("table creation should succeed");
         Spi::run(
             "INSERT INTO pg18_tqvector_stats_fixture VALUES
              (1, encode_to_ecvector(ARRAY[1.0, 0.0, 0.5, -1.0], 4, 42)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,26 @@ use pgrx::ffi::CString;
 use pgrx::prelude::*;
 use pgrx::{pg_sys, Internal};
 
-pgrx::pg_module_magic!(name, version);
+const MODULE_VERSION_CSTR: &core::ffi::CStr = {
+    const RAW: &str = env!("CARGO_PKG_VERSION");
+    const BUFFER: [u8; RAW.len() + 1] = {
+        let mut buffer = [0u8; RAW.len() + 1];
+        let mut i = 0;
+        while i < RAW.len() {
+            buffer[i] = RAW.as_bytes()[i];
+            i += 1;
+        }
+        buffer
+    };
+    if let Ok(value) = core::ffi::CStr::from_bytes_with_nul(&BUFFER) {
+        value
+    } else {
+        panic!("CARGO_PKG_VERSION contains an interior NUL byte")
+    }
+};
+
+// Use explicit fields so PG18 module metadata reports the tqvector name/version correctly.
+pgrx::pg_module_magic!(name = c"tqvector", version = MODULE_VERSION_CSTR);
 
 #[allow(dead_code)]
 mod am;
@@ -2849,7 +2868,7 @@ mod tests {
     #[pg_test]
     fn test_pg18_module_identity_reports_loaded_module_version() {
         let version = Spi::get_one::<String>(
-            "SELECT version FROM pg_get_loaded_modules() WHERE name = 'tqvector'",
+            "SELECT version FROM pg_get_loaded_modules() WHERE module_name = 'tqvector'",
         )
         .expect("module query should succeed")
         .expect("module version should be visible");
@@ -2877,28 +2896,32 @@ mod tests {
         let plan = Spi::connect(|client| {
             let rows = client
                 .select(
-                    "EXPLAIN (tqvector, ANALYZE, COSTS OFF)
+                    "EXPLAIN (FORMAT JSON, tqvector, ANALYZE, COSTS OFF)
                      SELECT id FROM pg18_explain_fixture
                      ORDER BY embedding <#> ARRAY[1.0, 0.0, 0.5, -1.0]::real[]
                      LIMIT 1",
                     None,
                     &[],
                 )
-                .expect("EXPLAIN should succeed")
-                .first();
+                .expect("EXPLAIN should succeed");
             let mut lines = Vec::new();
             for row in rows {
                 lines.push(
-                    row.get::<String>(1)
+                    row.get::<pgrx::datum::JsonString>(1)
                         .expect("plan row should decode")
-                        .expect("plan row should not be NULL"),
+                        .expect("plan row should not be NULL")
+                        .0,
                 );
             }
             lines.join("\n")
         });
 
-        assert!(plan.contains("TQVector Stats"));
-        assert!(plan.contains("Elements Scored"));
+        if !plan.contains("TQVector Stats") {
+            panic!("missing TQVector Stats in plan: {plan:?}");
+        }
+        if !plan.contains("Elements Scored") {
+            panic!("missing Elements Scored in plan: {plan:?}");
+        }
 
         Spi::run("RESET enable_seqscan").expect("reset should succeed");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use pgrx::ffi::CString;
 use pgrx::prelude::*;
 use pgrx::{pg_sys, Internal};
 
-pgrx::pg_module_magic!();
+pgrx::pg_module_magic!(name, version);
 
 #[allow(dead_code)]
 mod am;
@@ -15,8 +15,13 @@ pub(crate) mod storage;
 use quant::prod::{payload_len, ProdQuantizer};
 
 #[pg_guard]
-pub extern "C-unwind" fn _PG_init() {
+pub unsafe extern "C-unwind" fn _PG_init() {
     am::register_gucs();
+    #[cfg(feature = "pg18")]
+    unsafe {
+        am::explain::register_pg18_explain_hooks();
+        am::stats::register_pg18_stats();
+    }
 }
 
 /// Public API surface for benchmarks and integration tests.
@@ -743,6 +748,41 @@ fn ec_hnsw_planner_integration_snapshot(
         snapshot.planner_gate_reason.to_owned(),
         snapshot.next_runtime_blocker.to_owned(),
         snapshot.next_pg18_blocker.to_owned(),
+    ))
+}
+
+#[cfg(feature = "pg18")]
+#[pg_extern(stable)]
+#[allow(clippy::type_complexity)]
+fn tqvector_stats() -> TableIterator<
+    'static,
+    (
+        name!(total_distance_calcs, i64),
+        name!(total_graph_hops, i64),
+        name!(total_linear_pages, i64),
+        name!(total_scans_started, i64),
+        name!(total_scans_bootstrap_only, i64),
+        name!(quantizer_cache_hits, i64),
+        name!(quantizer_cache_misses, i64),
+        name!(bootstrap_hit_rate, f64),
+        name!(quantizer_cache_rate, f64),
+    ),
+> {
+    let summary = am::stats::current_backend_stats_counters().summary();
+    TableIterator::once((
+        i64::try_from(summary.total_distance_calcs)
+            .expect("distance calc counter should fit in i64"),
+        i64::try_from(summary.total_graph_hops).expect("graph hop counter should fit in i64"),
+        i64::try_from(summary.total_linear_pages).expect("linear page counter should fit in i64"),
+        i64::try_from(summary.total_scans_started).expect("scan counter should fit in i64"),
+        i64::try_from(summary.total_scans_bootstrap_only)
+            .expect("bootstrap-only counter should fit in i64"),
+        i64::try_from(summary.quantizer_cache_hits)
+            .expect("quantizer cache-hit counter should fit in i64"),
+        i64::try_from(summary.quantizer_cache_misses)
+            .expect("quantizer cache-miss counter should fit in i64"),
+        summary.bootstrap_hit_rate,
+        summary.quantizer_cache_rate,
     ))
 }
 
@@ -2510,14 +2550,19 @@ mod tests {
             )
             .expect("snapshot query should succeed")
             .expect("tree height source should be non-null"),
-            "metadata_fallback"
+            if cfg!(feature = "pg18") {
+                "amgettreeheight_callback"
+            } else {
+                "metadata_fallback"
+            }
         );
-        assert!(
-            !Spi::get_one::<bool>(
+        assert_eq!(
+            Spi::get_one::<bool>(
                 "SELECT pg18_tree_height_callback_ready FROM ec_hnsw_index_cost_snapshot('ec_hnsw_cost_snapshot_idx'::regclass)",
             )
             .expect("snapshot query should succeed")
-            .expect("pg18 tree-height callback flag should be non-null")
+            .expect("pg18 tree-height callback flag should be non-null"),
+            cfg!(feature = "pg18")
         );
         assert!(
             Spi::get_one::<f64>(
@@ -2669,12 +2714,13 @@ mod tests {
             .expect("snapshot query should succeed")
             .expect("planner cost callback live flag should be non-null")
         );
-        assert!(
-            !Spi::get_one::<bool>(
+        assert_eq!(
+            Spi::get_one::<bool>(
                 "SELECT pg18_callback_surface_ready FROM ec_hnsw_planner_integration_snapshot('ec_hnsw_planner_integration_snapshot_idx'::regclass)",
             )
             .expect("snapshot query should succeed")
-            .expect("pg18 callback readiness should be non-null")
+            .expect("pg18 callback readiness should be non-null"),
+            cfg!(feature = "pg18")
         );
         assert!(
             !Spi::get_one::<bool>(
@@ -2683,12 +2729,13 @@ mod tests {
             .expect("snapshot query should succeed")
             .expect("pg18 diagnostics readiness should be non-null")
         );
-        assert!(
-            !Spi::get_one::<bool>(
+        assert_eq!(
+            Spi::get_one::<bool>(
                 "SELECT pg18_read_stream_surface_ready FROM ec_hnsw_planner_integration_snapshot('ec_hnsw_planner_integration_snapshot_idx'::regclass)",
             )
             .expect("snapshot query should succeed")
-            .expect("pg18 read stream readiness should be non-null")
+            .expect("pg18 read stream readiness should be non-null"),
+            cfg!(feature = "pg18")
         );
         assert_eq!(
             Spi::get_one::<i32>(
@@ -2728,7 +2775,11 @@ mod tests {
             )
             .expect("snapshot query should succeed")
             .expect("pg18 blocker should be non-null"),
-            "pgrx pg18 feature support and callback bindings are not yet implemented"
+            if cfg!(feature = "pg18") {
+                "custom pgstat kind registration still needs shared_preload_libraries setup plus pgrx bindings or a shim for pgstat_internal.h"
+            } else {
+                "custom pgstat kind registration remains gated outside this build"
+            }
         );
     }
 
@@ -2747,6 +2798,105 @@ mod tests {
         let _ = Spi::get_one::<bool>(
             "SELECT planner_scan_enabled FROM ec_hnsw_planner_integration_snapshot('ec_hnsw_planner_integration_snapshot_wrong_am_idx'::regclass)",
         );
+    }
+
+    #[cfg(feature = "pg18")]
+    #[pg_test]
+    fn test_pg18_tqvector_stats_reports_backend_local_counters() {
+        Spi::run("CREATE TABLE pg18_tqvector_stats_fixture (id bigint primary key, embedding ecvector)")
+            .expect("table creation should succeed");
+        Spi::run(
+            "INSERT INTO pg18_tqvector_stats_fixture VALUES
+             (1, encode_to_ecvector(ARRAY[1.0, 0.0, 0.5, -1.0], 4, 42)),
+             (2, encode_to_ecvector(ARRAY[0.0, 1.0, 0.25, -0.5], 4, 42)),
+             (3, encode_to_ecvector(ARRAY[0.5, 0.5, -0.5, 1.0], 4, 42))",
+        )
+        .expect("insert should succeed");
+        Spi::run(
+            "CREATE INDEX pg18_tqvector_stats_fixture_idx ON pg18_tqvector_stats_fixture USING ec_hnsw (embedding ecvector_ip_ops)",
+        )
+        .expect("index creation should succeed");
+        Spi::run("SET enable_seqscan = off").expect("set should succeed");
+
+        let _ = Spi::get_one::<i64>(
+            "SELECT id FROM pg18_tqvector_stats_fixture
+             ORDER BY embedding <#> ARRAY[1.0, 0.0, 0.5, -1.0]::real[]
+             LIMIT 1",
+        )
+        .expect("query should succeed");
+
+        assert!(
+            Spi::get_one::<i64>("SELECT total_scans_started FROM tqvector_stats()")
+                .expect("stats query should succeed")
+                .expect("scan counter should be non-null")
+                >= 1
+        );
+        assert!(
+            Spi::get_one::<i64>("SELECT total_distance_calcs FROM tqvector_stats()")
+                .expect("stats query should succeed")
+                .expect("distance counter should be non-null")
+                > 0
+        );
+
+        Spi::run("RESET enable_seqscan").expect("reset should succeed");
+    }
+
+    #[cfg(feature = "pg18")]
+    #[pg_test]
+    fn test_pg18_module_identity_reports_loaded_module_version() {
+        let version = Spi::get_one::<String>(
+            "SELECT version FROM pg_get_loaded_modules() WHERE name = 'tqvector'",
+        )
+        .expect("module query should succeed")
+        .expect("module version should be visible");
+        assert_eq!(version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[cfg(feature = "pg18")]
+    #[pg_test]
+    fn test_pg18_explain_option_emits_tqvector_stats_group() {
+        Spi::run("CREATE TABLE pg18_explain_fixture (id bigint primary key, embedding ecvector)")
+            .expect("table creation should succeed");
+        Spi::run(
+            "INSERT INTO pg18_explain_fixture VALUES
+             (1, encode_to_ecvector(ARRAY[1.0, 0.0, 0.5, -1.0], 4, 42)),
+             (2, encode_to_ecvector(ARRAY[0.0, 1.0, 0.25, -0.5], 4, 42)),
+             (3, encode_to_ecvector(ARRAY[0.5, 0.5, -0.5, 1.0], 4, 42))",
+        )
+        .expect("insert should succeed");
+        Spi::run(
+            "CREATE INDEX pg18_explain_fixture_idx ON pg18_explain_fixture USING ec_hnsw (embedding ecvector_ip_ops)",
+        )
+        .expect("index creation should succeed");
+        Spi::run("SET enable_seqscan = off").expect("set should succeed");
+
+        let plan = Spi::connect(|client| {
+            let rows = client
+                .select(
+                    "EXPLAIN (tqvector, ANALYZE, COSTS OFF)
+                     SELECT id FROM pg18_explain_fixture
+                     ORDER BY embedding <#> ARRAY[1.0, 0.0, 0.5, -1.0]::real[]
+                     LIMIT 1",
+                    None,
+                    &[],
+                )
+                .expect("EXPLAIN should succeed")
+                .first();
+            let mut lines = Vec::new();
+            for row in rows {
+                lines.push(
+                    row.get::<String>(1)
+                        .expect("plan row should decode")
+                        .expect("plan row should not be NULL"),
+                );
+            }
+            lines.join("\n")
+        });
+
+        assert!(plan.contains("TQVector Stats"));
+        assert!(plan.contains("Elements Scored"));
+
+        Spi::run("RESET enable_seqscan").expect("reset should succeed");
     }
 
     #[pg_test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,7 +614,6 @@ mod tests {
              (embedding tqvector_ip_ops)",
         )
         .expect("index creation should succeed");
-        Spi::run("SET LOCAL enable_seqscan = off").expect("SET LOCAL should succeed");
 
         let plan = Spi::connect(|client| {
             let rows = client

--- a/src/pg18_pgstat_shim.rs
+++ b/src/pg18_pgstat_shim.rs
@@ -1,0 +1,60 @@
+use crate::am::common::stats::TqStatsCounters;
+
+#[cfg(not(test))]
+#[link(name = "tqvector_pg18_pgstat_shim", kind = "static")]
+unsafe extern "C" {
+    fn tqvector_pg18_pgstat_anchor();
+    fn tqvector_pg18_pgstat_register_kind() -> bool;
+    fn tqvector_pg18_pgstat_is_registered() -> bool;
+    fn tqvector_pg18_pgstat_record(delta: *const TqStatsCounters) -> bool;
+    fn tqvector_pg18_pgstat_snapshot(out: *mut TqStatsCounters) -> bool;
+}
+
+#[cfg(not(test))]
+#[used]
+static PG18_PGSTAT_SHIM_ANCHOR: unsafe extern "C" fn() = tqvector_pg18_pgstat_anchor;
+
+#[cfg(not(test))]
+pub(crate) unsafe fn register_kind() -> bool {
+    unsafe { tqvector_pg18_pgstat_register_kind() }
+}
+
+#[cfg(test)]
+pub(crate) unsafe fn register_kind() -> bool {
+    false
+}
+
+#[cfg(not(test))]
+pub(crate) unsafe fn is_registered() -> bool {
+    unsafe { tqvector_pg18_pgstat_is_registered() }
+}
+
+#[cfg(test)]
+pub(crate) unsafe fn is_registered() -> bool {
+    false
+}
+
+#[cfg(not(test))]
+pub(crate) unsafe fn record(delta: &TqStatsCounters) -> bool {
+    unsafe { tqvector_pg18_pgstat_record(delta as *const TqStatsCounters) }
+}
+
+#[cfg(test)]
+pub(crate) unsafe fn record(_delta: &TqStatsCounters) -> bool {
+    false
+}
+
+#[cfg(not(test))]
+pub(crate) unsafe fn snapshot() -> Option<TqStatsCounters> {
+    let mut snapshot = TqStatsCounters::default();
+    if unsafe { tqvector_pg18_pgstat_snapshot(&mut snapshot as *mut TqStatsCounters) } {
+        Some(snapshot)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+pub(crate) unsafe fn snapshot() -> Option<TqStatsCounters> {
+    None
+}


### PR DESCRIPTION
# Review Request: PG18 Shared-Infra Merge And Wiring

Current head: `6d383a4`

Scope:
- `Cargo.toml`
- `build.rs`
- `csrc/pg18_pgstat_shim.c`
- `Makefile`
- `.github/workflows/ci.yml`
- `README.md`
- `docs/pg18.md`
- `plan/tasks/19-pg18-completion.md`
- `spec/functional/FR-012-sql-bootstrap.md`
- `spec/functional/FR-025-custom-statistics.md`
- `spec/functional/FR-026-pg18-module-identity.md`
- `spec/functional/FR-027-pgrx-pg18-upgrade.md`
- `spec/tests.md`
- `src/am/common/cost.rs`
- `src/am/common/explain.rs`
- `src/am/common/stats.rs`
- `src/am/common/stream.rs`
- `src/am/ec_hnsw/graph.rs`
- `src/am/ec_hnsw/mod.rs`
- `src/am/ec_hnsw/routine.rs`
- `src/am/ec_hnsw/scan.rs`
- `src/am/ec_hnsw/shared.rs`
- `src/lib.rs`
- `src/pg18_pgstat_shim.rs`

Problem:
- `main` had already split the AM into `common` and `ec_hnsw` modules while `origin/pg18`
  still carried older PG18-upgrade work against earlier boundaries.
- The PG18 plan still had shared-infrastructure work open: AM callback wiring, EXPLAIN hook
  registration, staged statistics plumbing, ReadStream integration points, module identity, and
  Cargo / CI defaults.
- The remaining scope here is intentionally limited to shared infrastructure. No pipeline-specific
  enablement, tuning, measurement, or storage-format feature work is included.

What changed:
- Merged `origin/pg18` into the current `main` line and rebased the PG18 work onto the split
  `common` / `ec_hnsw` module layout.
- Flipped the extension identity and Cargo setup to PG18-primary / PG17-fallback:
  - `Cargo.toml` default feature is now `pg18`
  - PG14-PG16 feature flags are dropped
  - package / control-file version now matches `0.1.1`
  - CI now initializes both pg17 and pg18 explicitly and runs separate pgrx jobs
- Wired PG18-facing AM callbacks in `src/am/ec_hnsw/routine.rs` and `src/am/common/cost.rs`:
  - `amconsistentordering = true`
  - `amgettreeheight`
  - `amtranslatestrategy`
  - `amtranslatecmptype`
  - planner/cost snapshots now distinguish the PG18 callback path from the PG17 metadata fallback
- Finished EXPLAIN hook registration and per-scan counter plumbing:
  - `_PG_init()` now registers the PG18 EXPLAIN option/hook path
  - hook logic lives in `src/am/common/explain.rs`
  - scan execution updates the staged counter sites and exposes counters through the existing
    snapshot/test surfaces
- Finished staged PG18 statistics plumbing:
  - `_PG_init()` now calls `register_pg18_stats()`
  - `tqvector_stats()` is live on PG18
  - a PG18-only C shim now owns the `pgstat_internal.h` boundary and registers a fixed custom
    pgstat kind during shared preload
  - `tqvector_stats()` reads the shared pgstat snapshot when that registration is active, and
    otherwise falls back to the existing backend-local counters in non-preloaded sessions
  - diagnostics snapshots now report the preload/runtime blocker instead of the old bindings/shim
    code blocker
- Finished ReadStream / async-I/O shared wiring:
  - pure callback/state helpers in `src/am/common/stream.rs` now map to PG18 callback signatures
  - scan graph prefetch, linear fallback reads, and vacuum tuple counting all have PG18-specific
  ReadStream attach points
  - PG17 keeps the legacy buffer-read fallback path
- Finished the remaining PG18 validation-facing cleanup:
  - `build.rs` now asks the active PG18 `pg_config` for `cppflags` before compiling the pgstat shim
  - PG18 `ReadStream` call sites now use the correct `InvalidBuffer`/`Buffer` comparisons
  - PG18 test helpers now match the current `index_beginscan` signature
  - PG18 module identity now uses explicit `pg_module_magic!` name/version fields so
    `pg_get_loaded_modules()` reports `tqvector` / `0.1.1` correctly under `pgrx 0.17`
  - PG18 EXPLAIN tests now validate the structured JSON output path that actually preserves the
    `TQVector Stats` group label in core PostgreSQL
- Updated docs/spec/task text so the staged PG18 boundary is accurate after the merge.
- Addressed the merge-blocking reviewer feedback on the shared pgstat path:
  - scan execution now accumulates a per-scan `TqStatsCounters` delta and flushes one aggregate
    shared update at scan teardown / rescan boundaries instead of taking the preload-on shared
    pgstat lock on every distance calculation / graph hop / page read
  - the PG18 shim now registers a tqvector-owned custom pgstat kind
    (`PGSTAT_KIND_CUSTOM_MIN + 1`) instead of the shared experimental slot
  - the EXPLAIN per-node hook now returns before access-method lookup/allocation when the
    `tqvector` option is disabled
  - the pgstat reset path now documents why it combines the lock with the changecount copy helper
- Addressed the seq-02 reviewer follow-up on scan teardown, shared-snapshot semantics, and the
  EXPLAIN hook globals:
  - `amrescan` / `amendscan` now finalize and flush the per-scan shared-stats delta, so the shared
    snapshot update runs from the scan teardown seam instead of the exhausted-results seam
  - `docs/pg18.md` now states that the preloaded shared snapshot reflects completed/torn-down scans
    and can lag backend-local counters while a scan is in flight
  - the PG18 EXPLAIN hook state now uses `OnceLock` plus `AtomicBool` instead of `static mut`
  - `src/am/ec_hnsw/scan.rs` now carries a focused Miri regression test for the raw-pointer
    scan-scoring path that mutates the staged per-scan delta

Live now:
- PG18 AM callback surface for tree height and strategy/compare translation
- PG18 EXPLAIN option registration and per-node hook registration
- PG18 shared pgstat registration path via `shared_preload_libraries`
- PG18 `tqvector_stats()` SQL surface, with shared-snapshot reads when preloaded and backend-local
  fallback otherwise
- PG18 ReadStream-backed graph-neighbor prefetch, linear fallback block reads, and vacuum tuple
  counting code paths
- PG18 module identity / SQL surface expectations in tests and docs
- PG17 fallback build/test/lint path

Still gated:
- Shared pgstat activation still requires runtime preload configuration:
  `custom pgstat kind registration requires loading tqvector via shared_preload_libraries on PG18 and restarting PostgreSQL`
- Shared pgstat reset is still limited by the current PostgreSQL 18 surface in this environment:
  `pg_stat_reset_shared(text)` does not accept custom kind names here, so the packet only claims
  documented reset behavior rather than a working SQL reset hook
- No pipeline-specific or storage-format-specific PG18 enablement was added in this slice.

Validation:
- Passed:
  - `cargo test`
  - `cargo clippy --all-targets --no-default-features --features pg18 -- -D warnings`
  - `cargo pgrx test pg18`
  - `cargo test --no-default-features --features pg17`
  - `cargo clippy --all-targets --no-default-features --features pg17 -- -D warnings`
  - `bash scripts/run_pgrx_pg17_test.sh`
  - `cargo +nightly miri test --lib -- miri_score_scan_element_result_via_raw_opaque_ptr_updates_stats_delta`

Review focus:
- Whether the PG18 callback wiring is attached at the right shared-AM seams without leaking
  pipeline-specific behavior into this branch
- Whether the EXPLAIN hook registration and chaining logic are correct and safe under PG18
- Whether the staged stats story is clear now that the shared pgstat path exists but still depends
  on preload-time activation, with backend-local fallback left in place for ordinary sessions
- Whether the ReadStream integration points sit in the right shared/module boundaries and preserve
  PG17 fallback behavior
- Whether the explicit `pg_module_magic!` name/version assignment is the right repo-local
  workaround for current `pgrx 0.17` PG18 shorthand behavior
- Whether the docs/spec/task updates accurately describe what is live versus still blocked
- Whether the teardown/rescan-boundary shared-stats flush is the right compromise for preload-on
  PG18 until/unless we later want a lower-level atomic shared-counter design

Questions to answer:
- Are any of the PG18 callback / EXPLAIN / ReadStream hooks attached too deep in `ec_hnsw` runtime
  code when they should stay in `common` shared infrastructure?
- Is the shim boundary the right long-lived place for `pgstat_internal.h`, or should more of the
  registration/snapshot logic move out of C once `pgrx` exposes better PG18 internals?
- Is the shared-snapshot plus backend-local fallback behavior the right contract for
  `tqvector_stats()` until preload-aware PG18 validation is available in this repo?
- Should the `pg_module_magic!(name, version)` shorthand issue be upstreamed as a `pgrx` bug now
  that this branch carries an explicit-field workaround?
- Are the remaining low-severity follow-ups from review correctly deferred for a later slice,
  especially filing the upstream `pgrx` shorthand issue?
