### PR TITLE
Restore Task 87 + Task 88 plan files on main

### DIFF
--- a/plan/tasks/87-candidate-batched-scoring-across-ams.md
+++ b/plan/tasks/87-candidate-batched-scoring-across-ams.md
@@ -1,0 +1,341 @@
+# Task 87: Candidate-Batched Scoring Across Access Methods
+
+Status: proposed (2026-06-07)
+Owner: coder (to be assigned). One coder, one branch.
+Priority: 2 (kernel-level optimization unlock; follows Task 86)
+
+## Why
+
+Task 86 (TurboQuant improvements) investigation surfaced that
+TurboVec-style scoring kernels — 32-vector blocked u8 nibble
+LUTs, multi-query lanes, fused top-k — don't transfer to our
+AMs because **all four currently score candidates inline,
+per-vector, with no batching abstraction**. The kernel ideas
+require a contiguous candidate buffer to amortize block setup
+and exploit SIMD width.
+
+Reference: pgvectorscale's `StreamingDiskANN` already maintains
+a `resort_buffer` (in
+`pgvectorscale/src/access_method/scan.rs`) which is
+functionally a small candidate batch. The pattern is well-
+established in production vector search (FAISS IVF+PQ,
+pgvectorscale, reference HNSW implementations).
+
+Per Task 86 closeout (`reviews/task-86/010-closeout-audit/`),
+the "32-vector blocked slabs" follow-up was design-rejected
+under the current scoring shape because "AM transfer
+complexity; flat contiguous slabs do not map directly onto
+graph traversal or page-bounded scans." That rejection is
+true under inline scoring. **Candidate batching is the
+prerequisite that makes block kernels applicable to our AMs.**
+
+Without batching, the scoring kernel is typically 30–70 % of
+query wall time (varies by AM and nprobe). With a batched
+SIMD block kernel (FAISS-class), the scoring step is
+typically 2–5× faster. End-to-end query speedup is therefore
+plausibly 1.3–3× — meaningfully larger than Task 86's
+shipped 1.04× SPIRE LUT routing.
+
+## Why this is hard
+
+- Multi-AM refactor: touches scoring sites in HNSW, DiskANN,
+  IVF, SPIRE — four different traversal patterns.
+- HNSW's greedy search is iterative; you can batch within a
+  frontier-evaluation step but not across steps (next step
+  depends on the score result).
+- DiskANN's per-page scan has a natural batch size but
+  variable list length.
+- IVF + SPIRE posting lists are variable-length — batch
+  handles the head; needs scalar tail handling.
+- Block kernels typically use SIMD intrinsics — safety bar
+  for `unsafe` is real per `feedback_dont_defer_safety_fixes`.
+- The abstraction must compose with Task 88 (streaming ANN
+  result iteration) without forcing a redesign.
+
+## Goal
+
+Cut per-AM query latency on the scoring share by ≥ 2× on a
+real-corpus suite at recall-preserving fixtures. End-to-end
+query latency improvement depends on each AM's scoring share
+of total query time; measure both per-AM scoring delta and
+per-AM end-to-end delta.
+
+## Scope
+
+### In scope
+
+1. Shared `CandidateBatch` abstraction (`src/quant/` or
+   `src/am/common/`). **The abstraction itself must be
+   quantizer-agnostic** — the batch surface holds opaque
+   `(node_id, code_ptr, gamma?)` tuples; only the kernel
+   that consumes the batch is quantizer-specific.
+2. Per-AM scoring-site refactor in **all four AMs**:
+   HNSW, DiskANN, IVF, SPIRE. **No AM may be skipped.**
+3. Route the **TurboQuant no-QJL 4-bit** scoring path
+   through the abstraction in each AM. This is the path
+   Task 86 validated end-to-end on SPIRE; it has the
+   broadest existing test coverage and the clearest kernel
+   shape.
+4. Optionally one new 32-block u8 nibble LUT kernel
+   (TurboVec-style); whether to land it in Task 87 vs a
+   follow-up depends on the Phase 1 design call.
+5. Per-AM real-corpus measurement with baseline + change
+   cells (recall@10 + p50/p95/p99 latency + storage).
+6. Compose-with-streaming contract documented so Task 88's
+   resort-buffer can sit on top of the same abstraction.
+
+### Out of scope
+
+- Streaming ANN result iteration semantics (Task 88).
+- TurboQuant TQ+ calibration (separate follow-up).
+- On-disk format changes.
+- New SIMD intrinsics beyond what existing kernels use,
+  unless the Phase 1 design call lands the 32-block kernel
+  and that requires new `target_feature` paths (in which
+  case the safety bar applies fully).
+- **Block kernels for quantizer variants other than TQ
+  no-QJL 4-bit** (see "Quantizer scope" below).
+
+### Quantizer scope
+
+The `CandidateBatch` abstraction is quantizer-agnostic by
+design — adding a new quant type later must not require an
+abstraction redesign. But **kernel work in Task 87 is scoped
+to TurboQuant no-QJL 4-bit only.** Other quant types stay on
+their current inline scoring paths until follow-up tasks
+land their block kernels.
+
+Quant type roadmap (rough ROI ranking from Task 86 analysis;
+ordering of follow-ups is a separate prioritisation call):
+
+| Quant type | Task 87? | Notes |
+|---|---|---|
+| TurboQuant no-QJL 4-bit | **YES** | Task 87 in-scope; what Task 86 already validated on SPIRE |
+| TurboQuant no-QJL 2-bit | follow-up | Higher kernel-density potential than 4-bit |
+| TurboQuant QJL (any bits) | follow-up | Residual-sign path is more complex |
+| RaBitQ | follow-up | Already block-oriented in the literature |
+| Binary fingerprint | follow-up | Hamming-distance kernels vectorise trivially |
+| PQ | follow-up | Classic FAISS block-kernel territory |
+| f32 raw | **never** | Already SIMD-friendly per-vector; batching adds copy overhead with no kernel win |
+
+Phase 1 design must verify the abstraction can host all of
+the "follow-up" entries above without redesign — if the
+contract bakes in TurboQuant-only assumptions, the design is
+wrong and must be revised before Phase 2 starts. Specifically,
+the batch's per-candidate metadata must accommodate quant
+types with different per-vector side data (e.g. binary has
+none; QJL TQ carries gamma + residual signs; RaBitQ carries
+rotation metadata).
+
+## Phase 1 — Design Packet
+
+Land one design packet before any AM-level refactor:
+
+- Pick the `CandidateBatch` abstraction shape (struct fields,
+  fill/flush contract, lifetime of the underlying code-ptr
+  refs, batch-size policy).
+- **Verify the abstraction is quantizer-agnostic** by walking
+  each follow-up quant type from the Quantizer Scope table
+  (TQ 2-bit, TQ QJL, RaBitQ, binary, PQ) and confirming the
+  contract can host their per-candidate metadata shapes
+  without redesign. If a quant type forces a contract change,
+  fix it here, not in a future task.
+- Specify how each AM's existing scoring site maps to the
+  abstraction (per-AM contract).
+- Cross-reference against pgvectorscale's `resort_buffer`
+  pattern; document where they meet vs differ.
+- Decide whether the TurboQuant no-QJL 4-bit dim-LUT kernel
+  alone is enough for Task 87, or whether a new 32-block u8
+  nibble LUT kernel also lands now, based on the expected
+  per-AM scoring-share win.
+- Document the streaming-ANN compose contract so Task 88
+  doesn't force a redesign.
+- Pre-commit a measurement methodology: which real fixtures,
+  which nprobe / `ef` settings, how the scoring share is
+  isolated from total query time.
+
+## Phase 2–5 — Per-AM Integration Slices
+
+**One slice per AM**, landed in this order (smallest blast
+radius first, then increasing complexity):
+
+### Phase 2: SPIRE integration
+
+- SPIRE's **TurboQuant no-QJL 4-bit** scoring site uses
+  `CandidateBatch`. Other SPIRE quant paths (e.g. QJL
+  variants) stay on inline scoring.
+- Real-corpus suite: real10k / 50k / 100k DBPedia spread,
+  baseline-source-install vs change-source-install (Task 86
+  packet 008 shape), recall@10 + p50/p95/p99 + storage.
+- **Per-AM validation gate**: SPIRE TQ no-QJL 4-bit recall
+  byte-equal at every cell; scoring-share latency ≥ 2×
+  faster on the batched path; end-to-end latency improves
+  at every cell; non-batched SPIRE quant paths show no
+  regression.
+
+### Phase 3: IVF integration
+
+- IVF's **TurboQuant no-QJL 4-bit** scoring site uses
+  `CandidateBatch`. Other IVF quant paths stay on inline
+  scoring.
+- Same real-corpus suite shape.
+- **Per-AM validation gate**: IVF TQ no-QJL 4-bit recall
+  byte-equal at every cell; scoring-share latency ≥ 2×
+  faster on the batched path; end-to-end latency improves
+  at every cell; non-batched IVF quant paths show no
+  regression.
+
+### Phase 4: DiskANN integration
+
+- DiskANN's **TurboQuant no-QJL 4-bit** scoring site uses
+  `CandidateBatch` (per-page batches). Other DiskANN quant
+  paths (currently grouped-PQ / RaBitQ per Task 86 packet
+  006) stay on inline scoring.
+- Same real-corpus suite shape.
+- **Per-AM validation gate**: DiskANN TQ no-QJL 4-bit
+  recall byte-equal at every cell; scoring-share latency
+  ≥ 2× faster on the batched path;
+  end-to-end latency improves at every cell.
+
+### Phase 5: HNSW integration
+
+- HNSW's **TurboQuant no-QJL 4-bit** scoring site uses
+  `CandidateBatch` (per-frontier batches; batching within
+  each greedy-search step). Other HNSW quant paths (QJL
+  variants, RaBitQ if present) stay on inline scoring.
+- Same real-corpus suite shape.
+- **Per-AM validation gate**: HNSW TQ no-QJL 4-bit recall
+  byte-equal at every cell; scoring-share latency improves
+  on the batched path (the per-frontier batch may not hit
+  2× because batches are smaller — document the achieved
+  factor); end-to-end latency improves at every cell;
+  non-batched HNSW quant paths show no regression.
+
+## Phase 6 — Closeout
+
+- All four AM slices reviewer-approved.
+- Aggregate measurement comparison (4-AM × 3-corpus matrix).
+- Closeout packet citing per-AM evidence.
+- Status flip to `complete` referencing the closeout packet.
+
+## Validation gate (per AM, every cell)
+
+1. **Recall@10 byte-equal** at every fixture × nprobe cell vs
+   pre-refactor baseline.
+2. **Scoring-share latency** (isolated from traversal share)
+   measurably faster.
+3. **End-to-end p50/p95/p99 latency** improves at every cell.
+4. **Storage unchanged** (no format change in scope).
+5. **All existing pg_test surfaces pass** for the AM under
+   slice.
+6. **No new `unsafe` outside the existing SIMD kernel
+   boundary** unless Phase 1 design lands the 32-block
+   kernel — in which case full safety-doc + anti-pattern B
+   compliance.
+7. **Suite-driven per FR-038** — `ecaz bench suite` with
+   checked-in `suite.json`, baseline source install vs
+   change source install columns, both committed in the
+   packet.
+
+## Acceptance criteria
+
+1. `CandidateBatch` abstraction lives in a shared module.
+2. **All four AMs (HNSW, DiskANN, IVF, SPIRE) route through
+   it on their scoring path.** Not "the first two and we'll
+   see." Not "three of four with the fourth deferred."
+3. Per-AM real-corpus suite evidence ships in each slice's
+   packet.
+4. All existing pg_test surfaces pass across all four AMs.
+5. Closeout packet cites per-AM evidence + aggregate matrix.
+6. `plan/tasks/87-…md` status flips to `complete` only
+   referencing the closeout packet.
+
+### Per-AM completion is non-negotiable
+
+The task is **not** complete until all four AM slices have
+shipped + been reviewer-approved + met the per-AM validation
+gate. A partial close (e.g. "shipped SPIRE + IVF, deferring
+HNSW + DiskANN") requires:
+
+- An explicit Stop Condition packet naming the per-AM
+  blocker (e.g. "HNSW per-frontier batch is too small to
+  amortize overhead; measured scoring-share win is < 5 %").
+- Reviewer acceptance of the Stop Condition.
+- A follow-up task explicitly scoped for the deferred AM(s).
+
+Single-AM ship does **not** satisfy Task 87. The whole point
+is cross-AM applicability of the abstraction; shipping it
+on one AM and walking away is a Task 86-class kernel-routing
+fix, not Task 87.
+
+## Coordination
+
+- **Depends on Task 86** (TurboQuant improvements) closeout
+  being merged.
+- **Task 88** (streaming ANN) sits on top of this
+  abstraction. Sequence Task 87 first; Task 88 reuses the
+  `CandidateBatch` shape inside its resort_buffer.
+- **TurboQuant TQ+** (Task 86 packet 002 follow-up) is a
+  separate effort but will benefit from this abstraction —
+  the calibration prototype already produces `Prepared…Query`
+  shapes that batch naturally.
+- **pgvectorscale** is a read-only reference: clone at
+  `/Users/peter/dev_bak/pgvectorscale/`; key files
+  `access_method/scan.rs` (resort_buffer pattern) and
+  `access_method/graph/mod.rs` (streaming iteration).
+
+## Coder workflow notes
+
+- Phase 1 design packet must land before any AM slice
+  starts. Reviewer approves Phase 1 explicitly.
+- Each Phase 2–5 slice is its own packet with its own
+  real-corpus measurement. No "batched landing" of multiple
+  AMs in one packet.
+- Per memory `feedback_no_premature_task_close`, the
+  reviewer drives to 100 % of acceptance per AM; off-ramps
+  require Stop Condition packets.
+- Per memory `feedback_dont_defer_safety_fixes`, every new
+  unsafe block in any block kernel ships with a `# Safety`
+  doc.
+- Per memory `feedback_anti_pattern_b_unbounded_lifetime`,
+  the abstraction's lifetime contract must not use safe
+  `fn(*mut T) -> &'a T` patterns; typed view wrappers expose
+  operations.
+- Per memory `feedback_coder_push_smoke_checks`, push after
+  every slice; run smoke checks (focused `cargo test` +
+  `cargo check pg18`) between slices.
+
+## Stop conditions
+
+- Per AM, if measured scoring-share speedup is < 5 % after
+  the refactor (sized to whatever the abstraction overhead
+  costs), back the AM out and document. A no-op refactor
+  must not land in tree.
+- If per-AM recall regresses on any cell, BLOCK that AM's
+  slice and triage before retrying.
+- If the abstraction shape can't compose with Task 88's
+  streaming requirement (discovered late), pause Task 87
+  and revisit Phase 1.
+
+## References
+
+- Task 86: `plan/tasks/86-turboquant-turbovec-improvements.md`
+  (predecessor; surfaced the kernel-vs-access-pattern
+  mismatch)
+- Task 86 closeout: `reviews/task-86/010-closeout-audit/`
+  (32-block kernel deferred for "AM transfer complexity")
+- Task 86 packet 001 transferability matrix (per-AM block-
+  kernel fit ranking)
+- pgvectorscale resort_buffer pattern:
+  `/Users/peter/dev_bak/pgvectorscale/pgvectorscale/src/access_method/scan.rs`
+- FR-038 (benchmark provenance): every suite checked-in JSON
+- ADR-075 (Task 65b stepping stone framing) — similar
+  staged-rollout pattern
+
+## Estimated size
+
+Large. 4–6 weeks for one coder including Phase 1 design,
+4 AM slices each with their own real-corpus measurement, and
+closeout. The HNSW + DiskANN slices are the harder ones
+because their batch sizes are smaller and the abstraction
+must work for both flat-batch and per-step-batch shapes.

--- a/plan/tasks/88-streaming-ann-result-iteration.md
+++ b/plan/tasks/88-streaming-ann-result-iteration.md
@@ -1,0 +1,267 @@
+# Task 88: Streaming ANN Result Iteration (HNSW + DiskANN)
+
+Status: proposed (2026-06-07)
+Owner: coder (to be assigned). One coder, one branch.
+Priority: 2 (hybrid-search support; follows Task 87)
+
+## Why
+
+Task 86 investigation surfaced pgvectorscale's
+`StreamingDiskANN` pattern (see
+`/Users/peter/dev_bak/pgvectorscale/pgvectorscale/src/access_method/graph/mod.rs`
+`greedy_search_streaming_init` + `greedy_search_iterate`).
+The pattern yields candidates lazily to the PostgreSQL
+executor in approximate-score order, with a resort buffer +
+streaming stats for the approximate-vs-exact reranking
+boundary.
+
+Motivating workload: **hybrid search**.
+
+```sql
+SELECT id, body
+  FROM document
+ WHERE category = 'science'
+ ORDER BY embedding <=> $1
+ LIMIT 10;
+```
+
+Without streaming, the index AM must produce a full
+candidate set, the executor applies the `WHERE` filter, and
+work spent scoring filtered-out candidates is wasted. With
+streaming, the AM yields candidates incrementally; the
+executor applies the filter; the query stops after 10 matches
+survive. For restrictive filters this is a substantial
+end-to-end win — pgvectorscale's README explicitly cites
+this as the motivation: *"The post-filtering implementation,
+while slower, is streaming and correct, ensuring accurate
+results without requiring the entire result set to be loaded
+into memory."*
+
+## Why this is hard
+
+- Requires PG AM iterator semantics (`amgettuple`
+  continuation across calls; index scan state must persist
+  between executor invocations).
+- Approximate-distance order ≠ exact-distance order — needs
+  a resort buffer for the reranking boundary.
+- Streaming stats (running mean/variance/max distance) tell
+  the iterator when it's safe to pop from the resort buffer
+  without missing a closer candidate.
+- Only naturally applies to **graph-based AMs (HNSW +
+  DiskANN)** which have best-first traversal. IVF + SPIRE
+  scan partitions in arbitrary order and don't get the same
+  post-filter win — explicitly out of scope.
+- Must compose with Task 87's `CandidateBatch` abstraction
+  without forcing a redesign of either.
+
+## Goal
+
+Land streaming result iteration on the two graph-based AMs
+(HNSW + DiskANN), enabling post-filter early termination
+for hybrid-search workloads. Demonstrate measured latency
+wins at restrictive filter selectivities; preserve recall
+on non-filtered baselines.
+
+## Scope
+
+### In scope
+
+1. HNSW scan path supports `amgettuple` continuation.
+2. DiskANN scan path supports `amgettuple` continuation.
+3. Per-AM resort buffer + streaming stats matching
+   pgvectorscale's pattern.
+4. Per-AM hybrid-search benchmark workload.
+5. Compose with Task 87's `CandidateBatch` so each iterate
+   call can score a batch and push it into the resort
+   buffer (the resort buffer IS the candidate batch from
+   the executor's perspective).
+
+### Out of scope
+
+- IVF streaming (weak fit; no best-first traversal).
+- SPIRE streaming (same — weak fit; no best-first
+  traversal).
+- New filter operator surface — use PostgreSQL's existing
+  post-filter executor path.
+- TurboQuant TQ+ — separate follow-up.
+
+## Phase 1 — Design Packet
+
+Land one design packet before any AM-level work:
+
+- Streaming PG AM contract: `amgettuple` semantics,
+  `IndexScanDesc` lifetime, how iterator state survives
+  between calls.
+- Resort buffer + streaming stats design (copy pgvectorscale's
+  shape or adapt).
+- Per-AM scoring-site contract: must compose with Task 87's
+  `CandidateBatch`. Define how the iterator calls into the
+  shared kernel and pushes results into the resort buffer.
+- Hybrid-search benchmark methodology: which selectivities
+  (e.g. 1 %, 10 %, 50 %, 100 %), which `LIMIT` values
+  (10 / 100 / 1000), what counts as the baseline (today's
+  full-materialize path).
+- Pre-commit a `suite.json` shape so both AM slices use the
+  same harness.
+
+## Phase 2 — HNSW Streaming Slice
+
+- HNSW scan supports `amgettuple` continuation.
+- Resort buffer + streaming stats (per Phase 1 design).
+- Validation:
+  - **Hybrid-search workload**: latency improvement at every
+    measured (selectivity × LIMIT) cell.
+  - **Non-filtered baseline**: recall@10 + p50/p95/p99
+    latency neutral (no regression).
+  - **All existing HNSW pg_test surfaces pass.**
+  - **Suite-driven per FR-038**: `suite.json` checked in,
+    baseline vs streaming columns.
+
+## Phase 3 — DiskANN Streaming Slice
+
+- DiskANN scan supports `amgettuple` continuation.
+- Resort buffer + streaming stats (per Phase 1 design;
+  reuse HNSW's shape where applicable).
+- Validation (same shape as HNSW):
+  - **Hybrid-search workload**: latency improvement at every
+    measured (selectivity × LIMIT) cell.
+  - **Non-filtered baseline**: recall@10 + p50/p95/p99
+    latency neutral (no regression).
+  - **All existing DiskANN pg_test surfaces pass.**
+  - **Suite-driven per FR-038.**
+
+## Phase 4 — Closeout
+
+- Both HNSW and DiskANN slices reviewer-approved.
+- Aggregate measurement comparison.
+- Closeout packet citing per-AM evidence.
+- Status flip to `complete` referencing the closeout packet.
+
+## Validation gate (per AM, every cell)
+
+1. **Hybrid-search latency improves** at every measured
+   selectivity × LIMIT cell. Measured against a real corpus
+   (real10k / 50k / 100k) with a realistic filter column.
+2. **Non-filtered baseline recall@10 byte-equal** vs
+   pre-streaming.
+3. **Non-filtered baseline latency** within ±5 % (resort-
+   buffer overhead must not regress the no-filter path).
+4. **All existing pg_test surfaces pass** for the AM under
+   slice.
+5. **Suite-driven per FR-038** — `ecaz bench suite` with
+   checked-in `suite.json`, both columns committed.
+6. **No new `unsafe`** outside the existing AM boundary;
+   resort buffer is safe-Rust.
+
+## Acceptance criteria
+
+1. HNSW supports `amgettuple` continuation with resort
+   buffer + streaming stats.
+2. DiskANN supports `amgettuple` continuation with resort
+   buffer + streaming stats.
+3. Per-AM hybrid-search workload shows measured latency win
+   at every restrictive-filter cell.
+4. Per-AM non-filtered baseline shows recall byte-equal +
+   latency neutral.
+5. All existing pg_test surfaces pass for both AMs.
+6. Closeout packet cites per-AM evidence + aggregate matrix.
+7. `plan/tasks/88-…md` status flips to `complete` only
+   referencing the closeout packet.
+
+### Per-AM completion is non-negotiable
+
+The task is **not** complete until both HNSW and DiskANN
+have shipped + been reviewer-approved + met the per-AM
+validation gate. A partial close (e.g. "shipped HNSW,
+deferring DiskANN") requires:
+
+- An explicit Stop Condition packet naming the per-AM
+  blocker (e.g. "DiskANN's page-bounded scan can't preserve
+  approximate-score order across page boundaries without
+  buffering the whole page — overhead exceeds the
+  post-filter win at our typical selectivities").
+- Reviewer acceptance of the Stop Condition.
+- A follow-up task explicitly scoped for the deferred AM.
+
+Single-AM ship does **not** satisfy Task 88. The whole
+point is providing streaming for both graph-based AMs;
+shipping it on one and walking away makes the feature
+asymmetric and surprising for operators choosing between
+the two.
+
+## Coordination
+
+- **Depends on Task 87** (candidate-batched scoring) being
+  merged. Task 88 reuses Task 87's `CandidateBatch`
+  abstraction inside its resort buffer.
+- **IVF + SPIRE are explicitly out of scope.** If
+  streaming-for-IVF becomes a priority later (e.g. for a
+  specific hybrid-search workload), file a new task with
+  the post-filter use case justification — don't expand
+  Task 88's scope.
+- **pgvectorscale** is the reference implementation
+  (`/Users/peter/dev_bak/pgvectorscale/`). Key files:
+  - `pgvectorscale/src/access_method/scan.rs`
+    (`resort_buffer`, `StreamingStats`)
+  - `pgvectorscale/src/access_method/graph/mod.rs`
+    (`greedy_search_streaming_init`)
+  - Read-only reference; don't depend on it at build time.
+
+## Coder workflow notes
+
+- Phase 1 design packet must land before any AM slice
+  starts. Reviewer approves Phase 1 explicitly.
+- Each AM slice is its own packet with its own real-corpus
+  hybrid-search measurement. No "batched landing" of both
+  AMs in one packet.
+- The PG `amgettuple` continuation contract is the
+  trickiest part. Get it right in Phase 1; reuse across
+  both AMs.
+- Per memory `feedback_no_premature_task_close`, the
+  reviewer drives to 100 % per AM.
+- Per memory `feedback_dont_defer_safety_fixes`, any new
+  unsafe ships with `# Safety` docs.
+- The resort buffer is safe-Rust by construction (PG owns
+  the iterator lifetime via the executor).
+
+## Stop conditions
+
+- Per AM, if the streaming + resort-buffer overhead causes
+  the non-filtered baseline to regress > 5 %, back the AM
+  out and document. Streaming must not cost non-streaming
+  users.
+- Per AM, if no measured post-filter latency win materializes
+  at any reasonable selectivity × LIMIT cell, back the AM
+  out and document. The whole point is the post-filter win.
+- If the Task 87 `CandidateBatch` abstraction can't host
+  the resort buffer cleanly, pause Task 88 and coordinate
+  with Task 87 ownership.
+
+## References
+
+- Task 86 closeout: `reviews/task-86/010-closeout-audit/`
+  (surfaced the streaming-vs-batching distinction)
+- Task 87 (predecessor): `plan/tasks/87-candidate-batched-scoring-across-ams.md`
+- pgvectorscale `StreamingDiskANN` reference:
+  `/Users/peter/dev_bak/pgvectorscale/`
+- pgvectorscale README streaming section: *"The
+  post-filtering implementation, while slower, is streaming
+  and correct…"*
+- FR-038 (benchmark provenance)
+
+## Estimated size
+
+Medium-large. 2–4 weeks for one coder including Phase 1
+design, two AM slices with hybrid-search workloads, and
+closeout. Smaller than Task 87 because:
+
+- Two AMs instead of four
+- Both target AMs (HNSW + DiskANN) share the same graph-
+  traversal shape — Phase 1's iterator design transfers
+  across slices
+- The hard PG `amgettuple` semantics are designed once and
+  reused
+
+But meaningfully harder than a pure refactor because the
+iterator-lifetime contract is load-bearing for correctness,
+and the resort-buffer-pop heuristic affects recall.


### PR DESCRIPTION
Recovers the Task 87 (candidate-batched scoring across AMs) and Task 88 (streaming ANN result iteration) plan files from the original Task 86 branch.

These were created on the Task 86 branch (commit `f08fc606c`), then reverted (`bf819567c`) as scope-hygiene because they were follow-up planning work, not Task 86 deliverables. They were intended to land on main as a separate PR after Task 86 merged.

Task 89 (TQ+ cross-AM validation) is already on main from the Task 86 slim merge.

Two new doc files, zero src.