### PR TITLE
Task 104: matrix wording fix from closeout review

### DIFF
--- a/reviews/task-104/008-m5-matrix-closeout/m5-index-quant-option-matrix.md
+++ b/reviews/task-104/008-m5-matrix-closeout/m5-index-quant-option-matrix.md
@@ -142,5 +142,8 @@ affect parity or floor-gate conclusions.
 4. `d1235077c` — `ecaz bench suite` runnable `retired` kernel_status
    (tooling).
 
-No shared/x86 code was touched; the Task 103 Intel cells do not require
-a re-run (AVX2 paths byte-identical).
+The kernel changes are aarch64-only. Two shared surfaces were touched —
+the `candidate_batch` remainder dispatch (a rename; the x86 octet path
+still reaches the same AVX2 implementation) and the `ecaz bench suite`
+runner (tooling, not scoring) — neither alters x86 scoring behavior, so
+the Task 103 Intel cells do not require a re-run.


### PR DESCRIPTION
One-line doc fix: the closeout reviewer's non-blocking note — "no shared/x86 code touched" was over-broad; now names the two shared surfaces (candidate_batch dispatch rename, suite tooling) and why no Intel re-run is needed. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)