### PR TITLE
spec: backsync FR prose to actual code (FR-001/003/025/046/047 drift fixes)

### DIFF
--- a/spec/functional/common/FR-001-tqvector-data-type-registration.md
+++ b/spec/functional/common/FR-001-tqvector-data-type-registration.md
@@ -31,13 +31,12 @@ Little-endian, packed:
 | Offset | Size (bytes) | Field | Type | Description |
 |---|---|---|---|---|
 | 0 | 2 | dim | u16 | Vector dimensionality |
-| 2 | 1 | bits | u8 | Quantization bits (2–8) |
-| 3 | 8 | seed | u64 | Quantizer seed |
-| 11 | 4 | gamma | f32 | Residual norm used by the QJL correction term |
-| 15 | variable | code_bytes | [u8] | Bit-packed MSE indices followed by bit-packed QJL signs |
+| 2 | 4 | gamma | f32 | Residual norm used by the QJL correction term |
+| 6 | variable | code_bytes | [u8] | Bit-packed MSE indices followed by bit-packed QJL signs |
 
 Definitions:
-- Datum prefix length = `2 + 1 + 8 = 11` bytes (`dim`, `bits`, `seed`)
+- Datum prefix length = `2 + 4 = 6` bytes (`dim` + `gamma`; `MIN_BINARY_BYTES` in `src/lib.rs`)
+- `bits` and `seed` are NOT serialized on the wire; they are pinned to the canonical defaults (`DEFAULT_QUANT_BITS = 4`, `DEFAULT_QUANT_SEED = 42`) and re-derived on `unpack`
 - Quantized payload length = `4 + ceil(dim * (bits-1) / 8) + ceil(dim / 8)` bytes (`gamma` + `code_bytes`)
 - Code-bytes length = `ceil(dim * (bits-1) / 8) + ceil(dim / 8)` bytes (`mse_packed` + `qjl_packed`)
 
@@ -68,14 +67,14 @@ For a 1536-dim, 4-bit datum (QJL active, `mse_bits = 3`) the packed wire size is
 | ID | Criteria | Verification |
 |----|----------|--------------|
 | FR-001-AC-1 | `tqvector` is visible in `pg_type` after `CREATE EXTENSION ecaz` | Test |
-| FR-001-AC-2 | `tqvector` values are TOASTable; a 1536-dim 4-bit datum occupies 783 bytes total | Test |
+| FR-001-AC-2 | `tqvector` values are TOASTable; a 1536-dim 4-bit datum occupies 774 bytes total | Test |
 | FR-001-AC-3 | Pack/unpack of `(dim, bits, seed, gamma, code_bytes)` round-trips losslessly for all valid parameter combinations | Test |
 
 ### FR-001-AC-1: Type exists after CREATE EXTENSION
 After `CREATE EXTENSION ecaz`, the type `tqvector` SHALL be visible in `pg_type`.
 
 ### FR-001-AC-2: Varlena storage
-Values stored in `tqvector` columns SHALL be TOASTable. A 1536-dim, 4-bit datum SHALL occupy `11 + 4 + 576 + 192 = 783` bytes total: 11-byte datum prefix, 772-byte quantized payload, and 768-byte `code_bytes` section.
+Values stored in `tqvector` columns SHALL be TOASTable. A 1536-dim, 4-bit datum SHALL occupy `2 + 4 + 576 + 192 = 774` bytes total: 6-byte datum prefix (`dim` + `gamma`), 768-byte `code_bytes` section (`mse_packed` + `qjl_packed`).
 
 ### FR-001-AC-3: Binary layout correctness
 Pack/unpack of `(dim, bits, seed, gamma, code_bytes)` SHALL round-trip losslessly for all valid parameter combinations.

--- a/spec/functional/common/FR-003-binary-protocol.md
+++ b/spec/functional/common/FR-003-binary-protocol.md
@@ -37,13 +37,13 @@ The binary protocol surface is registered as two `LANGUAGE c` SQL functions in `
 | ID | Criteria | Verification |
 |----|----------|--------------|
 | FR-003-AC-1 | `tqvector_recv(tqvector_send(val))` produces a value identical to `val` for all valid values | Test |
-| FR-003-AC-2 | Binary payloads shorter than 15 bytes raise ERROR | Test |
+| FR-003-AC-2 | Binary payloads shorter than `MIN_BINARY_BYTES` (6 bytes) raise ERROR | Test |
 
 ### FR-003-AC-1: Binary round-trip
 `tqvector_recv(tqvector_send(val))` SHALL produce a value identical to `val` for all valid tqvector values.
 
 ### FR-003-AC-2: Reject truncated binary
-A binary payload shorter than 15 bytes SHALL raise ERROR. This threshold covers the 11-byte datum prefix plus the required 4-byte `gamma` field; `code_bytes` are validated separately from `dim` and `bits`.
+A binary payload shorter than `MIN_BINARY_BYTES` (6 bytes) SHALL raise ERROR. This threshold covers the 2-byte `dim` descriptor plus the required 4-byte `gamma` field; the trailing `code_bytes` length is validated separately against `code_len(dim, bits)`.
 
 ## Dependencies
 

--- a/spec/functional/common/FR-025-custom-statistics.md
+++ b/spec/functional/common/FR-025-custom-statistics.md
@@ -36,15 +36,14 @@ PG18 introduces `pgstat_register_kind()` which allows extensions to register cus
 ### Statistics Structure
 
 ```rust
-#[repr(C)]
-struct EcazStats {
-    total_distance_calcs: i64,       // Total score_ip_from_parts calls
-    total_graph_hops: i64,           // Total bootstrap expansion node visits
-    total_linear_pages: i64,         // Total linear scan pages read
-    total_scans_started: i64,        // Total amrescan calls
-    total_scans_bootstrap_only: i64, // Scans that returned all results from bootstrap
-    quantizer_cache_hits: i64,       // ProdQuantizer cache hits
-    quantizer_cache_misses: i64,     // ProdQuantizer cache misses (new codebook)
+struct TqStatsCounters {
+    total_distance_calcs: u64,       // Total candidate scoring calls
+    total_graph_hops: u64,           // Total bootstrap expansion node visits
+    total_linear_pages: u64,         // Total linear scan pages read
+    total_scans_started: u64,        // Total amrescan calls
+    total_scans_bootstrap_only: u64, // Scans that returned all results from bootstrap
+    quantizer_cache_hits: u64,       // ProdQuantizer cache hits
+    quantizer_cache_misses: u64,     // ProdQuantizer cache misses (new codebook)
 }
 ```
 

--- a/spec/functional/operator/FR-046-cloud-dataset-registry.md
+++ b/spec/functional/operator/FR-046-cloud-dataset-registry.md
@@ -41,9 +41,11 @@ third-party benchmarks each dataset is comparable against.
    DEEP1B SHALL be converted to parquet during the
    `corpus stage` step via a new adapter; downstream load logic is
    unchanged.
-5. Each registry entry SHALL declare `dim`, `distance`, `row_count`,
-   and an `expected_sha256` for the staged parquet manifest so
-   `corpus stage` is verifiable and re-runnable.
+5. Each registry entry SHALL declare `dim`, `distance`, `rows`, and
+   `format` so `corpus stage` is deterministic and re-runnable.
+   Staging verification SHALL rely on the staged `_manifest.json`
+   written into S3 (`{name, format, rows, dim}`); the registry does
+   not store a per-entry `expected_sha256`.
 6. `ecaz cloud corpus list-datasets` SHALL print the registry as a
    human-readable table and as JSON with `--json`.
 
@@ -53,7 +55,7 @@ third-party benchmarks each dataset is comparable against.
 |---|---|---|
 | FR-046-AC-1 | Every registered dataset has a non-empty `source`, `dim`, `row_count`, and `comparable_to` field | Test |
 | FR-046-AC-2 | `corpus stage --dataset bigann-1b --dry-run` reports the planned S3 keys and total bytes without downloading | Test |
-| FR-046-AC-3 | A staged dataset's manifest SHA matches the registry's `expected_sha256` after a successful `corpus stage` run | Demonstration |
+| FR-046-AC-3 | A staged dataset's `_manifest.json` records `{name, format, rows, dim}` matching the registry entry after a successful `corpus stage` run | Demonstration |
 
 ### FR-046-AC-1
 
@@ -67,8 +69,9 @@ S3 keys and total bytes without downloading.
 
 ### FR-046-AC-3
 
-A staged dataset's manifest SHA matches the registry's
-`expected_sha256` after a successful `corpus stage` run.
+A staged dataset's `_manifest.json` (written to S3 by `corpus stage`)
+records `{name, format, rows, dim}` matching the registry entry after a
+successful `corpus stage` run.
 
 ## Schema
 

--- a/spec/functional/operator/FR-047-cloud-loader-fanout.md
+++ b/spec/functional/operator/FR-047-cloud-loader-fanout.md
@@ -24,11 +24,12 @@ workstation.
 ## Behavior
 
 1. The loader EC2 SHALL be running and reachable via SSM during a
-   `corpus load`. If stopped, `corpus load` SHALL start it and stop
-   it on exit (configurable via `--keep-loader`).
-2. Parquet shards staged in S3 SHALL be sharded across N workers
-   (default `min(8, num_shards)`); workers run in parallel on the
-   loader EC2.
+   `corpus load` (provisioned by `ecaz cloud up` and resumed by
+   `ecaz cloud resume`); `corpus load` dispatches the load over SSM
+   and does not itself start or stop the instance.
+2. Parquet shards staged in S3 SHALL be loaded by N parallel workers
+   on the loader EC2 (the `--workers` flag, default `8`, fanned out
+   via `xargs -P<workers>`).
 3. Each worker SHALL invoke the existing
    `ecaz corpus prepare` + `ecaz corpus load` code paths against
    the DB's private IP, reusing the streaming COPY implementation


### PR DESCRIPTION
## Summary

Follow-up to #40. Reconciles five spec-body claims that contradicted the actual implementation — the backsync findings surfaced (but deliberately not edited) during the composed-object authoring pass. Each fix is verified against current code on `main`.

| FR | Was (stale) | Now (matches code) | Source of truth |
|---|---|---|---|
| FR-001 | 11-byte prefix (dim+bits+seed), 783 bytes total | 6-byte prefix (dim u16 + gamma f32) + code_bytes; bits/seed re-derived from `DEFAULT_QUANT_BITS=4`/`DEFAULT_QUANT_SEED=42`; **774 bytes** | `pack`/`unpack`, `MIN_BINARY_BYTES`, `code_len` in `src/lib.rs` |
| FR-003 | reject < 15 bytes | reject < `MIN_BINARY_BYTES` (6) | `src/lib.rs` `unpack` |
| FR-025 | `EcazStats` / `i64` | `TqStatsCounters` / `u64` | `src/am/common/stats.rs` |
| FR-046 | registry stores `expected_sha256` | no `expected_sha256`; staging verified via staged `_manifest.json` | `crates/ecaz-cloud/src/datasets.rs` `Dataset` |
| FR-047 | `--keep-loader`, default `min(8, num_shards)`, load starts/stops loader | `--workers` (default `8`) + `--resume`; load dispatches over SSM, does not start/stop the loader | `crates/ecaz-cloud/src/commands/corpus.rs` |

Only `Internal Binary Layout` / `Behavior` / `Acceptance Criteria` prose changed; the object sections (Properties/Schema/Workflow) added in #40 were already code-accurate and are untouched.

## Validation

```
quire validate 'spec/**/*.md' --scope .            # exit 0
quire validate 'spec/**/*.md' --scope . --strict   # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
