### PR TITLE
Complete Task 36 current SIMD differential validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           sudo apt-get install -y postgresql-server-dev-18 clang llvm pkg-config libssl-dev
 
       - name: SIMD/scalar differential tests
-        run: cargo test --features bench --test simd_diff -- --test-threads=1
+        run: make simd-diff
         env:
           PROPTEST_CASES: 256
 

--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,8 @@ simd-diff:
 	cargo test --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: int8/SDOT block/partial kernels"
 	cargo test --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: tiled LUT lane and query-shape guards"
+	cargo test --lib --features bench quant::prod::tests::tiled_lut_query_prep_ -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: real hamming32 SIMD kernels"
 	cargo test --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: DistANN codec composition, stride, and source IP"

--- a/Makefile
+++ b/Makefile
@@ -224,25 +224,25 @@ proptest:
 ## Run SIMD/scalar differential tests for host-reachable vector backends
 simd-diff:
 	@echo "task36 simd-diff: public bench hooks (Prod/FWHT/HNSW/DiskANN)"
-	cargo test --features bench --test simd_diff -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 10 --features bench --test simd_diff -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: RaBitQ arithmetic SIMD inventory"
-	cargo test --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 2 --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: rabitq32 bits=1/2/4 block and partial kernels"
-	cargo test --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 7 --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: qjl32 block/octet/remainder kernels"
-	cargo test --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 10 --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: lut32 block/partial/tiled kernels"
-	cargo test --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 9 --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: grouped-PQ block/partial kernels"
-	cargo test --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 8 --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: int8/SDOT block/partial kernels"
-	cargo test --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 5 --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: tiled LUT lane and query-shape guards"
-	cargo test --lib --features bench quant::prod::tests::tiled_lut_query_prep_ -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::prod::tests::tiled_lut_query_prep_ -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: real hamming32 SIMD kernels"
-	cargo test --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: DistANN codec composition, stride, and source IP"
-	cargo test --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
+	bash scripts/run-counted-cargo-test.sh 2 --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
 
 # --- On-disk format ---
 

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,24 @@ proptest:
 
 ## Run SIMD/scalar differential tests for host-reachable vector backends
 simd-diff:
-	cargo test --features bench --test simd_diff -- --test-threads=1
+	@echo "task36 simd-diff: public bench hooks (Prod/FWHT/HNSW/DiskANN)"
+	cargo test --features bench --test simd_diff -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: RaBitQ arithmetic SIMD inventory"
+	cargo test --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: rabitq32 bits=1/2/4 block and partial kernels"
+	cargo test --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: qjl32 block/octet/remainder kernels"
+	cargo test --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: lut32 block/partial/tiled kernels"
+	cargo test --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: grouped-PQ block/partial kernels"
+	cargo test --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: int8/SDOT block/partial kernels"
+	cargo test --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: real hamming32 SIMD kernels"
+	cargo test --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: DistANN codec composition, stride, and source IP"
+	cargo test --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
 
 # --- On-disk format ---
 

--- a/Makefile
+++ b/Makefile
@@ -241,8 +241,8 @@ simd-diff:
 	bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::prod::tests::tiled_lut_query_prep_ -- --test-threads=1 --nocapture
 	@echo "task36 simd-diff: real hamming32 SIMD kernels"
 	bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
-	@echo "task36 simd-diff: DistANN codec composition, stride, and source IP"
-	bash scripts/run-counted-cargo-test.sh 2 --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
+	@echo "task36 simd-diff: production QJL cascade and DistANN composition/source IP"
+	bash scripts/run-counted-cargo-test.sh 3 --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
 
 # --- On-disk format ---
 

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -138,25 +138,78 @@ Seeded Miri coverage now includes:
 
 ## SIMD/Scalar Differential Validation
 
-- `make simd-diff`: runs `tests/simd_diff.rs` with the `bench` feature. The
-  harness compares production-dispatched scoring/FWHT entry points against
-  scalar-reference entry points in the same process, and also calls test-only
-  AVX2/FMA or NEON entry points directly when the host supports them. This
-  keeps backend pinning independent of `ECAZ_SIMD` process-global dispatch.
-- GitHub Actions runs the same lane in a focused `simd-diff` job on
-  `ubuntu-24.04` x64 and `ubuntu-24.04-arm` arm64 hosted runners so both AVX2
-  and NEON coverage are PR-visible.
-- Tolerances:
-  - FWHT lanes: absolute/relative `1e-5`.
-  - `score_ip_from_parts`: absolute/relative `1e-5`.
-  - `score_ip_codes_lite`: absolute/relative `1e-5`.
-  - AM source inner product (HNSW/DiskANN): absolute/relative `1e-4`
-    because production SIMD may use fused multiply-add while the scalar
-    reference accumulates with separate operations.
+`make simd-diff` is the authoritative local lane. It runs the public
+`tests/simd_diff.rs` harness and focused in-library differential suites for
+RaBitQ arithmetic, `rabitq32`, `qjl32`, `lut32`, `grouped_pq_block`,
+`int8_approx32`, the real `hamming32` SIMD implementation, and the
+`ec_distann` codec binding. The focused commands are intentional: do not
+replace them with an unfiltered `cargo test`. The lane prints the detected
+host features and the ISA each family exercised. A host-reachable primary
+backend (NEON on aarch64 or AVX2+FMA on x86) returning “unavailable” is a test
+failure, not a skip.
 
-Tolerance changes require a review packet that explains the numeric reason.
-The Miri scalar fallback remains useful for reference-path UB checks, but SIMD
-correctness is owned by this differential lane.
+Current production inventory:
+
+- `prod` TurboQuant split-score and code-to-code score: scalar,
+  AVX2+FMA, and NEON. The `SimdBackend::Avx512` dispatch tier currently enters
+  the AVX2/FMA product scorer; there is no distinct AVX-512 product scorer.
+- FWHT: scalar, AVX2/FMA, and NEON. `rotation.rs` has no separate
+  architecture-specific scoring kernel.
+- RaBitQ arithmetic (`rabitq.rs`): NEON bits 1/4/8, AVX2+FMA bits 1/4/8, and
+  AVX-512 bits 1/4/8; optional BF16 variants require their explicit cargo
+  feature and hardware feature.
+- `rabitq32`: bits=1 and multi-bit bits=2/4 full-block and partial kernels on
+  AVX2+FMA and NEON. Its SVE module is a NEON-routing placeholder, not an SVE
+  implementation.
+- `qjl32`: AVX2 and NEON 32-candidate blocks and 8-candidate octets, scalar
+  remainders below an octet, plus a real SVE/SVE2 block implementation.
+- `lut32`: AVX2 and NEON block/octet/partial/tiled dispatch, plus real
+  SVE/SVE2 block and predicated partial implementations.
+- `grouped_pq_block`: AVX2 and NEON 32-candidate blocks with padded partial
+  dispatch, plus a real SVE/SVE2 block implementation.
+- `int8_approx32`: AVX2, NEON, and NEON SDOT/dotprod full-block and partial
+  paths. SVE/SVE2 currently route through NEON.
+- `hamming32`: NEON XOR/popcount block and partial paths are real SIMD. The
+  AVX2 and SVE modules are scalar/NEON routing placeholders and must not be
+  reported as distinct SIMD execution.
+- HNSW and DiskANN source inner product: scalar, AVX2+FMA, and NEON. DistANN
+  exact source scoring intentionally calls the shared DiskANN implementation.
+
+The common `CandidateBatch` binding carries these kernels into the AMs:
+HNSW uses TurboQuant LUT/tiled/int8/QJL, grouped-PQ, and RaBitQ bits=1; IVF
+uses those families plus RaBitQ bits=2/4; DiskANN uses hamming, grouped-PQ,
+TurboQuant LUT, and RaBitQ bits=1; SPIRE uses TurboQuant LUT/QJL and RaBitQ
+bits=1; DistANN uses grouped-PQ, TurboQuant LUT, and RaBitQ bits=1. DistANN
+has no private SIMD kernel, so its differential test checks direct codec
+scoring against prepared/batch scoring, persisted stride slicing, widths
+1/7/8/9/16/17/31/32/33, full-block plus tail, and IP-to-distance negation.
+
+Equality contracts:
+
+- Integer accumulators and lookup sums (`lut32`, `int8_approx32`, SDOT, and
+  `hamming32`) are bit/integer exact.
+- Grouped-PQ is bit-exact because scalar and vector paths retain group-order
+  accumulation.
+- RaBitQ block and arithmetic paths allow relative/absolute `1e-5`; vector
+  FMA/reduction order differs from the scalar anchor.
+- QJL allows 4 ULP or relative `1e-6`.
+- FWHT and `prod` split/code-to-code scores allow relative/absolute `1e-5`.
+- HNSW/DiskANN source inner product allows relative/absolute `1e-4` because
+  the SIMD implementation may fuse multiply-add while scalar does not.
+
+Tolerance changes require a review packet explaining the numeric reason.
+Hardware-specific execution claims are host-local: Apple arm64 proves NEON
+and, when detected, SDOT; Intel/x86 hosts prove AVX2/AVX-512; Graviton hosts
+prove SVE/SVE2. Unavailable paths must be listed as unexecuted rather than
+inferred from compilation. This local lane does not by itself claim CI
+coverage.
+
+Every new production SIMD scoring path must land with an existing
+scalar/reference entry point, a narrow test/bench-only forced-backend hook
+when dispatch could hide it, boundary and realistic-dimension differential
+fixtures, and a focused command added to `make simd-diff`. The Miri scalar
+fallback remains useful for reference-path UB checks; it is not SIMD
+execution evidence.
 
 ## Fuzzing
 

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -146,7 +146,9 @@ RaBitQ arithmetic, `rabitq32`, `qjl32`, `lut32`, `grouped_pq_block`,
 replace them with an unfiltered `cargo test`. The lane prints the detected
 host features and the ISA each family exercised. A host-reachable primary
 backend (NEON on aarch64 or AVX2+FMA on x86) returning “unavailable” is a test
-failure, not a skip.
+failure, not a skip. Production `prod` scoring is covered through the public
+forced-hook stage; the focused in-library `prod` stage pins the tiled-LUT
+query-shape and lane guards.
 
 Current production inventory:
 
@@ -192,10 +194,11 @@ Equality contracts:
   accumulation.
 - RaBitQ block and arithmetic paths allow relative/absolute `1e-5`; vector
   FMA/reduction order differs from the scalar anchor.
-- QJL scalar/remainder candidates are bit-exact. SIMD 32-candidate blocks
-  allow 4 ULP or relative `1e-6` because vector block reductions change the
-  accumulation order; the batch differential records the ISA returned by the
-  block kernel rather than printing host capability as a proxy.
+- QJL candidates in the scalar remainder below an octet are bit-exact. SIMD
+  8-candidate octets and 32-candidate blocks allow 4 ULP or relative `1e-6`
+  because vector reductions change the accumulation order. The production
+  candidate-batch differential covers widths 1/7/8/9/16/17/31/32/33 through
+  the real block→octet→scalar cascade.
 - FWHT and `prod` split/code-to-code scores allow relative/absolute `1e-5`.
 - HNSW/DiskANN source inner product allows relative/absolute `1e-4` because
   the SIMD implementation may fuse multiply-add while scalar does not.

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -201,8 +201,10 @@ Tolerance changes require a review packet explaining the numeric reason.
 Hardware-specific execution claims are host-local: Apple arm64 proves NEON
 and, when detected, SDOT; Intel/x86 hosts prove AVX2/AVX-512; Graviton hosts
 prove SVE/SVE2. Unavailable paths must be listed as unexecuted rather than
-inferred from compilation. This local lane does not by itself claim CI
-coverage.
+inferred from compilation. Repository CI is manual-dispatch-only; this lane is
+not an automatic pull-request or scheduled gate. Until that policy changes,
+pre-merge evidence is a task-scoped packet containing a local
+`make simd-diff` run from every host class being claimed.
 
 Every new production SIMD scoring path must land with an existing
 scalar/reference entry point, a narrow test/bench-only forced-backend hook

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -192,7 +192,10 @@ Equality contracts:
   accumulation.
 - RaBitQ block and arithmetic paths allow relative/absolute `1e-5`; vector
   FMA/reduction order differs from the scalar anchor.
-- QJL allows 4 ULP or relative `1e-6`.
+- QJL scalar/remainder candidates are bit-exact. SIMD 32-candidate blocks
+  allow 4 ULP or relative `1e-6` because vector block reductions change the
+  accumulation order; the batch differential records the ISA returned by the
+  block kernel rather than printing host capability as a proxy.
 - FWHT and `prod` split/code-to-code scores allow relative/absolute `1e-5`.
 - HNSW/DiskANN source inner product allows relative/absolute `1e-4` because
   the SIMD implementation may fuse multiply-add while scalar does not.
@@ -209,7 +212,9 @@ pre-merge evidence is a task-scoped packet containing a local
 Every new production SIMD scoring path must land with an existing
 scalar/reference entry point, a narrow test/bench-only forced-backend hook
 when dispatch could hide it, boundary and realistic-dimension differential
-fixtures, and a focused command added to `make simd-diff`. The Miri scalar
+fixtures, and a focused command added to `make simd-diff`. Every focused
+command has an explicit expected test count; a renamed or empty filter fails
+the lane. The Miri scalar
 fallback remains useful for reference-path UB checks; it is not SIMD
 execution evidence.
 

--- a/plan/tasks/36-simd-scalar-differential.md
+++ b/plan/tasks/36-simd-scalar-differential.md
@@ -12,8 +12,10 @@ No CI/scheduled trigger is added or claimed by this follow-up.
 ## Scope
 
 Add randomized property-based tests that compare every SIMD scoring/decoding
-implementation against a scalar reference for the same input, and gate them in
-the hardening lanes so regressions are caught at PR time.
+implementation against a scalar reference for the same input, and collect them
+in one hardening lane. Repository CI is currently manual-dispatch-only, so
+pre-merge execution must be recorded in a task-scoped review packet rather than
+described as an automatic PR gate.
 
 Coverage targets — every code path that has both a SIMD and a scalar variant:
 
@@ -86,6 +88,9 @@ Optional follow-on:
   SVE/SVE2 as unavailable, not passed.
 - `make hardening-local` includes `simd-diff` and stays under the existing wall
   clock budget by capping proptest cases per backend.
+- CI does not automatically run this lane on pull requests or a schedule.
+  Until repository CI policy changes, the pre-merge gate is a recorded local
+  `make simd-diff` run on each claimed host class.
 - A deliberately mutated SIMD path (flip a sign in one branch) is caught by
   `simd-diff` and reported as a non-trivial diff in the packet.
 

--- a/plan/tasks/36-simd-scalar-differential.md
+++ b/plan/tasks/36-simd-scalar-differential.md
@@ -91,6 +91,10 @@ Optional follow-on:
 - CI does not automatically run this lane on pull requests or a schedule.
   Until repository CI policy changes, the pre-merge gate is a recorded local
   `make simd-diff` run on each claimed host class.
+- The manual `ci.yml` SIMD matrix invokes the same fail-closed
+  `make simd-diff` lane. Its `ubuntu-24.04-arm` leg is the only CI job that
+  exercises NEON; the separate aarch64 full-test workflow remains reachable
+  only through manual dispatch because it has no active schedule trigger.
 - A deliberately mutated SIMD path (flip a sign in one branch) is caught by
   `simd-diff` and reported as a non-trivial diff in the packet.
 

--- a/plan/tasks/36-simd-scalar-differential.md
+++ b/plan/tasks/36-simd-scalar-differential.md
@@ -1,18 +1,13 @@
 # Task 36: SIMD↔Scalar Differential Validation
 
-Status: **implemented locally for currently-present SIMD paths; needs follow-up
-as new SIMD paths land** — successor to Task 34 (comprehensive hardening).
-The local implementation adds scalar-reference hooks, forced test-only backend
-entry points, `tests/simd_diff.rs`, `make simd-diff`, `hardening-local`
-wiring, and a focused GitHub Actions `simd-diff` matrix over `ubuntu-24.04`
-x64 and `ubuntu-24.04-arm` arm64 runners.
-Current Linux x86 validation passes
-`cargo test --features bench --test simd_diff -- --test-threads=1` with 9/9
-tests passing, including product-quantizer scoring, FWHT, pack/unpack
-roundtrips, HNSW/DiskANN AM source inner-product SIMD lanes, and the production
-1536/4-bit score path. Miri scalar-reference coverage passes 19 `miri_` tests.
-A mutation-control run that perturbed the production score assertion failed as
-expected.
+Status: **review requested for the current local SIMD inventory** — successor
+to Task 34 (comprehensive hardening). The authoritative `make simd-diff` lane
+now includes the original public harness plus focused current-kernel suites
+and DistANN composition coverage. On the July 2026 Apple arm64 development
+host it validates scalar references against production dispatch and forced
+NEON, including SDOT/dotprod. Intel AVX2/AVX-512 and Graviton SVE/SVE2 remain
+hardware-specific execution gaps and are not claimed by that local result.
+No CI/scheduled trigger is added or claimed by this follow-up.
 
 ## Scope
 
@@ -84,28 +79,38 @@ Optional follow-on:
 
 ## Validation
 
-- `make simd-diff` passes on macOS (Neon + scalar) and Linux x86 (Avx2Fma /
-  Avx512 if available + scalar).
-- GitHub Actions runs the same `simd-diff` lane on x64 and arm64 Linux hosted
-  runners so AVX2/FMA and NEON regressions are PR-visible when those host
-  features are available.
+- `make simd-diff` must pass on the current host and print the exercised
+  backend/ISA. A host-reachable NEON or AVX2+FMA backend may not silently skip.
+- Hardware execution is recorded per host. The current Apple arm64 packet
+  proves NEON and SDOT/dotprod; it records Intel AVX2/AVX-512 and Graviton
+  SVE/SVE2 as unavailable, not passed.
 - `make hardening-local` includes `simd-diff` and stays under the existing wall
   clock budget by capping proptest cases per backend.
 - A deliberately mutated SIMD path (flip a sign in one branch) is caught by
   `simd-diff` and reported as a non-trivial diff in the packet.
 
-Current note: no AVX-512 product-quantizer implementation, SIMD
-`unpack_mse_indices` implementation, arch-specific `rotation.rs` path, or
-IVF/SPIRE scan SIMD accumulator exists in this tree. Those items remain covered
-by the "add a diff when the SIMD path exists" rule rather than by dead-code
-tests.
+Current locally validated paths are the `prod` and FWHT NEON paths; RaBitQ
+arithmetic NEON bits 1/4/8; `rabitq32` NEON bits 1/2/4 full and partial;
+`qjl32`, `lut32`, grouped-PQ, int8/SDOT, and real hamming NEON paths;
+HNSW/DiskANN source inner product; and the HNSW/IVF/DiskANN/SPIRE/DistANN
+common candidate-batch bindings covered by their shared kernel suites.
+DistANN additionally has direct-vs-batch codec, stride, tail, negation, and
+shared exact-source-IP tests.
+
+Hardware-specific implementations present but not executed on the Apple host:
+RaBitQ AVX2 and AVX-512 arithmetic, AVX2 variants of the block kernels and
+source IP, and the real QJL/LUT/grouped-PQ SVE/SVE2 blocks. Genuinely deferred
+paths that do not exist are a distinct AVX-512 `prod` scorer, SIMD
+`unpack_mse_indices`, architecture-specific `rotation.rs`, IVF/SPIRE-private
+scan accumulators, and real SVE implementations for RaBitQ32, int8, and
+hamming. Hamming AVX2 is also a placeholder rather than a SIMD path.
 
 ## Exit Criteria
 
 - Every SIMD scoring/decoding function listed above has a paired scalar
   reference and a property-based diff test.
-- `simd-diff` runs in `hardening-local` on at least the host CPU and on the CI
-  matrix (per Task 48) for both NEON and AVX2 paths.
+- `simd-diff` runs in `hardening-local` and proves every backend reachable on
+  the validating host; other hardware stays explicitly unexecuted.
 - `docs/hardening.md` documents the per-metric tolerance and the rationale.
 - The Task 34 `cfg!(miri)` scalar fallbacks remain (they cover Miri runs), but
   are documented as Miri-only — production SIMD coverage is owned here.

--- a/plan/tasks/36-simd-scalar-differential.md
+++ b/plan/tasks/36-simd-scalar-differential.md
@@ -95,6 +95,8 @@ Optional follow-on:
   `make simd-diff` lane. Its `ubuntu-24.04-arm` leg is the only CI job that
   exercises NEON; the separate aarch64 full-test workflow remains reachable
   only through manual dispatch because it has no active schedule trigger.
+  This matrix has not been manually dispatched since the lane began using
+  counted `--lib` stages, so CI-runner symbol resolution remains untested.
 - A deliberately mutated SIMD path (flip a sign in one branch) is caught by
   `simd-diff` and reported as a non-trivial diff in the packet.
 

--- a/reviews/task-36/001-31145-task36-38-hardening-validation/artifacts/2026-07-25-m5-quant-lib-tests.log
+++ b/reviews/task-36/001-31145-task36-38-hardening-validation/artifacts/2026-07-25-m5-quant-lib-tests.log
@@ -1,0 +1,215 @@
+   Compiling ring v0.17.14
+   Compiling rustls-webpki v0.103.13
+   Compiling rustls v0.23.41
+   Compiling tokio-rustls v0.26.4
+   Compiling ecaz v0.1.1 (/Users/peter/tqvector)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 14.80s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-6e663634d39738f7)
+
+running 187 tests
+test quant::codebook::tests::log_gamma_known_values ... ok
+test quant::grouped_pq::tests::grouped_pq_nibble_reads_even_and_odd_groups ... ok
+test quant::codebook::tests::beta_pdf_out_of_range ... ok
+test quant::grouped_pq::tests::pack_grouped_pq_nibbles_packs_even_count ... ok
+test quant::grouped_pq::tests::pack_grouped_pq_nibbles_packs_odd_count ... ok
+test quant::grouped_pq::tests::nearest_centroid_l2_prefers_lowest_distance ... ok
+test quant::grouped_pq::tests::build_grouped_pq_lut_f32_uses_flat_codebooks_by_group ... ok
+test quant::grouped_pq::tests::grouped_pq_score_f32_sums_lut_rows_by_nibble ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::hadamard::tests::miri_fwht_small ... ok
+test quant::hadamard::tests::miri_orthonormal_fwht_small ... ok
+test quant::grouped_pq::tests::encode_grouped_pq_packs_nibbles_from_shared_codebooks ... ok
+test quant::hadamard::tests::tiled_fwht_matches_chunkwise_full_fwht ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::hadamard::tests::fwht_preserves_norm_after_normalization ... ok
+test quant::hadamard::tests::tiled_orthonormal_fwht_preserves_norm_per_tile ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::hamming32::tests::scalar_reference_is_xor_popcount ... ok
+test quant::isa::tests::select_highest_isa_falls_back_to_neon_or_scalar ... ok
+test quant::isa::tests::select_highest_isa_prefers_neon_on_graviton4 ... ok
+test quant::isa::tests::parse_isa_cap_accepts_known_values ... ok
+test quant::isa::tests::cap_encoding_roundtrips ... ok
+test quant::isa::tests::select_highest_isa_prefers_x86_avx2_on_x86_features ... ok
+test quant::isa::tests::select_highest_isa_uses_sve_tiers_only_without_neon ... ok
+test quant::hamming32::tests::partial_is_integer_exact_with_scalar_reference ... ok
+test quant::hamming32::tests::block32_is_integer_exact_with_scalar_reference ... ok
+test quant::isa::tests::capped_selection_limits_but_never_fakes ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... ok
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... ok
+test quant::lut32::neon::tests::transpose_8x16_yields_byte_columns ... ok
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::task124_profile_lut32_block32_and_query_prep ... ignored, Task 124 scorer microprofile; run explicitly with ECAZ_TQ_PROFILE_LOG
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::mse::tests::nearest_centroid_index_prefers_lower_index_on_tie ... ok
+test quant::isa::tests::parse_isa_cap_rejects_unknown_values - should panic ... ok
+test quant::mse::tests::quantize_to_indices_dispatches_unrolled_for_16_centroids ... ok
+test quant::codebook::tests::lloyd_max_b1_centroids_symmetric ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::prod::tests::decode_eight_3bit_aligned_matches_packer ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::mse::tests::branchless_matches_branching_over_random_inputs ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+test quant::codebook::tests::beta_pdf_integrates_to_one ... ok
+test quant::mse::tests::unrolled_16_matches_generic_branchless ... ok
+test quant::grouped_pq::tests::pq_fastscan_quantizer_trait_score_matches_direct_helpers ... ok
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::prod::tests::encode_decode_has_reasonable_fidelity ... ok
+test quant::hadamard::tests::orthonormal_fwht_runtime_path_matches_scalar_on_random_inputs ... ok
+test quant::hadamard::tests::fwht_runtime_path_matches_scalar_on_random_inputs ... ok
+test quant::prod::tests::miri_pack_unpack_mse ... ok
+test quant::prod::tests::miri_pack_unpack_qjl ... ok
+test quant::prod::tests::binary_sign_no_qjl_4bit_keeps_identical_vector_ranked_first ... ok
+test quant::prod::tests::encode_payload_length_matches_spec ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... ok
+test quant::prod::tests::mse_pack_unpack_roundtrip_all_widths ... ok
+test quant::prod::tests::encode_is_deterministic ... ok
+test quant::prod::tests::explicit_lut_no_qjl_4bit_tracks_direct_scoring_with_int16_lut ... ok
+test quant::prod::tests::pack_mse_indices_fast_paths_match_generic ... ok
+test quant::prod::tests::qjl_pack_unpack_roundtrip ... ok
+test quant::prod::tests::binary_sign_query_prep_rejects_qjl_active_lane - should panic ... ok
+test quant::prod::tests::qjl_sign_lanes_exhaustive ... ok
+test quant::prod::tests::code_to_code_score_is_symmetric_and_ignores_qjl ... ok
+test quant::prod::tests::int8_approx_no_qjl_4bit_keeps_identical_vector_ranked_first ... ok
+test quant::prod::tests::explicit_lut_query_prep_rejects_qjl_active_lane - should panic ... ok
+test quant::prod::tests::int8_approx_query_prep_rejects_qjl_active_lane - should panic ... ok
+test quant::prod::tests::cached_quantizer_reuses_instances ... ok
+test quant::prod::tests::quantizer_1536_4bit_disables_unused_qjl_and_lut_state ... ok
+test quant::prod::tests::quantizer_1536_4bit_reallocates_qjl_budget_to_mse ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_binary_sign_query_prep ... ok
+test quant::prod::tests::prepared_query_score_matches_explicit_formula ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_explicit_lut_query_prep ... ok
+test quant::prod::tests::miri_score_ip_encoded ... ok
+test quant::prod::tests::miri_score_ip_codes_lite ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_int8_approx_query_prep ... ok
+test quant::prod::tests::task124_profile_no_qjl_lut_query_prep ... ignored, Task 124 query-prep microprofile; run explicitly with ECAZ_TQ_QUERY_PREP_PROFILE_LOG
+test quant::prod::tests::quantizer_1536_4bit_supports_tiled_lut_query_prep ... ok
+test quant::prod::tests::quantizer_1536_uses_tiled_working_dimension ... ok
+test quant::prod::tests::quantizer_trait_score_matches_inherent_score_ip_encoded ... ok
+test quant::prod::tests::quantizer_no_qjl_lut_min_bound_keeps_or_prunes_exact_score ... ok
+test quant::prod::tests::miri_encode_decode_roundtrip ... ok
+test quant::prod::tests::quantizer_32_4bit_keeps_qjl_and_lut_state_when_active ... ok
+test quant::prod::tests::tiled_lut_no_qjl_4bit_matches_direct_scoring ... ok
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::prod::tests::score_from_parts_honors_supplied_gamma ... ok
+test quant::qjl32::tests::qjl32_batch_with_blocks_and_tail_matches_pre_slice_scorer_bits ... ok
+test quant::prod::tests::score_from_parts_matches_encoded_payload_path ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq::tests::batch_max_prevalidated_matches_scalar_max ... ok
+test quant::rabitq::tests::bit_level_packers_round_trip_all_supported_widths ... ok
+test quant::rabitq::tests::bits1_batch_estimator_matches_scalar_order ... ok
+test quant::rabitq::tests::bits1_batch_estimator_rejects_wrong_width_and_stride ... ok
+test quant::rabitq::tests::bits1_byte_lut_matches_per_bit_decode ... ok
+test quant::rabitq::tests::bits1_byte_lut_scalar_sum_matches_per_bit_decode ... ok
+test quant::rabitq::tests::bits4_batch_estimator_matches_scalar_order ... ok
+test quant::rabitq::tests::bits8_batch_estimator_matches_scalar_order ... ok
+test quant::rabitq::tests::bits8_precompute_matches_lut_decode ... ok
+test quant::rabitq::tests::centered_api_rejects_qbit_bits ... ok
+test quant::rabitq::tests::centered_context_and_scorer_cover_raw_and_degenerate_paths ... ok
+test quant::rabitq::tests::centered_encode_pins_asymmetric_center_tail_and_zero_residual ... ok
+test quant::rabitq::tests::centered_estimator_bound_dominates_error_on_random_vectors ... ok
+test quant::rabitq::tests::centered_estimator_is_exact_on_sign_aligned_residual ... ok
+test quant::rabitq::tests::centered_scorer_floor_boundaries_cover_below_equal_and_above ... ok
+test quant::rabitq::tests::centered_scorer_matches_manual_unit_residual_ip ... ok
+test quant::rabitq::tests::centered_scorer_pins_nontrivial_bound_formula ... ok
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq::tests::custom_rotation_plugs_into_seam ... ok
+test quant::rabitq::tests::dequantized_estimator_scores_reconstructed_payload_and_guards_tail_scalars ... ok
+test quant::rabitq::tests::encode_code_pins_qbit_payload_and_scalars ... ok
+test quant::rabitq::tests::encode_code_pins_zero_vector_tail_and_levels ... ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane - should panic ... FAILED
+test quant::rabitq::tests::estimate_ip_guards_and_bound_are_pinned ... ok
+test quant::rabitq::tests::estimate_ip_o_dot_floor_covers_below_equal_and_above ... ok
+test quant::rabitq::tests::estimator_bound_dominates_error_on_random_vectors ... ok
+test quant::rabitq::tests::estimator_recovers_self_ip_on_sign_aligned_vector ... ok
+test quant::rabitq::tests::hamming_similarity_identity_equals_dim ... ok
+test quant::rabitq::tests::least_squares_estimator_uses_o_dot_as_shrinkage ... ok
+test quant::rabitq::tests::neon_sum_query_dequant_matches_scalar_bits1 ... ok
+test quant::rabitq::tests::neon_sum_query_dequant_matches_scalar_bits4 ... ok
+test quant::rabitq::tests::neon_sum_query_dequant_matches_scalar_bits8 ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+test quant::rabitq::tests::prepared_queries_only_keep_bits1_byte_lut_for_bits1 ... ok
+test quant::rabitq::tests::qbit_code_len_scales_with_bits ... ok
+test quant::rabitq::tests::qbit_encoder_reduces_error_vs_binary ... ok
+test quant::rabitq::tests::qbit_quantize_and_dequantize_pin_level_midpoints ... ok
+test quant::rabitq::tests::qbit_quantize_pins_non_roundtrip_scale_term ... ok
+test quant::rabitq::tests::qbit_rejects_unsupported_bits ... ok
+test quant::rabitq::tests::quantizer_and_prepared_estimator_accessors_are_stable ... ok
+test quant::rabitq::tests::query_scorer_matches_estimator_for_nontrivial_pair ... ok
+test quant::prod::tests::raw_code_score_matches_encoded_lite_path ... ok
+test quant::rabitq::tests::residual_code_is_byte_identical_shape_to_absolute_code ... ok
+test quant::rabitq::tests::residual_estimate_recovers_exact_residual_term ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::rabitq::tests::seeded_srht_cache_keys_include_bits_seed_and_clip ... ok
+test quant::rabitq::tests::sign_sidecar_helpers_pack_exact_words ... ok
+test quant::rabitq::tests::sign_words_from_rotated_matches_manual_pack ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+test quant::rabitq::tests::residual_beats_absolute_on_concentrated_lists ... ok
+test quant::rabitq::tests::residual_scoring_matches_exact_within_tolerance ... ok
+test quant::rabitq::tests::try_estimate_scalar_cutoff_is_monotone_in_threshold ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::rotation::tests::srht_preserves_norm ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::rotation::tests::tiled_srht_roundtrip_1536 ... ok
+test quant::simd::tests::backend_name_matches_detected_backend ... ok
+test quant::rabitq::tests::try_estimate_bound_carrying_cutoff_agrees_with_scalar ... ok
+test quant::simd::tests::detect_backend_honors_forced_scalar ... ok
+test quant::simd::tests::forced_backend_accepts_auto_empty_and_absent ... ok
+test quant::simd::tests::forced_backend_accepts_supported_backend_names ... ok
+test quant::simd::tests::x86_backend_gate_requires_avx2_and_fma ... ok
+test quant::simd::tests::x86_feature_slots_model_task67_kernel_requirements ... ok
+test quant::simd::tests::forced_backend_rejects_unknown_name ... ok
+test quant::rabitq::tests::try_estimate_scalar_cutoff_is_sound_under_non_identity_rotation ... ok
+test quant::rabitq::tests::try_estimate_scalar_cutoff_never_prunes_a_keepable_candidate ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_at_production_dims ... ok
+test quant::hadamard::tests::fwht_runtime_path_matches_scalar_at_large_sizes ... ok
+test quant::rotation::tests::srht_runtime_path_matches_scalar_on_random_inputs ... ok
+test quant::rotation::tests::srht_padded_matches_pad_input_plus_srht ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_with_tail_dims ... ok
+test quant::prod::tests::cached_with_presence_reports_whether_entry_already_existed ... ok
+test quant::rabitq::tests::code_len_matches_dimension ... ok
+test quant::rabitq::tests::srht_seeded_rotation_is_deterministic_and_independent_of_prod ... ok
+test quant::tiled_lut32::tests::run_is_bit_equal_with_production_tiled_scorer ... ok
+test quant::rabitq::tests::encode_then_score_same_vector_is_nonnegative ... ok
+test quant::prod::tests::miri_quantizer_cache_concurrent_init_under_contention ... ok
+test quant::rabitq::tests::persisted_sidecar_helpers_preserve_supported_and_unsupported_lanes ... ok
+test quant::prod::tests::qjl_pre_task104_neon_multi_accum_tolerance_diagnostic ... ok
+test quant::prod::tests::qjl_neon_production_path_matches_scalar_reference_tolerance ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_on_random_inputs ... ok
+
+failures:
+
+---- quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane stdout ----
+
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane' (34260425) panicked at src/quant/prod.rs:1837:5:
+assertion `left == right` failed
+  left: 8
+ right: 16
+note: panic did not contain expected string
+      panic message: "assertion `left == right` failed\n  left: 8\n right: 16"
+ expected substring: "explicit LUT query prep requires the no-QJL 4-bit lane"
+
+failures:
+    quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane
+
+test result: FAILED. 184 passed; 1 failed; 2 ignored; 0 measured; 2052 filtered out; finished in 1.58s
+
+error: test failed, to rerun pass `--lib`

--- a/reviews/task-36/001-31145-task36-38-hardening-validation/artifacts/2026-07-25-m5-simd-diff.log
+++ b/reviews/task-36/001-31145-task36-38-hardening-validation/artifacts/2026-07-25-m5-simd-diff.log
@@ -1,0 +1,21 @@
+   Compiling ring v0.17.14
+   Compiling rustls v0.23.41
+   Compiling rustls-webpki v0.103.13
+   Compiling tokio-rustls v0.26.4
+   Compiling ecaz v0.1.1 (/Users/peter/tqvector)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 25.53s
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-ae859985e3d3f8a8)
+
+running 9 tests
+test am_source_inner_product_simd_matches_scalar_reference ... ok
+test dispatched_code_to_code_score_matches_scalar_reference ... ok
+test dispatched_fwht_matches_scalar_reference ... ok
+test dispatched_score_ip_from_parts_matches_scalar_reference ... ok
+test forced_neon_fwht_matches_scalar_reference_when_available ... ok
+test forced_neon_score_paths_match_scalar_reference_when_available ... ok
+test packed_mse_indices_roundtrip_across_widths ... ok
+test production_1536_4bit_score_path_matches_scalar_reference ... ok
+test three_bit_unpack_fixture_stays_bit_exact ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 24.87s
+

--- a/reviews/task-36/001-31145-task36-38-hardening-validation/artifacts/manifest.md
+++ b/reviews/task-36/001-31145-task36-38-hardening-validation/artifacts/manifest.md
@@ -285,3 +285,42 @@ fixtures for `ec_hnsw`, `ec_ivf`, `ec_diskann`, and `ec_spire` unless noted.
 - Lane: final postmaster state check
 - Command: `script -q -e -c "/home/peter/.pgrx/18.3/pgrx-install/bin/pg_ctl -D /home/peter/.pgrx/data-18 status" reviews/task-36/001-31145-task36-38-hardening-validation/artifacts/task38-final-pg18-status.log`
 - Key result: PG18 postmaster is running without provider environment in the command line.
+
+## 2026-07-25 Apple M5 (NEON) re-review artifacts
+
+Added by reviewer feedback `feedback/2026-07-25-01-reviewer.md`.
+
+- Head SHA: `48fc8ee21`
+- Branch: `task-132-134-tq-optimization-tests`
+- Task bucket / packet: `reviews/task-36/001-31145-task36-38-hardening-validation`
+- Host: Apple M5, macOS (Darwin 25.4.0), aarch64/NEON. No SVE, no AVX2 —
+  x86 and SVE claims in this packet were reviewed statically only.
+- Timestamp: 2026-07-25
+
+### 2026-07-25-m5-simd-diff.log
+
+- Lane: Task 36 `make simd-diff` differential lane, NEON pathway
+- Command: `cargo test --features bench --test simd_diff -- --test-threads=1`
+- Key result: `test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 24.87s`
+- Both `forced_neon_score_paths_match_scalar_reference_when_available` and
+  `forced_neon_fwht_matches_scalar_reference_when_available` executed rather
+  than skipping their `if let Some(..)` availability guard, so the NEON
+  intrinsic bodies were genuinely diffed against the scalar references.
+
+### 2026-07-25-m5-quant-lib-tests.log
+
+- Lane: crate `--lib` unit tests filtered to `quant::`, which is where the
+  post-May block-kernel scalar-diff tests live (`lut32`, `qjl32`, `rabitq32`,
+  `hamming32`, `int8_approx32`, `grouped_pq_block`). This lane is not run by
+  `make simd-diff`, `make hardening-local`, or any CI job.
+- Command: `cargo test --no-default-features --features pg18,bench --lib quant::`
+- Key result: `test result: FAILED. 184 passed; 1 failed; 2 ignored; 0 measured; 2052 filtered out`
+- Failure: `quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane`
+  panics at `src/quant/prod.rs:1837` with `left: 8, right: 16` instead of the
+  expected lane-guard message. Bisected to `3d66bdcf3`, which rewrote
+  `prepare_ip_query_tiled_lut_no_qjl_4bit` to build the f32 LUT inline and
+  dropped the query-length assert and the no-QJL/4-bit lane guard it had
+  previously inherited by delegating to `prepare_ip_query_lut_no_qjl_4bit`.
+- Scope caveat: this is the `quant::`-filtered run (185 tests). A full
+  unfiltered `--lib` sweep was started but had not produced output when this
+  feedback was written; no claim is made here about the remaining 2052 tests.

--- a/reviews/task-36/001-31145-task36-38-hardening-validation/feedback/2026-07-25-01-reviewer.md
+++ b/reviews/task-36/001-31145-task36-38-hardening-validation/feedback/2026-07-25-01-reviewer.md
@@ -1,0 +1,243 @@
+---
+agent: claude
+role: reviewer
+model: claude-opus-5[1m]
+date: 2026-07-25
+seq: 01
+---
+
+# Review Feedback: Task 36 SIMD/Scalar Differential — Apple M5 (NEON) re-review
+
+Scope: Task 36 only (Task 38 not re-reviewed this cycle). Host is an Apple M5,
+so this pass validates the **aarch64/NEON pathway**; AVX2/AVX-512 and SVE
+claims are reviewed statically only and are called out as such.
+
+Head reviewed: `48fc8ee21` on `task-132-134-tq-optimization-tests`.
+
+## Verdict
+
+**CHANGES REQUESTED — the lane itself is healthy, but it no longer covers the
+SIMD surface it is supposed to gate, and it is not gating anything in CI.**
+
+The May packet closed cleanly and the harness it built is good: forced
+`_for_test` backend entry points, scalar references, documented tolerances, and
+a mutation control. That work still passes here. The problem is drift since
+May: the hot-path block kernels that landed in tasks 102/103/111/125 are not in
+the Task 36 lane, and the CI wiring the task claims as its gate is now inert.
+Task 36's own status line already anticipates this — "needs follow-up as new
+SIMD paths land" — and that follow-up is now overdue by four kernel families.
+
+## What passes here (verified on M5)
+
+`make simd-diff` is green on NEON: 9/9.
+
+    reviews/task-36/001-.../artifacts/2026-07-25-m5-simd-diff.log
+
+    test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured;
+    0 filtered out; finished in 24.87s
+
+Both forced-NEON tests (`forced_neon_score_paths_...`,
+`forced_neon_fwht_...`) actually executed rather than skipping via the
+`if let Some(..)` guard, so the NEON intrinsic bodies were genuinely diffed
+against scalar on this host. The forced-backend design from the May cycles is
+doing its job — dispatch pinning is independent of `ECAZ_SIMD`, exactly as
+`docs/hardening.md` claims.
+
+## Finding 1 (HIGH) — `tests/simd_diff.rs` covers the May surface, not today's
+
+`tests/simd_diff.rs` diffs `prod.rs` score paths, `hadamard.rs` FWHT,
+`pack/unpack_mse_indices`, and HNSW/DiskANN source inner product. Since May the
+tree has grown six SIMD kernel families with per-arch implementations that the
+lane does not touch:
+
+| module | backends present | in `simd_diff.rs`? |
+| --- | --- | --- |
+| `src/quant/lut32/` | avx2, neon, sve, scalar | no |
+| `src/quant/qjl32/` | avx2, neon, sve, scalar | no |
+| `src/quant/rabitq32/` | avx2, neon, sve, mb_avx2, mb_neon, scalar | no |
+| `src/quant/hamming32/` | avx2, neon, sve, scalar | no |
+| `src/quant/int8_approx32/` | avx2, neon, sve, scalar | no |
+| `src/quant/grouped_pq_block/` | avx2, neon, sve, scalar | no |
+
+To be fair to the coder: these are **not untested**. Each module carries
+in-tree `#[cfg(test)]` scalar-diff tests, and `lut32`, `qjl32`, and
+`grouped_pq_block` correctly adopted the Task 36 pattern — `*_neon_for_test` /
+`*_avx2_for_test` / `*_sve_for_test` forced entry points, an `Isa` assertion on
+the returned backend, and bit-exact comparison against the module's
+`score_*_scalar` reference. That is the right shape and it is good work.
+
+The gap is placement, not absence: those tests live in the crate's `--lib`
+suite, which is **not** what `make simd-diff`, `make hardening-local`, or the
+CI `simd-diff` job run. Task 36's exit criterion is that the differential lane
+is the gate. Right now the newest and hottest kernels are gated by a suite that
+no CI job executes (see Finding 2).
+
+Recommended: rather than duplicating the module tests into
+`tests/simd_diff.rs`, extend the `simd-diff` **lane** to include them, e.g.
+have `make simd-diff` also run `cargo test --features bench --lib quant::` (or
+a `simd_diff` filter over the module tests), and update `docs/hardening.md` §
+"SIMD/Scalar Differential Validation" to name the block-kernel families and
+their tolerance (bit-exact for the integer/LUT kernels, which is stronger than
+the existing 1e-5/1e-4 float entries and worth stating).
+
+## Finding 2 (HIGH) — the lane is not gating anything; "PR-visible" is stale
+
+`plan/tasks/36-simd-scalar-differential.md`, the packet `request.md`, and
+`docs/hardening.md:146` all state that the `simd-diff` matrix makes AVX2 and
+NEON regressions "PR-visible". At HEAD that is not true:
+
+- `.github/workflows/ci.yml` is `on: workflow_dispatch:` only. `push` and
+  `pull_request` were removed in `1c22a8329` ("Make CI workflows manual-only")
+  and the nightly/weekly `schedule` crons in `67f23b56b` ("Make test workflows
+  manual-only", 2026-06-29). Nothing in `ci.yml` — including `simd-diff` —
+  runs at PR time or on any timer.
+- The only arm64 runner in `ci.yml` is the `simd-diff` matrix leg
+  (`ubuntu-24.04-arm`). Every other job, including `pgrx-pg18`, pins
+  `ubuntu-24.04` x86.
+- `pgrx-pg18` does not run the crate test suite at all — it installs the
+  extension and then runs only `ecaz dev test pg18-preload-pgstat`. The one job
+  that runs `cargo pgrx test` is `pgrx-pg17`, which is additionally gated
+  `if: github.event_name == 'workflow_dispatch'`.
+- `build-matrix-aarch64-linux-gnu.yml` has a `full` job that would run
+  `cargo test --no-default-features --features pg18` on `ubuntu-24.04-arm` —
+  the one lane that would exercise the NEON block kernels from Finding 1 — but
+  it is gated `if: github.event_name == 'schedule' || workflow_dispatch` on a
+  workflow whose trigger block is `workflow_dispatch` only. The schedule arm is
+  dead; the job only ever runs if a human dispatches it.
+
+Net: **the NEON paths of the block kernels have no automated coverage on any
+host.** They run when a developer runs them on an Apple box — which is what
+happened here, and which is how Finding 3 surfaced.
+
+I am not asking the coder to revert the manual-only CI policy; that was a
+deliberate repo-wide decision that post-dates this packet and is out of Task
+36's scope. What Task 36 does own is the accuracy of its own claims. Either:
+
+1. re-arm the `simd-diff` job (and only that job) on `pull_request`, since it
+   is cheap and is the task's stated gate; or
+2. correct the task file, `request.md`, and `docs/hardening.md` to say the lane
+   is manual/dispatch-only, and state what the actual pre-merge gate is.
+
+Option 1 is the one that satisfies the exit criterion. Option 2 keeps the
+criterion unmet but at least stops the docs asserting a gate that does not
+exist. Silently leaving the "PR-visible" wording in place is the one outcome I
+would reject.
+
+## Finding 3 (MEDIUM) — red test at HEAD on aarch64: tiled LUT prep lost its lane guard
+
+    reviews/task-36/001-.../artifacts/2026-07-25-m5-quant-lib-tests.log
+
+    test result: FAILED. 184 passed; 1 failed; 2 ignored; 0 measured;
+    2052 filtered out
+
+    ---- quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane ----
+    panicked at src/quant/prod.rs:1837:5:
+    assertion `left == right` failed
+      left: 8
+     right: 16
+    note: panic did not contain expected string
+      expected substring: "explicit LUT query prep requires the no-QJL 4-bit lane"
+
+(Scope note: this is the `quant::`-filtered `--lib` run, 185 tests. A full
+unfiltered `--lib` sweep was started but had not produced output when this
+feedback was written, so I am not claiming the rest of the suite is green.)
+
+Root cause, bisected to `3d66bdcf3` "Compact TurboQuant LUT scorer table" (the
+task-125 int16-LUT work). Before that commit
+`prepare_ip_query_tiled_lut_no_qjl_4bit` delegated to
+`prepare_ip_query_lut_no_qjl_4bit` and inherited its two asserts. The commit
+made the non-tiled path build an **i16** LUT, so the tiled path — which still
+needs f32 — was rewritten to call `build_prepared_query_lut` directly, and both
+asserts were dropped in the process:
+
+`src/quant/prod.rs:401` (tiled, current):
+
+    assert!(tile_size > 0, "...");
+    let rotated = rotation::srht_padded(query, &self.signs);
+    let lut = build_prepared_query_lut(&rotated[..self.original_dim], &self.codebook, 16);
+
+vs `src/quant/prod.rs:378` (non-tiled, retained):
+
+    assert_eq!(query.len(), self.original_dim, "query length mismatch: ...");
+    assert!(
+        self.bits == 4 && !qjl_enabled(self.original_dim, self.bits),
+        "explicit LUT query prep requires the no-QJL 4-bit lane"
+    );
+
+Severity is MEDIUM, not HIGH, because the production call sites are still
+guarded: `src/am/ec_hnsw/scan.rs:2146` checks
+`int8_approx_no_qjl_4bit_supported()` and raises `pgrx::error!` before calling
+the tiled prep. So this is not a live wrong-answer path today. But the failure
+mode if that guard is ever missed is the silent kind Task 36 exists to catch:
+with a QJL-active/3-bit quantizer the codebook is 8 entries while
+`num_centroids` is hardcoded to 16, so `build_prepared_query_lut` takes its
+8-wide `if let` arm and fills only `dim*8` of a `dim*16` buffer as stride-8
+rows. The consumer then reads stride-16. In debug the `debug_assert_eq!` at
+`prod.rs:1837` catches it; in release it is compiled out and the scan returns
+quietly wrong scores. No panic, no recall floor breach at small scale — the
+exact profile the task's "Why" section describes.
+
+Fix is two lines: restore the length assert and the lane guard in
+`prepare_ip_query_tiled_lut_no_qjl_4bit`. Worth also making
+`build_prepared_query_lut`'s `debug_assert_eq!` a hard `assert_eq!` — it is
+called once per query prep, not per candidate, so it is not on the hot path and
+the release-mode silence is not buying anything measurable. If that cost is
+disputed, measure it; per this repo's rules a "too expensive" claim about a
+once-per-query assert needs a number.
+
+## Finding 4 (LOW) — `int8_approx32` diff tests can pass vacuously
+
+Backend pinning across the block-kernel modules is inconsistent:
+
+- `lut32`, `qjl32`, `grouped_pq_block`: forced `*_for_test` entry points +
+  `assert!(matches!(isa, Isa::Neon))`-style checks. Correct.
+- `hamming32`, `rabitq32`: no forced entry points, but they assert
+  `assert_eq!(isa, host_expected_simd_isa())`, which fails loudly if dispatch
+  falls back. Acceptable.
+- `int8_approx32`: neither. `block32_and_partial_are_bit_equal_with_scalar_reference`
+  and `simd_dim_tails_are_bit_equal_with_scalar_reference` call
+  `score_int8_approx_block32` / `_partial` and compare against
+  `score_int8_approx_scalar`, with no assertion about which backend ran.
+
+`forced_backend_from_env()` in `src/quant/simd.rs:186` means `ECAZ_SIMD=scalar`
+in the environment turns both of those into scalar-vs-scalar comparisons that
+pass while testing nothing. Add the `host_expected_simd_isa()` assertion to
+match `hamming32`, or add `*_for_test` hooks to match `lut32`.
+
+## Finding 5 (LOW) — SVE is unvalidated anywhere
+
+`lut32`, `qjl32`, and `grouped_pq_block` ship `sve.rs` kernels with
+`*_sve_for_test` hooks and tests that early-`return` when
+`runtime_vector_lanes_for_test()` is `None`. Apple Silicon has no SVE, so those
+tests silently no-op here — correct behavior, but it means SVE is diffed on no
+host in this project: the Graviton lane is the manual-dispatch
+`build-matrix-aarch64-linux-gnu.yml` from Finding 2. This is a coverage hole
+worth naming explicitly in the task file rather than leaving implied by the
+"add a diff when the SIMD path exists" rule, which reads as satisfied when it
+is not.
+
+## Answers to the original Reviewer Focus questions
+
+- **SIMD tolerance choices and scalar reference isolation** — still sound for
+  the paths in the lane. The 1e-4 for AM source inner product with the
+  documented FMA rationale is the right call, and the newer kernels asserting
+  bit-exactness (`to_bits()`) is stronger and appropriate for integer/LUT math.
+  `docs/hardening.md` should grow rows for those kernels.
+- **Are the forced backend wrappers narrow enough for bench/test use** — yes,
+  and the pattern propagated well to three of the six new kernel families. Make
+  it all six (Finding 4).
+
+## Recommended actions, ordered
+
+1. Restore the lane guard + length assert in
+   `prepare_ip_query_tiled_lut_no_qjl_4bit`; get `--lib` green on aarch64
+   (Finding 3).
+2. Resolve the "PR-visible" claim — re-arm `simd-diff` on `pull_request`, or
+   correct the task file, `request.md`, and `docs/hardening.md` (Finding 2).
+3. Bring the six block-kernel families into the `simd-diff` lane and document
+   their tolerances (Finding 1).
+4. Add ISA pinning to `int8_approx32` (Finding 4).
+5. Record the SVE coverage hole in the task file (Finding 5).
+
+Items 1 and 2 should land before Task 36 is described as closed for the NEON
+pathway. Items 3–5 are follow-up.

--- a/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/2026-07-25-reviewer-empty-filter-exit0.log
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/2026-07-25-reviewer-empty-filter-exit0.log
@@ -1,0 +1,31 @@
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+   Compiling ecaz v0.1.1 (/private/tmp/wt-task36)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 28.14s
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-066c79309fe4fb1b)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s
+
+EXIT=0

--- a/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/2026-07-25-reviewer-make-simd-diff-repro.log
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/2026-07-25-reviewer-make-simd-diff-repro.log
@@ -1,0 +1,228 @@
+task36 simd-diff: public bench hooks (Prod/FWHT/HNSW/DiskANN)
+cargo test --features bench --test simd_diff -- --test-threads=1 --nocapture
+    Updating crates.io index
+     Locking 452 packages to latest compatible versions
+      Adding arrow-array v55.2.0 (available: v59.1.0)
+      Adding arrow-schema v55.2.0 (available: v59.1.0)
+      Adding criterion v0.5.1 (available: v0.8.2)
+      Adding directories v5.0.1 (available: v6.0.0)
+      Adding generic-array v0.14.7 (available: v0.14.9)
+      Adding hashbrown v0.15.5 (available: v0.17.1)
+      Adding iai-callgrind v0.14.2 (available: v0.16.1)
+      Adding indicatif v0.17.11 (available: v0.18.6)
+      Adding ndarray v0.16.1 (available: v0.17.2)
+      Adding parquet v55.2.0 (available: v59.1.0)
+      Adding pgrx v0.17.0 (available: v0.18.1)
+      Adding pgrx-pg-config v0.17.0 (available: v0.18.1)
+      Adding pgrx-tests v0.17.0 (available: v0.18.1)
+      Adding rand v0.8.7 (available: v0.10.2)
+      Adding rand_chacha v0.3.1 (available: v0.10.0)
+      Adding rand_distr v0.4.3 (available: v0.6.0)
+      Adding reqwest v0.12.28 (available: v0.13.4)
+      Adding sha2 v0.10.9 (available: v0.11.0)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 07s
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-066c79309fe4fb1b)
+
+running 10 tests
+test am_source_inner_product_simd_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_code_to_code_score_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_fwht_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_score_ip_from_parts_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test forced_neon_fwht_matches_scalar_reference_when_available ... ok
+test forced_neon_score_paths_match_scalar_reference_when_available ... ok
+test host_backend_inventory_is_visible ... task36_host arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false unavailable=x86_avx2_fma,x86_avx512
+ok
+test packed_mse_indices_roundtrip_across_widths ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test production_1536_4bit_score_path_matches_scalar_reference ... ok
+test three_bit_unpack_fixture_stays_bit_exact ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.58s
+
+task36 simd-diff: RaBitQ arithmetic SIMD inventory
+cargo test --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 51.93s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 2 tests
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... task36_rabitq kernel=scalar_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=1536 status=exercised
+ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2517 filtered out; finished in 0.00s
+
+task36 simd-diff: rabitq32 bits=1/2/4 block and partial kernels
+cargo test --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.20s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 7 tests
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... task36_rabitq32 bits=2 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=2 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 2512 filtered out; finished in 0.05s
+
+task36 simd-diff: qjl32 block/octet/remainder kernels
+cargo test --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 10 tests
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_batch_with_blocks_and_tail_matches_pre_slice_scorer_bits ... task36_qjl32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2509 filtered out; finished in 0.25s
+
+task36 simd-diff: lut32 block/partial/tiled kernels
+cargo test --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 9 tests
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 2510 filtered out; finished in 0.03s
+
+task36 simd-diff: grouped-PQ block/partial kernels
+cargo test --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 8 tests
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2511 filtered out; finished in 0.00s
+
+task36 simd-diff: int8/SDOT block/partial kernels
+cargo test --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 5 tests
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... ok
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... ok
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... task36_int8_approx32 neon=true dotprod=true widths=1,7,8,9,16,17,31,32,33
+ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2514 filtered out; finished in 0.05s
+
+task36 simd-diff: real hamming32 SIMD kernels
+cargo test --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 3 tests
+test quant::hamming32::tests::block32_is_integer_exact_with_scalar_reference ... ok
+test quant::hamming32::tests::partial_is_integer_exact_with_scalar_reference ... task36_hamming32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::hamming32::tests::scalar_reference_is_xor_popcount ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2516 filtered out; finished in 0.00s
+
+task36 simd-diff: DistANN codec composition, stride, and source IP
+cargo test --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 2 tests
+test am::ec_distann::insert::tests::simd_diff_exact_distance_is_shared_diskann_inner_product_negation ... task36_distann source_inner_product_backend=neon
+ok
+test am::ec_distann::quantizer::tests::simd_diff_distann_codec_batches_match_direct_scalar_scores_across_widths ... task36_distann format=grouped_pq dimensions=64 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=rabitq dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=turboquant dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2517 filtered out; finished in 0.06s
+

--- a/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/2026-07-25-reviewer-prod-tests-red.log
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/2026-07-25-reviewer-prod-tests-red.log
@@ -1,0 +1,68 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 13.49s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 45 tests
+test quant::prod::tests::binary_sign_no_qjl_4bit_keeps_identical_vector_ranked_first ... ok
+test quant::prod::tests::binary_sign_query_prep_rejects_qjl_active_lane - should panic ... ok
+test quant::prod::tests::cached_quantizer_reuses_instances ... ok
+test quant::prod::tests::cached_with_presence_reports_whether_entry_already_existed ... ok
+test quant::prod::tests::code_to_code_score_is_symmetric_and_ignores_qjl ... ok
+test quant::prod::tests::decode_eight_3bit_aligned_matches_packer ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_at_production_dims ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_on_random_inputs ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_with_tail_dims ... ok
+test quant::prod::tests::encode_decode_has_reasonable_fidelity ... ok
+test quant::prod::tests::encode_is_deterministic ... ok
+test quant::prod::tests::encode_payload_length_matches_spec ... ok
+test quant::prod::tests::explicit_lut_no_qjl_4bit_tracks_direct_scoring_with_int16_lut ... ok
+test quant::prod::tests::explicit_lut_query_prep_rejects_qjl_active_lane - should panic ... ok
+test quant::prod::tests::int8_approx_no_qjl_4bit_keeps_identical_vector_ranked_first ... ok
+test quant::prod::tests::int8_approx_query_prep_rejects_qjl_active_lane - should panic ... ok
+test quant::prod::tests::miri_encode_decode_roundtrip ... ok
+test quant::prod::tests::miri_pack_unpack_mse ... ok
+test quant::prod::tests::miri_pack_unpack_qjl ... ok
+test quant::prod::tests::miri_quantizer_cache_concurrent_init_under_contention ... ok
+test quant::prod::tests::miri_score_ip_codes_lite ... ok
+test quant::prod::tests::miri_score_ip_encoded ... ok
+test quant::prod::tests::mse_pack_unpack_roundtrip_all_widths ... ok
+test quant::prod::tests::pack_mse_indices_fast_paths_match_generic ... ok
+test quant::prod::tests::prepared_query_score_matches_explicit_formula ... ok
+test quant::prod::tests::qjl_neon_production_path_matches_scalar_reference_tolerance ... ok
+test quant::prod::tests::qjl_pack_unpack_roundtrip ... ok
+test quant::prod::tests::qjl_pre_task104_neon_multi_accum_tolerance_diagnostic ... ok
+test quant::prod::tests::qjl_sign_lanes_exhaustive ... ok
+test quant::prod::tests::quantizer_1536_4bit_disables_unused_qjl_and_lut_state ... ok
+test quant::prod::tests::quantizer_1536_4bit_reallocates_qjl_budget_to_mse ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_binary_sign_query_prep ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_explicit_lut_query_prep ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_int8_approx_query_prep ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_tiled_lut_query_prep ... ok
+test quant::prod::tests::quantizer_1536_uses_tiled_working_dimension ... ok
+test quant::prod::tests::quantizer_32_4bit_keeps_qjl_and_lut_state_when_active ... ok
+test quant::prod::tests::quantizer_no_qjl_lut_min_bound_keeps_or_prunes_exact_score ... ok
+test quant::prod::tests::quantizer_trait_score_matches_inherent_score_ip_encoded ... ok
+test quant::prod::tests::raw_code_score_matches_encoded_lite_path ... ok
+test quant::prod::tests::score_from_parts_honors_supplied_gamma ... ok
+test quant::prod::tests::score_from_parts_matches_encoded_payload_path ... ok
+test quant::prod::tests::task124_profile_no_qjl_lut_query_prep ... ignored, Task 124 query-prep microprofile; run explicitly with ECAZ_TQ_QUERY_PREP_PROFILE_LOG
+test quant::prod::tests::tiled_lut_no_qjl_4bit_matches_direct_scoring ... ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane - should panic ... FAILED
+
+failures:
+
+---- quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane stdout ----
+
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane' (34328997) panicked at src/quant/prod.rs:1842:5:
+assertion `left == right` failed
+  left: 8
+ right: 16
+note: panic did not contain expected string
+      panic message: "assertion `left == right` failed\n  left: 8\n right: 16"
+ expected substring: "explicit LUT query prep requires the no-QJL 4-bit lane"
+
+failures:
+    quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane
+
+test result: FAILED. 43 passed; 1 failed; 1 ignored; 0 measured; 2474 filtered out; finished in 4.70s
+
+error: test failed, to rerun pass `--lib`

--- a/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/cargo-fmt-check.log
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/cargo-fmt-check.log
@@ -1,0 +1,1784 @@
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/crates/ecaz-cli/src/commands/corpus/load.rs:2191:
+         stop.store(true, Ordering::SeqCst);
+         task.await
+             .map_err(|error| eyre!("build memory monitor task failed: {error}"))??;
+-        if let Some(after) = crate::commands::bench::latency::read_proc_status_memory(backend_pid)
+(B-            .await?
+(B+        if let Some(after) =
+(B+            crate::commands::bench::latency::read_proc_status_memory(backend_pid).await?
+(B         {
+             peak.lock().await.merge(after);
+         }
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/am/ec_diskann/scan.rs:1591:
+         // A chain graph exposes few admissible frontier entries per
+         // round, so the beam cannot widen flushes much here — but
+         // batching rounds must never *increase* the flush count.
+-        let flushes = |p: &FrontierProfile| {
+(B-            p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>()
+(B-        };
+(B+        let flushes =
+(B+            |p: &FrontierProfile| p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>();
+(B         assert!(
+             flushes(&profile) <= flushes(&sequential_profile),
+             "batched rounds must not exceed the sequential flush count"
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/am/ec_ivf/page.rs:3507:
+         "ec_ivf posting entry block sequence",
+         |buffer, block_number| {
+             let decode_started = std::time::Instant::now();
+-            let result =
+(B-                visit_all_ivf_posting_entries_from_buffer(buffer, block_number, payload_len, visitor);
+(B+            let result = visit_all_ivf_posting_entries_from_buffer(
+(B+                buffer,
+(B+                block_number,
+(B+                payload_len,
+(B+                visitor,
+(B+            );
+(B             decode_elapsed += decode_started.elapsed();
+             result
+         },
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/storage/page.rs:341:
+         assert_eq!(second.block_number, base, "same page while it fits");
+         assert_eq!(third.block_number, base + 1, "next page is base+1");
+         // Lookups resolve against the base.
+-        assert_eq!(chain.get_page(first.block_number).unwrap().raw_tuple(first).unwrap(), &[1; 32]);
+(B-        assert_eq!(chain.get_page(third.block_number).unwrap().raw_tuple(third).unwrap(), &[3; 32]);
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(first.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(first)
+(B+                .unwrap(),
+(B+            &[1; 32]
+(B+        );
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(third.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(third)
+(B+                .unwrap(),
+(B+            &[3; 32]
+(B+        );
+(B         // Below-base blocks are not in this chain.
+         assert!(chain.get_page(base - 1).is_none());
+         // pages() carry the base-relative block numbers for write_data_pages.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/src/am/ec_diskann/options.rs:194:
+ }
+
+ pub(super) fn current_beam_width() -> usize {
+-    usize::try_from(ECDISKANN_BEAM_WIDTH_GUC.get()).unwrap_or(1).max(1)
+(B+    usize::try_from(ECDISKANN_BEAM_WIDTH_GUC.get())
+(B+        .unwrap_or(1)
+(B+        .max(1)
+(B }
+
+ pub(super) fn scan_profile_notice_enabled() -> bool {
+Diff in /Users/peter/dev/tqvector/src/am/ec_diskann/scan.rs:1591:
+         // A chain graph exposes few admissible frontier entries per
+         // round, so the beam cannot widen flushes much here — but
+         // batching rounds must never *increase* the flush count.
+-        let flushes = |p: &FrontierProfile| {
+(B-            p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>()
+(B-        };
+(B+        let flushes =
+(B+            |p: &FrontierProfile| p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>();
+(B         assert!(
+             flushes(&profile) <= flushes(&sequential_profile),
+             "batched rounds must not exceed the sequential flush count"
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/build_gate.rs:358:
+         if rt_index <= 0 || rt_index > table_length {
+             continue;
+         }
+-        let rte = unsafe {
+(B-            pg_sys::list_nth(stmt.rtable, rt_index - 1).cast::<pg_sys::RangeTblEntry>()
+(B-        };
+(B+        let rte =
+(B+            unsafe { pg_sys::list_nth(stmt.rtable, rt_index - 1).cast::<pg_sys::RangeTblEntry>() };
+(B         let Some(rte) = (unsafe { rte.as_ref() }) else {
+             continue;
+         };
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/canonical_wire.rs:20:
+     code: &str,
+     field: &str,
+ ) -> Result<[u8; N], String> {
+-    bytes.try_into().map_err(|bytes: Vec<u8>| {
+(B-        format!(
+(B-            "{code}: {field} is {} bytes, expected {N}",
+(B-            bytes.len()
+(B-        )
+(B-    })
+(B+    bytes
+(B+        .try_into()
+(B+        .map_err(|bytes: Vec<u8>| format!("{code}: {field} is {} bytes, expected {N}", bytes.len()))
+(B }
+
+-pub(crate) fn fixed_digest(
+(B-    bytes: Vec<u8>,
+(B-    code: &str,
+(B-    field: &str,
+(B-) -> Result<[u8; 32], String> {
+(B+pub(crate) fn fixed_digest(bytes: Vec<u8>, code: &str, field: &str) -> Result<[u8; 32], String> {
+(B     fixed_bytes(bytes, code, field)
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/coordinator_retirement.rs:508:
+                             .value::<Vec<u8>>()
+                             .map_err(|_| "EC_EPOCH_STATE: retire digest decode failed".to_owned())?
+                             .ok_or_else(|| "EC_EPOCH_STATE: retire digest is NULL".to_owned())?,
+-                        state: RetireDecisionState::parse(&row["decision_state"]
+(B-                            .value::<String>()
+(B-                            .map_err(|_| "EC_EPOCH_STATE: retire state decode failed".to_owned())?
+(B-                            .ok_or_else(|| "EC_EPOCH_STATE: retire state is NULL".to_owned())?)?,
+(B+                        state: RetireDecisionState::parse(
+(B+                            &row["decision_state"]
+(B+                                .value::<String>()
+(B+                                .map_err(|_| {
+(B+                                    "EC_EPOCH_STATE: retire state decode failed".to_owned()
+(B+                                })?
+(B+                                .ok_or_else(|| "EC_EPOCH_STATE: retire state is NULL".to_owned())?,
+(B+                        )?,
+(B                         xmin: row["decision_xmin"]
+                             .value::<String>()
+                             .map_err(|_| {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/coordinator_retirement.rs:658:
+                         stored.build_id.into(),
+                     ],
+                 )
+-                .map_err(|error| {
+(B-                    format!("EC_EPOCH_STATE: head-sample reclaim failed: {error}")
+(B-                })?;
+(B+                .map_err(|error| format!("EC_EPOCH_STATE: head-sample reclaim failed: {error}"))?;
+(B             Ok::<(), String>(())
+         })?;
+         let updated = Spi::connect_mut(|client| {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/cost.rs:67:
+                 let constants = unsafe { current_planner_cost_constants() };
+                 // Per-query work is BW x H expansions (NFR-019); model the
+                 // search breadth as that product.
+-                let ef_search = i32::try_from(
+(B-                    options::current_beam_width() * options::current_hop_rounds(),
+(B-                )
+(B-                .unwrap_or(i32::MAX);
+(B+                let ef_search =
+(B+                    i32::try_from(options::current_beam_width() * options::current_hop_rounds())
+(B+                        .unwrap_or(i32::MAX);
+(B                 estimate_planner_cost(
+                     PlannerCostInputs {
+                         index_pages: index_pages_value,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/custom_scan.rs:1208:
+         .iter()
+         .take(previous_proven)
+         .position(|output| {
+-            output
+(B-                .as_ref()
+(B-                .and_then(materialized_remote_output_vec_id)
+(B-                == Some(vec_id)
+(B+            output.as_ref().and_then(materialized_remote_output_vec_id) == Some(vec_id)
+(B         })?;
+     previous_outputs.get_mut(position)?.take()
+ }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/custom_scan.rs:1773:
+ #[cfg(test)]
+ mod materialization_candidate_tests {
+     use super::{
+-        pending_materialization_window, take_materialized_remote_output_by_id,
+(B-        CustomScanOutputRow,
+(B+        pending_materialization_window, take_materialized_remote_output_by_id, CustomScanOutputRow,
+(B     };
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:85:
+     // are not already tombstoned (monotone: never re-flip).
+     let mut to_tombstone: Vec<ItemPointer> = Vec::new();
+     for (_vec_id, record_tid) in &directory {
+-        let raw = read_raw_tuple_bytes_from_relation(
+(B-            handle,
+(B-            *record_tid,
+(B-            "ec_distann tombstone scan",
+(B-        )?;
+(B+        let raw =
+(B+            read_raw_tuple_bytes_from_relation(handle, *record_tid, "ec_distann tombstone scan")?;
+(B         if raw.first().copied() != Some(DISTANN_NODE_TAG)
+             || raw.len() < DISTANN_NODE_HEAP_TID_OFFSET + 6
+         {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:180:
+     let handle = NonNull::new(index_relation).ok_or_else(|| {
+         DistannExpandError::Internal("ec_distann tombstone needs a valid index relation".to_owned())
+     })?;
+-    let metadata =
+(B-        read_metadata_from_index_handle(handle).map_err(DistannExpandError::Internal)?;
+(B+    let metadata = read_metadata_from_index_handle(handle).map_err(DistannExpandError::Internal)?;
+(B     super::require_legacy_local_storage(&metadata, "ec_distann tombstone")
+         .map_err(DistannExpandError::GenerationMissing)?;
+     if vec_ids.is_empty() {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:205:
+                 "ec_distann tombstone: vec_id {vec_id:#018x} is not in the directory"
+             ))
+         })?;
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, record_tid, "ec_distann tombstone by vec_id")
+(B-                .map_err(DistannExpandError::Internal)?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(
+(B+            handle,
+(B+            record_tid,
+(B+            "ec_distann tombstone by vec_id",
+(B+        )
+(B+        .map_err(DistannExpandError::Internal)?;
+(B         let flags = u16::from_le_bytes(
+             raw[DISTANN_NODE_FLAGS_OFFSET..DISTANN_NODE_FLAGS_OFFSET + 2]
+                 .try_into()
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:358:
+ /// Append one delta tuple on a freshly-extended page (one entry per page: a
+ /// dim-1536 entry is ~6 KB, near a page anyway, and the buffer is bounded).
+ /// WAL-logged. Returns the new tuple's TID.
+-fn append_delta_tuple(
+(B-    handle: RelationHandle,
+(B-    payload: Vec<u8>,
+(B-) -> Result<ItemPointer, String> {
+(B+fn append_delta_tuple(handle: RelationHandle, payload: Vec<u8>) -> Result<ItemPointer, String> {
+(B     let buffer = LockedBufferGuard::read_main_locked_handle(
+         handle,
+         P_NEW,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch.rs:214:
+             let mut id = base_identity();
+             mutate(&mut id);
+             let changed = compute_epoch_fingerprint(&id, DISTANN_EPOCH_FINGERPRINT_V1);
+-            assert_ne!(base, changed, "mutator {index} did not change the fingerprint");
+(B+            assert_ne!(
+(B+                base, changed,
+(B+                "mutator {index} did not change the fingerprint"
+(B+            );
+(B             assert!(!fingerprints_match(&base, &changed));
+         }
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch_manifest.rs:57:
+     Ok(result)
+ }
+
+-fn read_metadata(index_oid: pg_sys::Oid, caller: &'static str) -> Result<DistannMetadataPage, String> {
+(B+fn read_metadata(
+(B+    index_oid: pg_sys::Oid,
+(B+    caller: &'static str,
+(B+) -> Result<DistannMetadataPage, String> {
+(B     let guard = IndexRelationGuard::open(
+         index_oid,
+         pg_sys::AccessShareLock as pg_sys::LOCKMODE,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch_manifest.rs:175:
+         name!(in_flight_count, i64),
+     ),
+ > {
+-    let metadata =
+(B-        read_metadata(index_regclass, "ec_distann_epoch_status").unwrap_or_else(|e| pgrx::error!("{e}"));
+(B+    let metadata = read_metadata(index_regclass, "ec_distann_epoch_status")
+(B+        .unwrap_or_else(|e| pgrx::error!("{e}"));
+(B     TableIterator::new(std::iter::once((
+         epoch_state_name(metadata.epoch_state).to_owned(),
+         metadata.active_epoch as i64,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch_manifest.rs:192:
+ fn ec_distann_debug_set_in_flight(index_regclass: pg_sys::Oid, count: i64) {
+     let count = u32::try_from(count)
+         .unwrap_or_else(|_| pgrx::error!("ec_distann_debug_set_in_flight: count out of range"));
+-    with_metadata_mut(index_regclass, "ec_distann_debug_set_in_flight", |metadata| {
+(B-        metadata.in_flight_count = count;
+(B-        Ok(())
+(B-    })
+(B+    with_metadata_mut(
+(B+        index_regclass,
+(B+        "ec_distann_debug_set_in_flight",
+(B+        |metadata| {
+(B+            metadata.in_flight_count = count;
+(B+            Ok(())
+(B+        },
+(B+    )
+(B     .unwrap_or_else(|e| pgrx::error!("{e}"));
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/expand.rs:58:
+                     tid.block_number, tid.offset_number
+                 ));
+             }
+-            DistannNodeTuple::decode_into(raw, self.graph_degree_r, self.code_len, &mut self.pooled_node)
+(B+            DistannNodeTuple::decode_into(
+(B+                raw,
+(B+                self.graph_degree_r,
+(B+                self.code_len,
+(B+                &mut self.pooled_node,
+(B+            )
+(B         })?;
+         match visit {
+             LockedPageTupleVisit::Present(()) => Ok(()),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/handoff_wire.rs:79:
+     pub(crate) fn from_descriptor(
+         descriptor: &super::generation_descriptor::DistannGenerationDescriptor,
+     ) -> Result<Self, String> {
+-        let binding = super::quantizer::DistannCodecBinding::from_artifact(
+(B-            &descriptor.codec_artifact,
+(B-        )?;
+(B+        let binding =
+(B+            super::quantizer::DistannCodecBinding::from_artifact(&descriptor.codec_artifact)?;
+(B         Self::new(
+             binding.code_len(usize::from(descriptor.dimensions))?,
+             usize::from(descriptor.graph_degree),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/head_cache.rs:132:
+         )
+     };
+     let head_seed = metadata.seed ^ DISTANN_HEAD_GRAPH_SEED_WRAP;
+-    let head_entry = crate::am::approximate_medoid(
+(B-        head_vectors.len(),
+(B-        head_vectors.len(),
+(B-        head_seed,
+(B-        head_dist,
+(B-    );
+(B+    let head_entry =
+(B+        crate::am::approximate_medoid(head_vectors.len(), head_vectors.len(), head_seed, head_dist);
+(B     let (head_graph, _stats) = crate::am::build_vamana_graph_with_stats(
+         head_vectors.len(),
+         head_entry,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/identity.rs:43:
+
+ /// vec_id for a heap TID (local mode; single-node posture only).
+ pub(crate) fn vec_id_from_local_heap_tid(heap_tid: ItemPointer) -> u64 {
+-    let packed =
+(B-        (u64::from(heap_tid.block_number) << 16) | u64::from(heap_tid.offset_number);
+(B+    let packed = (u64::from(heap_tid.block_number) << 16) | u64::from(heap_tid.offset_number);
+(B     fmix64(packed ^ DISTANN_VEC_ID_DOMAIN_LOCAL)
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:100:
+     let mut pairwise = vec![vec![0.0_f32; n]; n];
+     for left in 0..n {
+         for right in (left + 1)..n {
+-            let distance =
+(B-                exact_distance(&candidates[left].source_vector, &candidates[right].source_vector);
+(B+            let distance = exact_distance(
+(B+                &candidates[left].source_vector,
+(B+                &candidates[right].source_vector,
+(B+            );
+(B             pairwise[left][right] = distance;
+             pairwise[right][left] = distance;
+         }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:183:
+         return Err("ec_distann backlink planning max_degree must be > 0".to_owned());
+     }
+     // Already linked (idempotent — a re-inserted/duplicate edge is a no-op).
+-    if target.current_neighbors.iter().any(|n| n.vec_id == new_vec_id) {
+(B+    if target
+(B+        .current_neighbors
+(B+        .iter()
+(B+        .any(|n| n.vec_id == new_vec_id)
+(B+    {
+(B         return Ok(target.current_neighbors.iter().map(|n| n.vec_id).collect());
+     }
+     // Free slot: append, preserving existing edges.
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:306:
+     let new_code = binding.encode(new_source_vector);
+
+     // Directory first — the descent and the collision guard both need it.
+-    let directory =
+(B-        read_directory_from_relation(handle, metadata.directory_head, metadata.node_count as usize)?;
+(B+    let directory = read_directory_from_relation(
+(B+        handle,
+(B+        metadata.directory_head,
+(B+        metadata.node_count as usize,
+(B+    )?;
+(B     // 167-003-P2: reject a vec_id collision BEFORE appending. The directory is a
+     // strict-ascending vec_id set (the reader rejects duplicates); a duplicate
+     // insert (e.g. a retried fold) must error, never append a second record for
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:395:
+         })?;
+         let raw = read_raw_tuple_bytes_from_relation(handle, tid, "ec_distann insert forward")?;
+         let node = DistannNodeTuple::decode(&raw, graph_degree_r, code_len)?;
+-        forward.push(DistannInsertNeighbor { vec_id: fid, code: node.search_code });
+(B+        forward.push(DistannInsertNeighbor {
+(B+            vec_id: fid,
+(B+            code: node.search_code,
+(B+        });
+(B         forward_tids.push(tid);
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:527:
+             .map_err(|e| format!("ec_distann graph insert node add failed: {e:?}"))?
+     };
+     wal_txn.finish();
+-    Ok(ItemPointer { block_number, offset_number })
+(B+    Ok(ItemPointer {
+(B+        block_number,
+(B+        offset_number,
+(B+    })
+(B }
+
+ /// Amend a forward neighbor's adjacency to include `new_vec_id`, WAL-logged in
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:556:
+         pg_sys::BUFFER_LOCK_EXCLUSIVE as i32,
+     )
+     .ok_or_else(|| {
+-        format!("ec_distann backlink: could not open block {}", neighbor_tid.block_number)
+(B+        format!(
+(B+            "ec_distann backlink: could not open block {}",
+(B+            neighbor_tid.block_number
+(B+        )
+(B     })?;
+     let r = usize::from(graph_degree_r);
+     let vec_ids_off = distann_node_neighbor_vec_ids_offset(code_len);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:738:
+         let samples = vec![
+             (10_u64, vec![0.99, 0.01, 0.0]), // closest
+             (20, vec![0.0, 1.0, 0.0]),
+-            (30, vec![0.9, 0.1, 0.0]),   // 2nd closest
+(B-            (40, vec![-1.0, 0.0, 0.0]),  // farthest
+(B+            (30, vec![0.9, 0.1, 0.0]),  // 2nd closest
+(B+            (40, vec![-1.0, 0.0, 0.0]), // farthest
+(B         ];
+         let ranked = rank_insert_candidates(&new_vec, &samples, 2).unwrap();
+         assert_eq!(ranked.len(), 2, "limit respected");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:765:
+         let r: u16 = 4;
+         let code_len = 8;
+         let fwd = vec![
+-            DistannInsertNeighbor { vec_id: 111, code: vec![1_u8; code_len] },
+(B-            DistannInsertNeighbor { vec_id: 222, code: vec![2_u8; code_len] },
+(B+            DistannInsertNeighbor {
+(B+                vec_id: 111,
+(B+                code: vec![1_u8; code_len],
+(B+            },
+(B+            DistannInsertNeighbor {
+(B+                vec_id: 222,
+(B+                code: vec![2_u8; code_len],
+(B+            },
+(B         ];
+         let node = build_insert_node_tuple(
+             999,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:773:
+-            ItemPointer { block_number: 3, offset_number: 7 },
+(B+            ItemPointer {
+(B+                block_number: 3,
+(B+                offset_number: 7,
+(B+            },
+(B             vec![9_u8; code_len],
+             &fwd,
+             r,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:778:
+         )
+         .unwrap();
+         assert_eq!(node.vec_id, 999);
+-        assert_eq!(node.neighbor_count, 2, "count = real neighbors, not padding");
+(B+        assert_eq!(
+(B+            node.neighbor_count, 2,
+(B+            "count = real neighbors, not padding"
+(B+        );
+(B         assert_eq!(node.neighbor_vec_ids.len(), r as usize, "fixed R slots");
+         assert_eq!(node.neighbor_vec_ids[0], 111);
+-        assert_eq!(node.neighbor_vec_ids[2], 0, "slots past count are zero-padded");
+(B+        assert_eq!(
+(B+            node.neighbor_vec_ids[2], 0,
+(B+            "slots past count are zero-padded"
+(B+        );
+(B         assert!(!node.tombstoned);
+         // Round-trips through the on-disk encoding at fixed length.
+         let encoded = node.encode(r, code_len).unwrap();
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:788:
+         assert_eq!(encoded.len(), DistannNodeTuple::encoded_len(r, code_len));
+-        assert_eq!(DistannNodeTuple::decode(&encoded, r, code_len).unwrap(), node);
+(B+        assert_eq!(
+(B+            DistannNodeTuple::decode(&encoded, r, code_len).unwrap(),
+(B+            node
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:794:
+         let code_len = 8;
+         // Too many neighbors for R.
+         let many: Vec<_> = (0..5)
+-            .map(|i| DistannInsertNeighbor { vec_id: i, code: vec![0_u8; code_len] })
+(B+            .map(|i| DistannInsertNeighbor {
+(B+                vec_id: i,
+(B+                code: vec![0_u8; code_len],
+(B+            })
+(B             .collect();
+         assert!(
+-            build_insert_node_tuple(1, ItemPointer::INVALID, vec![0; code_len], &many, 4, code_len)
+(B-                .is_err(),
+(B+            build_insert_node_tuple(
+(B+                1,
+(B+                ItemPointer::INVALID,
+(B+                vec![0; code_len],
+(B+                &many,
+(B+                4,
+(B+                code_len
+(B+            )
+(B+            .is_err(),
+(B             "neighbors > R rejected"
+         );
+         // Wrong search_code length.
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:807:
+             "search_code len mismatch rejected"
+         );
+         // Wrong neighbor code length.
+-        let bad = vec![DistannInsertNeighbor { vec_id: 1, code: vec![0_u8; 4] }];
+(B+        let bad = vec![DistannInsertNeighbor {
+(B+            vec_id: 1,
+(B+            code: vec![0_u8; 4],
+(B+        }];
+(B         assert!(
+-            build_insert_node_tuple(1, ItemPointer::INVALID, vec![0; code_len], &bad, 4, code_len)
+(B-                .is_err(),
+(B+            build_insert_node_tuple(
+(B+                1,
+(B+                ItemPointer::INVALID,
+(B+                vec![0; code_len],
+(B+                &bad,
+(B+                4,
+(B+                code_len
+(B+            )
+(B+            .is_err(),
+(B             "neighbor code len mismatch rejected"
+         );
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:827:
+             ],
+         };
+         let kept = plan_insert_backlink(&target, 999, &[0.95, 0.05, 0.0], 1.2, 4).unwrap();
+-        assert_eq!(kept, vec![10, 20, 999], "free slot -> append, edges preserved");
+(B+        assert_eq!(
+(B+            kept,
+(B+            vec![10, 20, 999],
+(B+            "free slot -> append, edges preserved"
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:853:
+         let target = DistannBacklinkTarget {
+             vec_id: 100,
+             source_vector: vec![1.0, 0.0, 0.0],
+-            current_neighbors: vec![candidate(999, &[0.9, 0.1, 0.0]), candidate(10, &[0.8, 0.2, 0.0])],
+(B+            current_neighbors: vec![
+(B+                candidate(999, &[0.9, 0.1, 0.0]),
+(B+                candidate(10, &[0.8, 0.2, 0.0]),
+(B+            ],
+(B         };
+         let kept = plan_insert_backlink(&target, 999, &[0.9, 0.1, 0.0], 1.2, 4).unwrap();
+-        assert_eq!(kept, vec![999, 10], "already-linked -> unchanged (idempotent)");
+(B+        assert_eq!(
+(B+            kept,
+(B+            vec![999, 10],
+(B+            "already-linked -> unchanged (idempotent)"
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:863:
+     fn select_rejects_bad_input() {
+         let source = [1.0_f32, 0.0];
+-        assert!(select_insert_forward_neighbors(&[], &[], 1.2, 3).is_err(), "empty source");
+(B+        assert!(
+(B+            select_insert_forward_neighbors(&[], &[], 1.2, 3).is_err(),
+(B+            "empty source"
+(B+        );
+(B         assert!(
+             select_insert_forward_neighbors(&source, &[], 0.5, 3).is_err(),
+             "alpha < 1.0"
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:11:
+ //! materialization (Tasks 162–179).
+
+ mod ambuild;
+-mod build_gate;
+(B mod build_coordinator;
++mod build_gate;
+(B mod coordinator_abandonment;
+ #[cfg(any(test, feature = "pg_test"))]
++pub(crate) use self::ambuild::read_metadata_from_index;
+(B+#[cfg(any(test, feature = "pg_test"))]
+(B+pub(crate) use self::ambuild::test_physical_capture_dead_callback_does_not_access_datums;
+(B+pub(crate) use self::ambuild::{build_physical_graph_workspace, capture_physical_source_rows};
+(B+#[cfg(any(test, feature = "pg_test"))]
+(B pub(crate) use self::build_coordinator::build_session_lock_count_for_test;
+ #[cfg(any(test, feature = "pg_test"))]
+ pub(crate) use self::custom_scan::{
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:21:
+     exec_state_context_cleanups_for_test, reset_exec_state_context_cleanups_for_test,
+ };
+-#[cfg(any(test, feature = "pg_test"))]
+(B-pub(crate) use self::ambuild::read_metadata_from_index;
+(B-pub(crate) use self::ambuild::{
+(B-    build_physical_graph_workspace, capture_physical_source_rows,
+(B-};
+(B-#[cfg(any(test, feature = "pg_test"))]
+(B-pub(crate) use self::ambuild::{
+(B-    test_physical_capture_dead_callback_does_not_access_datums,
+(B-};
+(B mod canonical_wire;
+-mod cost;
+(B mod coordinator_retirement;
++mod cost;
+(B mod custom_scan;
+ mod dml;
+ mod epoch;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:51:
+ mod head_sample;
+ mod identity;
+ mod insert;
+-mod lifecycle_wire;
+(B mod lifecycle_guard;
+ mod lifecycle_state;
++mod lifecycle_wire;
+(B mod manifest_v2;
+ mod node_registry;
+ mod options;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:80:
+ pub(crate) mod scan;
+ mod shard_build;
+ mod source_spool;
+-mod traversal_replica;
+(B #[cfg(feature = "distann-head-attribution-benchmark")]
+ pub(crate) mod stage_counters;
++mod traversal_replica;
+(B pub mod tuple;
+
+ pub(crate) fn quote_ident(identifier: &str) -> String {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:90:
+ }
+
+ #[cfg(any(test, feature = "pg_test"))]
+-pub(crate) use self::generation_catalog::extension_relation_name as catalog_relation_name;
+(B-#[cfg(any(test, feature = "pg_test"))]
+(B pub(crate) use self::coordinator_retirement::ensure_fingerprint_not_retiring as ensure_fingerprint_not_retiring_for_test;
++#[cfg(any(test, feature = "pg_test"))]
+(B+pub(crate) use self::generation_catalog::extension_relation_name as catalog_relation_name;
+(B pub use self::generation_descriptor::{
+     roster_digest, DistannBuildOptions, DistannBuildSpec, DistannCodecArtifact,
+     DistannGenerationDescriptor, DistannHeadPolicy, DistannOwnerExpectation, DistannRosterEntry,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:107:
+     DISTANN_GENERATION_DESCRIPTOR_PLACEMENT_HASH_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET, DISTANN_GENERATION_DESCRIPTOR_VERSION,
+     DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET, DISTANN_GRAPH_RECORD_VERSION,
+-    DISTANN_HANDOFF_WIRE_VERSION,
+(B-    DISTANN_PHYSICAL_INDEX_FORMAT_VERSION, DISTANN_PLACEMENT_HASH_VERSION,
+(B+    DISTANN_HANDOFF_WIRE_VERSION, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B+    DISTANN_PLACEMENT_HASH_VERSION,
+(B };
++#[cfg(any(test, feature = "pg_test"))]
+(B+pub(crate) use self::handoff_router::{DistannHandoffRouteIdentity, DistannStageAck};
+(B+pub(crate) use self::handoff_wire::restore_owner_stream_hash_state;
+(B pub use self::handoff_wire::{
+     owner_stream_digest, DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape,
+     DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:122:
+     DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET,
+ };
+ #[cfg(any(test, feature = "pg_test"))]
+-pub(crate) use self::handoff_router::{DistannHandoffRouteIdentity, DistannStageAck};
+(B-pub(crate) use self::handoff_wire::restore_owner_stream_hash_state;
+(B-#[cfg(any(test, feature = "pg_test"))]
+(B pub(crate) use self::identity::vec_id_from_source_identity;
+ pub use self::lifecycle_wire::{
+     DistannAbandonBindingAuditV1, DistannAbandonedBinding, DistannAbandonedBindingSetV1,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:131:
+     DistannBuildCandidateV1, DistannCancelPublishAuditV1, DistannPublishedEpochIdentity,
+-    DistannRetireDecisionV1,
+(B-    DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+(B+    DistannRetireDecisionV1, DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+(B     DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET, DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES,
+     DISTANN_ABANDONED_BINDING_SET_VERSION, DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+     DISTANN_ABANDON_BINDING_AUDIT_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:140:
+     DISTANN_ABANDON_BINDING_AUDIT_VERSION, DISTANN_ABANDON_BINDING_AUDIT_VERSION_OFFSET,
+     DISTANN_BUILD_CANDIDATE_BUILD_SPEC_LENGTH_OFFSET, DISTANN_BUILD_CANDIDATE_FIXED_PREFIX_BYTES,
+     DISTANN_BUILD_CANDIDATE_REGISTRATION_DIGEST_OFFSET, DISTANN_BUILD_CANDIDATE_VERSION,
+-    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET,
+(B-    DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B+    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B     DISTANN_CANCEL_PUBLISH_AUDIT_COORDINATOR_UUID_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_EPOCH_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_FINGERPRINT_LENGTH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:148:
+     DISTANN_CANCEL_PUBLISH_AUDIT_FIXED_PREFIX_BYTES, DISTANN_CANCEL_PUBLISH_AUDIT_VERSION,
+-    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET,
+(B+    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET, DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET,
+(B     DISTANN_RETIRE_DECISION_EPOCH_OFFSET, DISTANN_RETIRE_DECISION_FINGERPRINT_LENGTH_OFFSET,
+     DISTANN_RETIRE_DECISION_FIXED_PREFIX_BYTES, DISTANN_RETIRE_DECISION_TARGET_BUILD_ID_OFFSET,
+     DISTANN_RETIRE_DECISION_VERSION, DISTANN_RETIRE_DECISION_VERSION_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:263:
+     }
+
+     pub fn decode(input: &[u8]) -> Result<Self, String> {
+-        if !matches!(input.len(), DISTANN_METADATA_BYTES | DISTANN_CONTROL_METADATA_BYTES) {
+(B+        if !matches!(
+(B+            input.len(),
+(B+            DISTANN_METADATA_BYTES | DISTANN_CONTROL_METADATA_BYTES
+(B+        ) {
+(B             return Err(format!(
+                 "distann metadata length mismatch: got {}, expected {DISTANN_METADATA_BYTES} or {DISTANN_CONTROL_METADATA_BYTES}",
+                 input.len()
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:332:
+             head_sample_head: ItemPointer::decode(&input[44..50])?,
+             delta_buffer_head: ItemPointer::decode(&input[50..56])?,
+             codec_subvector_count: u16::from_le_bytes(
+-                input[56..58].try_into().expect("codec_subvector_count bytes"),
+(B+                input[56..58]
+(B+                    .try_into()
+(B+                    .expect("codec_subvector_count bytes"),
+(B             ),
+             codec_subvector_dim: u16::from_le_bytes(
+                 input[58..60].try_into().expect("codec_subvector_dim bytes"),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:342:
+             content_digest: u64::from_le_bytes(
+                 input[72..80].try_into().expect("content_digest bytes"),
+             ),
+-            delta_count: u32::from_le_bytes(
+(B-                input[80..84].try_into().expect("delta_count bytes"),
+(B-            ),
+(B+            delta_count: u32::from_le_bytes(input[80..84].try_into().expect("delta_count bytes")),
+(B             epoch_state: input[DISTANN_METADATA_EPOCH_STATE_OFFSET],
+-            active_epoch: u64::from_le_bytes(
+(B-                input[85..93].try_into().expect("active_epoch bytes"),
+(B-            ),
+(B+            active_epoch: u64::from_le_bytes(input[85..93].try_into().expect("active_epoch bytes")),
+(B             in_flight_count: u32::from_le_bytes(
+                 input[93..97].try_into().expect("in_flight_count bytes"),
+             ),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:400:
+ #[cfg(test)]
+ mod tests {
+     use super::{
+-        DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES,
+(B-        DISTANN_METADATA_BYTES, DISTANN_METADATA_LOGICAL_INDEX_UUID_OFFSET,
+(B-        DISTANN_NEIGHBOR_CODEC_GROUPED_PQ, DISTANN_NEIGHBOR_CODEC_RABITQ,
+(B-        INDEX_FORMAT_V1_DISTANN, INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B+        DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES, DISTANN_METADATA_BYTES,
+(B+        DISTANN_METADATA_LOGICAL_INDEX_UUID_OFFSET, DISTANN_NEIGHBOR_CODEC_GROUPED_PQ,
+(B+        DISTANN_NEIGHBOR_CODEC_RABITQ, INDEX_FORMAT_V1_DISTANN, INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B     };
+     use crate::storage::page::ItemPointer;
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:465:
+         let mut encoded = sample().encode();
+         encoded[0] = 0xFF;
+         encoded[1] = 0xFF;
+-        let error =
+(B-            DistannMetadataPage::decode(&encoded).expect_err("unknown version must fail");
+(B+        let error = DistannMetadataPage::decode(&encoded).expect_err("unknown version must fail");
+(B         assert!(error.contains("format version"));
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:494:
+             u16::from_le_bytes(encoded[0..2].try_into().unwrap()),
+             INDEX_FORMAT_V1_DISTANN
+         );
+-        assert_eq!(encoded, DistannMetadataPage::decode(&encoded).unwrap().encode());
+(B+        assert_eq!(
+(B+            encoded,
+(B+            DistannMetadataPage::decode(&encoded).unwrap().encode()
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:209:
+             usize::from(metadata.dimensions),
+             DISTANN_TURBOQUANT_BITS,
+         )),
+-        other => Err(format!("ec_distann unsupported neighbor codec kind {other}")),
+(B+        other => Err(format!(
+(B+            "ec_distann unsupported neighbor codec kind {other}"
+(B+        )),
+(B     }
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:249:
+         match metadata.neighbor_codec_kind {
+             DISTANN_NEIGHBOR_CODEC_GROUPED_PQ => {
+                 let flat_codebooks = flat_codebooks.ok_or_else(|| {
+-                    "ec_distann grouped_pq query preparation requires the codebook chain"
+(B-                        .to_owned()
+(B+                    "ec_distann grouped_pq query preparation requires the codebook chain".to_owned()
+(B                 })?;
+                 let group_count = usize::from(metadata.codec_subvector_count);
+                 let group_size = usize::from(metadata.codec_subvector_dim);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:257:
+                 if group_count == 0 || group_size == 0 {
+                     return Err(
+-                        "ec_distann grouped_pq metadata is missing subvector parameters".to_owned()
+(B+                        "ec_distann grouped_pq metadata is missing subvector parameters".to_owned(),
+(B                     );
+                 }
+                 let rotated = crate::am::ec_diskann::scan_query::encode_query_srht(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:326:
+                 })
+             }
+             DistannCodecArtifact::RaBitQ { seed, bits, .. } => {
+-                let quantizer =
+(B-                    RaBitQQuantizer::cached_seeded_srht_bits(dimensions, *seed, *bits)?;
+(B+                let quantizer = RaBitQQuantizer::cached_seeded_srht_bits(dimensions, *seed, *bits)?;
+(B                 Ok(Self::RaBitQ {
+                     prepared: quantizer.prepare_estimator(raw_query),
+                 })
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:401:
+                     out_scores,
+                 )?;
+             }
+-            Self::RaBitQ { prepared } => {
+(B-                match prepared.bits1_block_prepared(code_len) {
+(B-                    Some(block_prepared) => {
+(B-                        let mut batch = CandidateBatch::with_capacity(count);
+(B-                        for slot in 0..count {
+(B-                            batch.push(
+(B-                                slot,
+(B-                                CandidatePayload::new(
+(B-                                    &codes[slot * code_len..(slot + 1) * code_len],
+(B-                                    CandidateMeta::RaBitQ,
+(B-                                ),
+(B-                            )?;
+(B-                        }
+(B-                        score_rabitq_bits1_batch_for(
+(B-                            CandidateBatchScoringSurface::Distann,
+(B-                            block_prepared,
+(B-                            &batch,
+(B-                            out_scores,
+(B+            Self::RaBitQ { prepared } => match prepared.bits1_block_prepared(code_len) {
+(B+                Some(block_prepared) => {
+(B+                    let mut batch = CandidateBatch::with_capacity(count);
+(B+                    for slot in 0..count {
+(B+                        batch.push(
+(B+                            slot,
+(B+                            CandidatePayload::new(
+(B+                                &codes[slot * code_len..(slot + 1) * code_len],
+(B+                                CandidateMeta::RaBitQ,
+(B+                            ),
+(B                         )?;
+                     }
+-                    None => {
+(B-                        for slot in 0..count {
+(B-                            out_scores[slot] = prepared.estimate_ip_scalar_only(
+(B-                                &codes[slot * code_len..(slot + 1) * code_len],
+(B-                            );
+(B-                        }
+(B+                    score_rabitq_bits1_batch_for(
+(B+                        CandidateBatchScoringSurface::Distann,
+(B+                        block_prepared,
+(B+                        &batch,
+(B+                        out_scores,
+(B+                    )?;
+(B+                }
+(B+                None => {
+(B+                    for slot in 0..count {
+(B+                        out_scores[slot] = prepared.estimate_ip_scalar_only(
+(B+                            &codes[slot * code_len..(slot + 1) * code_len],
+(B+                        );
+(B                     }
+                 }
+-            }
+(B+            },
+(B             Self::TurboQuant {
+                 quantizer,
+                 prepared,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:81:
+     let mut entries = Vec::with_capacity(expected_entries);
+     let mut cursor = head_tid;
+     while cursor != ItemPointer::INVALID {
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann directory chunk")?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann directory chunk")?;
+(B         let tuple = DistannDirectoryTuple::decode(&raw)?;
+         entries.extend_from_slice(&tuple.entries);
+         cursor = tuple.next_tid;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:115:
+     let mut samples = Vec::new();
+     let mut cursor = head_tid;
+     while cursor != ItemPointer::INVALID {
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann head sample")?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann head sample")?;
+(B         let tuple = DistannHeadSampleTuple::decode(&raw, dimensions)?;
+         cursor = tuple.next_tid;
+         samples.push(tuple);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:169:
+     let mut cursor = head_tid;
+     let mut group_index = 0_usize;
+     while cursor != ItemPointer::INVALID {
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann codebook tuple")?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann codebook tuple")?;
+(B         let tuple = crate::am::VamanaCodebookTuple::decode(&raw, centroid_count)?;
+         if usize::from(tuple.group_index) != group_index {
+             return Err(format!(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:201:
+     graph_degree_r: u16,
+     code_len: usize,
+ ) -> Result<DistannNodeTuple, String> {
+-    let page = chain
+(B-        .get_page(tid.block_number)
+(B-        .ok_or_else(|| format!("ec_distann node block {} not materialized", tid.block_number))?;
+(B+    let page = chain.get_page(tid.block_number).ok_or_else(|| {
+(B+        format!(
+(B+            "ec_distann node block {} not materialized",
+(B+            tid.block_number
+(B+        )
+(B+    })?;
+(B     let raw = page.raw_tuple(tid)?;
+     if raw.first().copied() != Some(DISTANN_NODE_TAG) {
+         return Err(format!(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/remote_endpoint.rs:30:
+ use crate::storage::slot_guard::TupleTableSlotGuard;
+
+ use super::ambuild::read_metadata_from_index_handle;
+-use super::quote_ident;
+(B use super::epoch::{
+     compute_epoch_fingerprint, fingerprint_from_bytes, fingerprints_match,
+     DISTANN_EPOCH_FINGERPRINT_V1,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/remote_endpoint.rs:40:
+ use super::head_cache::cached_index_entry;
+ use super::placement::owning_node;
+ use super::quantizer::{metadata_code_len, DistannPreparedQuery};
++use super::quote_ident;
+(B use super::reader::{
+     directory_lookup, read_directory_from_relation, read_raw_tuple_bytes_from_relation,
+ };
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/remote_endpoint.rs:765:
+     let entry = cached_index_entry(index_oid.into(), handle, &metadata)?;
+     let prepared_query =
+         DistannPreparedQuery::prepare(&metadata, entry.flat_codebooks.as_deref(), query)?;
+-    let owner_open_validate_ns = i64::try_from(open_validate_started.elapsed().as_nanos())
+(B-        .unwrap_or(i64::MAX);
+(B+    let owner_open_validate_ns =
+(B+        i64::try_from(open_validate_started.elapsed().as_nanos()).unwrap_or(i64::MAX);
+(B     let code_len = metadata_code_len(&metadata)?;
+
+     let heap_oid = index_heap_relation_oid_handle(handle);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/roster.rs:29:
+
+ use super::epoch::DistannEpochIdentity;
+ use super::page::DistannMetadataPage;
+-use super::placement::{
+(B-    DistannPlacementDirectory, DistannRosterNode, DISTANN_PLACEMENT_HASH_V1,
+(B-};
+(B+use super::placement::{DistannPlacementDirectory, DistannRosterNode, DISTANN_PLACEMENT_HASH_V1};
+(B
+-static ECDISTANN_ROSTER_GUC: GucSetting<Option<CString>> =
+(B-    GucSetting::<Option<CString>>::new(None);
+(B+static ECDISTANN_ROSTER_GUC: GucSetting<Option<CString>> = GucSetting::<Option<CString>>::new(None);
+(B static ECDISTANN_LOCAL_NODE_ID_GUC: GucSetting<i32> = GucSetting::<i32>::new(0);
+ /// PostgreSQL int GUCs are 32-bit; epoch numbers at research scale fit easily.
+ static ECDISTANN_EPOCH_GUC: GucSetting<i32> = GucSetting::<i32>::new(0);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/roster.rs:123:
+             continue;
+         }
+         let (id_str, conninfo) = entry.split_once('@').ok_or_else(|| {
+-            format!(
+(B-                "ec_distann.roster entry {index} ({entry:?}) must be `node_id@conninfo`"
+(B-            )
+(B+            format!("ec_distann.roster entry {index} ({entry:?}) must be `node_id@conninfo`")
+(B         })?;
+         let node_id: u32 = id_str.trim().parse().map_err(|_| {
+             format!("ec_distann.roster entry {index} has non-numeric node_id {id_str:?}")
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/roster.rs:189:
+             DistannRosterNode {
+                 node_id: entry.node_id,
+                 is_local,
+-                conninfo: if is_local { String::new() } else { entry.conninfo },
+(B+                conninfo: if is_local {
+(B+                    String::new()
+(B+                } else {
+(B+                    entry.conninfo
+(B+                },
+(B             }
+         })
+         .collect();
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/routine.rs:14:
+     ambuild, cost,
+     expand::LocalNodeExpander,
+     head_cache, options,
+-    quote_ident,
+(B     quantizer::{self, DistannPreparedQuery},
++    quote_ident,
+(B     scan::{
+         distann_orchestrated_search, DistannOrchestrationParams, DistannScanCounters,
+         DistannScanHit, DistannSeedCandidate,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/row_schema.rs:49:
+     pub(crate) columns: Vec<ResolvedRowSchemaColumn>,
+ }
+
+-pub(crate) fn resolve_relation_schema(relation_oid: pg_sys::Oid) -> Result<ResolvedRowSchema, String> {
+(B+pub(crate) fn resolve_relation_schema(
+(B+    relation_oid: pg_sys::Oid,
+(B+) -> Result<ResolvedRowSchema, String> {
+(B     let rows = Spi::connect(|client| {
+         client
+             .select(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:338:
+ #[cfg(test)]
+ mod tests {
+     use super::{
+-        distann_orchestrated_search, run_scan_attempt_with_restart, DistannExpandedNode,
+(B-        DistannExpandError, DistannNodeExpander, DistannOrchestrationParams, DistannSeedCandidate,
+(B+        distann_orchestrated_search, run_scan_attempt_with_restart, DistannExpandError,
+(B+        DistannExpandedNode, DistannNodeExpander, DistannOrchestrationParams, DistannSeedCandidate,
+(B     };
+     use crate::storage::page::ItemPointer;
+     use std::cell::Cell;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:379:
+         let calls = Cell::new(0);
+         let result = run_scan_attempt_with_restart(|| {
+             calls.set(calls.get() + 1);
+-            Err::<i32, _>(DistannExpandError::EpochMismatch(format!("mismatch {}", calls.get())))
+(B+            Err::<i32, _>(DistannExpandError::EpochMismatch(format!(
+(B+                "mismatch {}",
+(B+                calls.get()
+(B+            )))
+(B         });
+         assert!(matches!(result, Err(DistannExpandError::EpochMismatch(_))));
+         assert_eq!(calls.get(), 2, "capped at two attempts");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:420:
+             vec_ids
+                 .iter()
+                 .map(|vec_id| {
+-                    let (exact, tombstone, neighbors) = self
+(B-                        .nodes
+(B-                        .get(vec_id)
+(B-                        .ok_or_else(|| DistannExpandError::Internal(format!("unknown vec_id {vec_id}")))?;
+(B+                    let (exact, tombstone, neighbors) =
+(B+                        self.nodes.get(vec_id).ok_or_else(|| {
+(B+                            DistannExpandError::Internal(format!("unknown vec_id {vec_id}"))
+(B+                        })?;
+(B                     Ok(DistannExpandedNode {
+                         vec_id: *vec_id,
+                         exact_dist: (!tombstone).then_some(*exact),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:469:
+             vec_id: 1,
+             dist: -0.9,
+         }];
+-        let (hits, counters) =
+(B-            distann_orchestrated_search(&seeds, &mut expander, params(2, 8, 10))
+(B-                .expect("search should succeed");
+(B+        let (hits, counters) = distann_orchestrated_search(&seeds, &mut expander, params(2, 8, 10))
+(B+            .expect("search should succeed");
+(B         assert_eq!(counters.records_expanded, 2);
+         assert!(counters.records_expanded <= 2 * 8);
+         assert!(counters.beam_exhausted, "cycle exhausts the beam");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:493:
+             vec_id: 1,
+             dist: -0.5,
+         }];
+-        let (hits, counters) =
+(B-            distann_orchestrated_search(&seeds, &mut expander, params(4, 8, 10))
+(B-                .expect("search should succeed");
+(B+        let (hits, counters) = distann_orchestrated_search(&seeds, &mut expander, params(4, 8, 10))
+(B+            .expect("search should succeed");
+(B         assert_eq!(hits.len(), 1, "fewer-than-k is a complete result");
+         assert!(counters.beam_exhausted);
+         assert!(!counters.early_exit);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:537:
+             vec_id: 1,
+             dist: -0.9,
+         }];
+-        let (hits, counters) =
+(B-            distann_orchestrated_search(&seeds, &mut expander, params(1, 8, 1))
+(B-                .expect("search should succeed");
+(B+        let (hits, counters) = distann_orchestrated_search(&seeds, &mut expander, params(1, 8, 1))
+(B+            .expect("search should succeed");
+(B         assert!(counters.early_exit);
+         assert_eq!(counters.records_expanded, 1);
+         assert_eq!(hits[0].vec_id, 1);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/shard_build.rs:348:
+                 "ec_distann duplicate or invalid shard spool index {shard_index}"
+             ));
+         }
+-        self.build_peak_completion_bytes = self
+(B-            .build_peak_completion_bytes
+(B-            .max(encoded.bytes.len());
+(B+        self.build_peak_completion_bytes =
+(B+            self.build_peak_completion_bytes.max(encoded.bytes.len());
+(B         let mut io = ShardSpoolIo::create()?;
+         io.write_all(&encoded.bytes);
+         let shard_bytes = u64::try_from(encoded.bytes.len())
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/shard_build.rs:840:
+                 // A send failure means the backend is already unwinding; no
+                 // PostgreSQL API or panic belongs on this worker thread.
+                 if sender.send((shard_index, result)).is_err() {
+-                    let _ = release_completion_bytes(
+(B-                        &retained_completion_bytes,
+(B-                        encoded_bytes,
+(B-                    );
+(B+                    let _ = release_completion_bytes(&retained_completion_bytes, encoded_bytes);
+(B                     return;
+                 }
+             });
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/shard_build.rs:1669:
+     }
+
+     fn raw_entry(node: u32, neighbors: &[u32]) -> Vec<u8> {
+-        let mut bytes = Vec::with_capacity(
+(B-            DISTANN_SHARD_SPILL_HEADER_BYTES + std::mem::size_of_val(neighbors),
+(B-        );
+(B+        let mut bytes =
+(B+            Vec::with_capacity(DISTANN_SHARD_SPILL_HEADER_BYTES + std::mem::size_of_val(neighbors));
+(B         bytes.extend_from_slice(&node.to_le_bytes());
+         bytes.extend_from_slice(&(neighbors.len() as u32).to_le_bytes());
+         for &neighbor in neighbors {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:152:
+                 .iter()
+                 .any(|byte| *byte != 0)
+         {
+-            return Err(
+(B-                "distann physical node record has non-zero adjacency padding".to_owned(),
+(B-            );
+(B+            return Err("distann physical node record has non-zero adjacency padding".to_owned());
+(B         }
+         Ok(())
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:233:
+         expected_version: Option<u16>,
+     ) -> Result<Self, String> {
+         let mut out = Self::empty();
+-        Self::decode_into_version(
+(B-            input,
+(B-            graph_degree_r,
+(B-            code_len,
+(B-            expected_version,
+(B-            &mut out,
+(B-        )?;
+(B+        Self::decode_into_version(input, graph_degree_r, code_len, expected_version, &mut out)?;
+(B         Ok(out)
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:269:
+         }
+         if let Some(expected_version) = expected_version {
+             let format_version = u16::from_le_bytes(
+-                input[DISTANN_NODE_FORMAT_VERSION_OFFSET
+(B-                    ..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B+                input[DISTANN_NODE_FORMAT_VERSION_OFFSET..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B                     .try_into()
+                     .expect("graph record version bytes"),
+             );
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:387:
+                 input[0]
+             ));
+         }
+-        let entry_count =
+(B-            usize::from(u16::from_le_bytes(input[2..4].try_into().expect("count bytes")));
+(B+        let entry_count = usize::from(u16::from_le_bytes(
+(B+            input[2..4].try_into().expect("count bytes"),
+(B+        ));
+(B         let expected = Self::encoded_len(entry_count);
+         if input.len() != expected {
+             return Err(format!(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:536:
+ #[cfg(test)]
+ mod tests {
+     use super::{
+-        DistannDeltaTuple, DistannNodeTuple, DISTANN_FLAG_TOMBSTONE,
+(B-        DISTANN_NODE_FORMAT_VERSION, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+(B-        DISTANN_NODE_HEADER_BYTES,
+(B+        DistannDeltaTuple, DistannNodeTuple, DISTANN_FLAG_TOMBSTONE, DISTANN_NODE_FORMAT_VERSION,
+(B+        DISTANN_NODE_FORMAT_VERSION_OFFSET, DISTANN_NODE_HEADER_BYTES,
+(B     };
+     use crate::storage::page::ItemPointer;
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:577:
+             search_code: (0..CODE_LEN as u8).collect(),
+             neighbor_vec_ids: vec![101, 202, 303, 0],
+             neighbor_codes: (0..R as usize * CODE_LEN)
+-                .map(|offset| if offset < 3 * CODE_LEN { offset as u8 } else { 0 })
+(B+                .map(|offset| {
+(B+                    if offset < 3 * CODE_LEN {
+(B+                        offset as u8
+(B+                    } else {
+(B+                        0
+(B+                    }
+(B+                })
+(B                 .collect(),
+         }
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:603:
+             .expect("physical encode should succeed");
+         assert_eq!(
+             u16::from_le_bytes(
+-                encoded[DISTANN_NODE_FORMAT_VERSION_OFFSET
+(B-                    ..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B+                encoded[DISTANN_NODE_FORMAT_VERSION_OFFSET..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B                     .try_into()
+                     .unwrap()
+             ),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:697:
+                 offset_number: 2,
+             },
+             entries: vec![
+-                (10, ItemPointer { block_number: 1, offset_number: 1 }),
+(B-                (20, ItemPointer { block_number: 1, offset_number: 2 }),
+(B-                (30, ItemPointer { block_number: 2, offset_number: 1 }),
+(B+                (
+(B+                    10,
+(B+                    ItemPointer {
+(B+                        block_number: 1,
+(B+                        offset_number: 1,
+(B+                    },
+(B+                ),
+(B+                (
+(B+                    20,
+(B+                    ItemPointer {
+(B+                        block_number: 1,
+(B+                        offset_number: 2,
+(B+                    },
+(B+                ),
+(B+                (
+(B+                    30,
+(B+                    ItemPointer {
+(B+                        block_number: 2,
+(B+                        offset_number: 1,
+(B+                    },
+(B+                ),
+(B             ],
+         };
+         let encoded = tuple.encode().expect("encode");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:706:
+-        assert_eq!(
+(B-            encoded.len(),
+(B-            super::DistannDirectoryTuple::encoded_len(3)
+(B-        );
+(B+        assert_eq!(encoded.len(), super::DistannDirectoryTuple::encoded_len(3));
+(B         let decoded = super::DistannDirectoryTuple::decode(&encoded).expect("decode");
+         assert_eq!(decoded, tuple);
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:719:
+             vector: vec![0.25, -0.5, 1.0, 0.0],
+         };
+         let encoded = tuple.encode();
+-        assert_eq!(
+(B-            encoded.len(),
+(B-            super::DistannHeadSampleTuple::encoded_len(4)
+(B-        );
+(B-        let decoded =
+(B-            super::DistannHeadSampleTuple::decode(&encoded, 4).expect("decode");
+(B+        assert_eq!(encoded.len(), super::DistannHeadSampleTuple::encoded_len(4));
+(B+        let decoded = super::DistannHeadSampleTuple::decode(&encoded, 4).expect("decode");
+(B         assert_eq!(decoded, tuple);
+         assert!(super::DistannHeadSampleTuple::decode(&encoded, 5).is_err());
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/page.rs:3507:
+         "ec_ivf posting entry block sequence",
+         |buffer, block_number| {
+             let decode_started = std::time::Instant::now();
+-            let result =
+(B-                visit_all_ivf_posting_entries_from_buffer(buffer, block_number, payload_len, visitor);
+(B+            let result = visit_all_ivf_posting_entries_from_buffer(
+(B+                buffer,
+(B+                block_number,
+(B+                payload_len,
+(B+                visitor,
+(B+            );
+(B             decode_elapsed += decode_started.elapsed();
+             result
+         },
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:449:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:663:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:883:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:1144:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:1249:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:1191:
+     capacity: usize,
+ ) -> *mut CandidateDedupPool {
+     if opaque.candidate_dedup.is_null() {
+-        opaque.candidate_dedup = Box::into_raw(Box::new(CandidateDedupPool::with_capacity(
+(B-            capacity,
+(B-        )));
+(B+        opaque.candidate_dedup =
+(B+            Box::into_raw(Box::new(CandidateDedupPool::with_capacity(capacity)));
+(B         return opaque.candidate_dedup;
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:1692:
+     // pure `pre_rerank_candidate_limit` / `ranked_collect_limit` helpers take it
+     // as a parameter so they never touch pgrx GUC FFI off-thread.
+     let effective_rerank_width =
+-        super::options::resolve_scan_rerank_width(index_options.rerank_width).effective_rerank_width;
+(B+        super::options::resolve_scan_rerank_width(index_options.rerank_width)
+(B+            .effective_rerank_width;
+(B     let mut running_top = bound_pruning_active
+         .then(|| pre_rerank_candidate_limit(index_options, effective_rerank_width))
+         .flatten()
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:1944:
+         // the rerank helper validates whether heap_f32 state is present
+         // before use.
+         let rerank_started = should_record_exact_rerank.then(Instant::now);
+-        unsafe { rerank_probe_candidates(scan, index_options, opaque, centroid_scores, candidates) };
+(B+        unsafe {
+(B+            rerank_probe_candidates(scan, index_options, opaque, centroid_scores, candidates)
+(B+        };
+(B         if let Some(rerank_started) = rerank_started {
+             record_stage_elapsed(
+                 opaque,
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:2511:
+         index_options.rerank.v1_effective(),
+         super::options::RerankMode::HeapF32
+     ) {
+-        Some(pre_rerank_candidate_limit(index_options, effective_rerank_width).unwrap_or(candidate_len))
+(B+        Some(
+(B+            pre_rerank_candidate_limit(index_options, effective_rerank_width)
+(B+                .unwrap_or(candidate_len),
+(B+        )
+(B     } else {
+         None
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5408:
+         let mut stream = Vec::new();
+         let mut state = 0x2545F4914F6CDD1D_u64;
+         for i in 0..10_000_u32 {
+-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+(B+            state = state
+(B+                .wrapping_mul(6364136223846793005)
+(B+                .wrapping_add(1442695040888963407);
+(B             let block = (state >> 33) as u32 % 512;
+             let offset = 1 + ((state >> 17) as u16 % 128);
+             let score = ((state >> 40) as f32) / 1e6 - 8.0;
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5446:
+             for (left, right) in from_pool.iter().zip(from_reference.iter()) {
+                 assert_eq!(left.heap_tid, right.heap_tid, "limit {limit:?}");
+                 assert_eq!(left.rerank_tid, right.rerank_tid, "limit {limit:?}");
+-                assert_eq!(left.score.to_bits(), right.score.to_bits(), "limit {limit:?}");
+(B+                assert_eq!(
+(B+                    left.score.to_bits(),
+(B+                    right.score.to_bits(),
+(B+                    "limit {limit:?}"
+(B+                );
+(B             }
+         }
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5495:
+         let mut stream = Vec::with_capacity(CANDIDATES);
+         let mut state = 0x9E3779B97F4A7C15_u64;
+         for i in 0..CANDIDATES as u64 {
+-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+(B+            state = state
+(B+                .wrapping_mul(6364136223846793005)
+(B+                .wrapping_add(1442695040888963407);
+(B             // Unique tids so the map holds the full candidate count.
+             let block = (i / 291) as u32;
+             let offset = 1 + (i % 291) as u16;
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5530:
+         let map_ref = &map;
+         let map_walk = time_ns(
+             "map walk only (values -> black_box)",
+-            Box::new(move || map_ref.values().map(|c| c.heap_tid.offset_number as usize).sum()),
+(B+            Box::new(move || {
+(B+                map_ref
+(B+                    .values()
+(B+                    .map(|c| c.heap_tid.offset_number as usize)
+(B+                    .sum()
+(B+            }),
+(B         );
+         let ranked_len = |ranked: RankedProbeCandidates| match ranked {
+             RankedProbeCandidates::Sorted(candidates) => candidates.len(),
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:38:
+ };
+ pub use self::ec_diskann::{vamana_decode_overflow_tuple_fixture, VamanaOverflowTupleFixture};
+ pub use self::ec_distann::page::{
+-    DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES,
+(B-    DISTANN_METADATA_ACTIVE_EPOCH_OFFSET, DISTANN_METADATA_ALPHA_OFFSET,
+(B-    DISTANN_METADATA_BUILD_LIST_SIZE_L_OFFSET, DISTANN_METADATA_BYTES,
+(B+    DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES, DISTANN_METADATA_ACTIVE_EPOCH_OFFSET,
+(B+    DISTANN_METADATA_ALPHA_OFFSET, DISTANN_METADATA_BUILD_LIST_SIZE_L_OFFSET,
+(B+    DISTANN_METADATA_BYTES, DISTANN_METADATA_CLOSURE_EPSILON_OFFSET,
+(B     DISTANN_METADATA_CODEC_SUBVECTOR_COUNT_OFFSET, DISTANN_METADATA_CODEC_SUBVECTOR_DIM_OFFSET,
+-    DISTANN_METADATA_CLOSURE_EPSILON_OFFSET, DISTANN_METADATA_CONTENT_DIGEST_OFFSET,
+(B-    DISTANN_METADATA_DELTA_BUFFER_HEAD_OFFSET, DISTANN_METADATA_DELTA_COUNT_OFFSET,
+(B+    DISTANN_METADATA_CONTENT_DIGEST_OFFSET, DISTANN_METADATA_DELTA_BUFFER_HEAD_OFFSET,
+(B+    DISTANN_METADATA_DELTA_COUNT_OFFSET, DISTANN_METADATA_DIMENSIONS_OFFSET,
+(B     DISTANN_METADATA_DIRECTORY_HEAD_OFFSET, DISTANN_METADATA_ENTRY_POINT_OFFSET,
+-    DISTANN_METADATA_DIMENSIONS_OFFSET,
+(B     DISTANN_METADATA_EPOCH_STATE_OFFSET, DISTANN_METADATA_FLAGS_OFFSET,
+     DISTANN_METADATA_FORMAT_VERSION_OFFSET, DISTANN_METADATA_GRAPH_DEGREE_R_OFFSET,
+     DISTANN_METADATA_GROUPED_CODEBOOK_HEAD_OFFSET, DISTANN_METADATA_HEAD_INDEX_CAP_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:52:
+     DISTANN_METADATA_HEAD_SAMPLE_HEAD_OFFSET, DISTANN_METADATA_IN_FLIGHT_COUNT_OFFSET,
+     DISTANN_METADATA_LOGICAL_INDEX_UUID_OFFSET, DISTANN_METADATA_NEIGHBOR_CODEC_KIND_OFFSET,
+-    DISTANN_METADATA_NODE_COUNT_OFFSET, DISTANN_METADATA_SEED_OFFSET,
+(B-    INDEX_FORMAT_V1_DISTANN, INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B+    DISTANN_METADATA_NODE_COUNT_OFFSET, DISTANN_METADATA_SEED_OFFSET, INDEX_FORMAT_V1_DISTANN,
+(B+    INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B };
++pub(crate) use self::ec_distann::restore_owner_stream_hash_state;
+(B pub use self::ec_distann::tuple::{
+-    distann_node_neighbor_codes_offset, distann_node_neighbor_vec_ids_offset,
+(B-    DistannNodeTuple, DISTANN_NODE_FLAGS_OFFSET, DISTANN_NODE_FORMAT_VERSION,
+(B-    DISTANN_NODE_FORMAT_VERSION_OFFSET, DISTANN_NODE_HEADER_BYTES,
+(B-    DISTANN_NODE_HEAP_TID_OFFSET, DISTANN_NODE_NEIGHBOR_COUNT_OFFSET,
+(B+    distann_node_neighbor_codes_offset, distann_node_neighbor_vec_ids_offset, DistannNodeTuple,
+(B+    DISTANN_NODE_FLAGS_OFFSET, DISTANN_NODE_FORMAT_VERSION, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+(B+    DISTANN_NODE_HEADER_BYTES, DISTANN_NODE_HEAP_TID_OFFSET, DISTANN_NODE_NEIGHBOR_COUNT_OFFSET,
+(B     DISTANN_NODE_SEARCH_CODE_OFFSET, DISTANN_NODE_TAG_OFFSET, DISTANN_NODE_VEC_ID_OFFSET,
+ };
+ pub use self::ec_distann::{
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:65:
+     owner_stream_digest, DistannAbandonBindingAuditV1, DistannAbandonedBinding,
+     DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildOptions, DistannBuildSpec,
+-    DistannCancelPublishAuditV1,
+(B-    DistannCodecArtifact, DistannEpochFingerprint, DistannEpochManifestV2,
+(B-    DistannGenerationDescriptor, DistannHeadPolicy,
+(B-    DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape,
+(B-    DistannManifestBuildOptions, DistannManifestCodecParameters, DistannOwnerExpectation,
+(B-    DistannPublishedEpochIdentity, DistannReadyReceipt, DistannRetireDecisionV1,
+(B-    DistannRosterEntry, DistannRowSchemaAttribute,
+(B-    DistannRowSchemaDescriptor, DistannSourceSnapshot, DISTANN_BUILD_SPEC_VERSION,
+(B-    DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+(B-    DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET, DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES,
+(B-    DISTANN_ABANDONED_BINDING_SET_VERSION, DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+(B+    DistannCancelPublishAuditV1, DistannCodecArtifact, DistannEpochFingerprint,
+(B+    DistannEpochManifestV2, DistannGenerationDescriptor, DistannHandoffBatch, DistannHandoffEntry,
+(B+    DistannHandoffShape, DistannHeadPolicy, DistannManifestBuildOptions,
+(B+    DistannManifestCodecParameters, DistannOwnerExpectation, DistannPublishedEpochIdentity,
+(B+    DistannReadyReceipt, DistannRetireDecisionV1, DistannRosterEntry, DistannRowSchemaAttribute,
+(B+    DistannRowSchemaDescriptor, DistannSourceSnapshot, DistannSuccessorActivationV1,
+(B+    DISTANN_ABANDONED_BINDING_ENTRY_BYTES, DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET,
+(B+    DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES, DISTANN_ABANDONED_BINDING_SET_VERSION,
+(B+    DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+(B     DISTANN_ABANDON_BINDING_AUDIT_FIXED_PREFIX_BYTES,
+     DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_BUILD_ID_OFFSET,
+     DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_EPOCH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:82:
+     DISTANN_ABANDON_BINDING_AUDIT_VERSION, DISTANN_ABANDON_BINDING_AUDIT_VERSION_OFFSET,
+     DISTANN_BUILD_CANDIDATE_BUILD_SPEC_LENGTH_OFFSET, DISTANN_BUILD_CANDIDATE_FIXED_PREFIX_BYTES,
+     DISTANN_BUILD_CANDIDATE_REGISTRATION_DIGEST_OFFSET, DISTANN_BUILD_CANDIDATE_VERSION,
+-    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET,
+(B-    DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B+    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_BUILD_SPEC_VERSION,
+(B+    DISTANN_BUILD_SPEC_VERSION_OFFSET, DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B     DISTANN_CANCEL_PUBLISH_AUDIT_COORDINATOR_UUID_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_EPOCH_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_FINGERPRINT_LENGTH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:90:
+     DISTANN_CANCEL_PUBLISH_AUDIT_FIXED_PREFIX_BYTES, DISTANN_CANCEL_PUBLISH_AUDIT_VERSION,
+-    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET,
+(B-    DISTANN_BUILD_SPEC_VERSION_OFFSET, DISTANN_CODEC_ARTIFACT_VERSION,
+(B+    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET, DISTANN_CODEC_ARTIFACT_VERSION,
+(B     DISTANN_CODEC_ARTIFACT_VERSION_OFFSET, DISTANN_EPOCH_FINGERPRINT_BYTES,
+     DISTANN_EPOCH_MANIFEST_VERSION, DISTANN_EPOCH_MANIFEST_VERSION_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_COORDINATOR_UUID_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:101:
+     DISTANN_GENERATION_DESCRIPTOR_INDEX_FORMAT_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_PLACEMENT_HASH_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET, DISTANN_GENERATION_DESCRIPTOR_VERSION,
+-    DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET,
+(B-    DISTANN_GRAPH_RECORD_VERSION, DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES,
+(B-    DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_MAX_BYTES,
+(B-    DISTANN_HANDOFF_VERSION_OFFSET, DISTANN_HANDOFF_WIRE_VERSION,
+(B+    DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET, DISTANN_GRAPH_RECORD_VERSION,
+(B+    DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES,
+(B+    DISTANN_HANDOFF_MAX_BYTES, DISTANN_HANDOFF_VERSION_OFFSET, DISTANN_HANDOFF_WIRE_VERSION,
+(B+    DISTANN_MANIFEST_BUILD_OPTIONS_BYTES, DISTANN_MANIFEST_BUILD_OPTIONS_VERSION,
+(B+    DISTANN_MANIFEST_BUILD_OPTIONS_VERSION_OFFSET, DISTANN_MANIFEST_CODEC_PARAMETERS_BYTES,
+(B+    DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION, DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION_OFFSET,
+(B     DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_OFFSET, DISTANN_OWNER_STREAM_HASH_STATE_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:111:
+     DISTANN_OWNER_STREAM_HASH_STATE_CHAIN_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_IMPLEMENTATION_OFFSET,
+-    DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET,
+(B-    DISTANN_MANIFEST_BUILD_OPTIONS_BYTES, DISTANN_MANIFEST_BUILD_OPTIONS_VERSION,
+(B-    DISTANN_MANIFEST_BUILD_OPTIONS_VERSION_OFFSET, DISTANN_MANIFEST_CODEC_PARAMETERS_BYTES,
+(B-    DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION, DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION_OFFSET,
+(B-    DISTANN_PHYSICAL_INDEX_FORMAT_VERSION, DISTANN_PLACEMENT_HASH_VERSION,
+(B-    DISTANN_READY_RECEIPT_BYTES, DISTANN_READY_RECEIPT_STATE,
+(B+    DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B+    DISTANN_PLACEMENT_HASH_VERSION, DISTANN_READY_RECEIPT_BYTES, DISTANN_READY_RECEIPT_STATE,
+(B     DISTANN_READY_RECEIPT_VERSION, DISTANN_READY_RECEIPT_VERSION_OFFSET,
+     DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET, DISTANN_RETIRE_DECISION_EPOCH_OFFSET,
+     DISTANN_RETIRE_DECISION_FINGERPRINT_LENGTH_OFFSET, DISTANN_RETIRE_DECISION_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:122:
+     DISTANN_RETIRE_DECISION_TARGET_BUILD_ID_OFFSET, DISTANN_RETIRE_DECISION_VERSION,
+-    DISTANN_RETIRE_DECISION_VERSION_OFFSET,
+(B-    DISTANN_ROW_SCHEMA_VERSION, DISTANN_ROW_SCHEMA_VERSION_OFFSET,
+(B-    DISTANN_SOURCE_SNAPSHOT_VERSION, DISTANN_SOURCE_SNAPSHOT_VERSION_OFFSET,
+(B-    DISTANN_SUCCESSOR_ACTIVATION_COORDINATOR_UUID_OFFSET,
+(B+    DISTANN_RETIRE_DECISION_VERSION_OFFSET, DISTANN_ROW_SCHEMA_VERSION,
+(B+    DISTANN_ROW_SCHEMA_VERSION_OFFSET, DISTANN_SOURCE_SNAPSHOT_VERSION,
+(B+    DISTANN_SOURCE_SNAPSHOT_VERSION_OFFSET, DISTANN_SUCCESSOR_ACTIVATION_COORDINATOR_UUID_OFFSET,
+(B     DISTANN_SUCCESSOR_ACTIVATION_FIXED_PREFIX_BYTES,
+     DISTANN_SUCCESSOR_ACTIVATION_PREDECESSOR_PRESENT_OFFSET, DISTANN_SUCCESSOR_ACTIVATION_VERSION,
+     DISTANN_SUCCESSOR_ACTIVATION_VERSION_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:130:
+ };
+-pub(crate) use self::ec_distann::restore_owner_stream_hash_state;
+(B #[allow(unused_imports)]
+ pub(crate) use self::ec_hnsw::{
+     graph, index_admin_snapshot, index_cost_snapshot, page, planner_integration_snapshot,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:411:
+         owner_stream_digest, DistannAbandonBindingAuditV1, DistannAbandonedBinding,
+         DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildOptions,
+         DistannBuildSpec, DistannCancelPublishAuditV1, DistannCodecArtifact,
+-        DistannEpochFingerprint, DistannEpochManifestV2,
+(B-        DistannGenerationDescriptor, DistannHeadPolicy,
+(B-        DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape, DistannManifestBuildOptions,
+(B-        DistannManifestCodecParameters, DistannMetadataPage, DistannNodeTuple,
+(B-        DistannOwnerExpectation, DistannPublishedEpochIdentity, DistannReadyReceipt,
+(B-        DistannRetireDecisionV1, DistannRosterEntry,
+(B+        DistannEpochFingerprint, DistannEpochManifestV2, DistannGenerationDescriptor,
+(B+        DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape, DistannHeadPolicy,
+(B+        DistannManifestBuildOptions, DistannManifestCodecParameters, DistannMetadataPage,
+(B+        DistannNodeTuple, DistannOwnerExpectation, DistannPublishedEpochIdentity,
+(B+        DistannReadyReceipt, DistannRetireDecisionV1, DistannRosterEntry,
+(B         DistannRowSchemaAttribute, DistannRowSchemaDescriptor, DistannSourceSnapshot,
+         DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+         DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:423:
+-        DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES,
+(B-        DISTANN_ABANDONED_BINDING_SET_VERSION,
+(B+        DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES, DISTANN_ABANDONED_BINDING_SET_VERSION,
+(B         DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+         DISTANN_ABANDON_BINDING_AUDIT_FIXED_PREFIX_BYTES,
+         DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_BUILD_ID_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:428:
+         DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_EPOCH_OFFSET,
+         DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_FINGERPRINT_LENGTH_OFFSET,
+         DISTANN_ABANDON_BINDING_AUDIT_VERSION, DISTANN_ABANDON_BINDING_AUDIT_VERSION_OFFSET,
+-        DISTANN_BUILD_SPEC_VERSION, DISTANN_BUILD_SPEC_VERSION_OFFSET,
+(B         DISTANN_BUILD_CANDIDATE_BUILD_SPEC_LENGTH_OFFSET,
+         DISTANN_BUILD_CANDIDATE_FIXED_PREFIX_BYTES,
+         DISTANN_BUILD_CANDIDATE_REGISTRATION_DIGEST_OFFSET, DISTANN_BUILD_CANDIDATE_VERSION,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:435:
+-        DISTANN_BUILD_CANDIDATE_VERSION_OFFSET,
+(B-        DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B+        DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_BUILD_SPEC_VERSION,
+(B+        DISTANN_BUILD_SPEC_VERSION_OFFSET, DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B         DISTANN_CANCEL_PUBLISH_AUDIT_COORDINATOR_UUID_OFFSET,
+         DISTANN_CANCEL_PUBLISH_AUDIT_EPOCH_OFFSET,
+         DISTANN_CANCEL_PUBLISH_AUDIT_FINGERPRINT_LENGTH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:440:
+         DISTANN_CANCEL_PUBLISH_AUDIT_FIXED_PREFIX_BYTES, DISTANN_CANCEL_PUBLISH_AUDIT_VERSION,
+-        DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET,
+(B-        DISTANN_CODEC_ARTIFACT_VERSION, DISTANN_CODEC_ARTIFACT_VERSION_OFFSET,
+(B-        DISTANN_CONTROL_METADATA_BYTES, DISTANN_EPOCH_FINGERPRINT_BYTES,
+(B-        DISTANN_EPOCH_MANIFEST_VERSION, DISTANN_EPOCH_MANIFEST_VERSION_OFFSET,
+(B+        DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET, DISTANN_CODEC_ARTIFACT_VERSION,
+(B+        DISTANN_CODEC_ARTIFACT_VERSION_OFFSET, DISTANN_CONTROL_METADATA_BYTES,
+(B+        DISTANN_EPOCH_FINGERPRINT_BYTES, DISTANN_EPOCH_MANIFEST_VERSION,
+(B+        DISTANN_EPOCH_MANIFEST_VERSION_OFFSET,
+(B         DISTANN_GENERATION_DESCRIPTOR_COORDINATOR_UUID_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_DIMENSIONS_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:450:
+         DISTANN_GENERATION_DESCRIPTOR_HANDOFF_WIRE_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_INDEX_FORMAT_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_PLACEMENT_HASH_OFFSET,
+-        DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET,
+(B-        DISTANN_GENERATION_DESCRIPTOR_VERSION, DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET,
+(B-        DISTANN_GRAPH_RECORD_VERSION,
+(B+        DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET, DISTANN_GENERATION_DESCRIPTOR_VERSION,
+(B+        DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET, DISTANN_GRAPH_RECORD_VERSION,
+(B         DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES,
+         DISTANN_HANDOFF_MAX_BYTES, DISTANN_HANDOFF_VERSION_OFFSET, DISTANN_HANDOFF_WIRE_VERSION,
+-        DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_OFFSET, DISTANN_OWNER_STREAM_HASH_STATE_BYTES,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_CHAIN_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_IMPLEMENTATION_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET,
+(B         DISTANN_MANIFEST_BUILD_OPTIONS_BYTES, DISTANN_MANIFEST_BUILD_OPTIONS_VERSION,
+         DISTANN_MANIFEST_BUILD_OPTIONS_VERSION_OFFSET, DISTANN_MANIFEST_CODEC_PARAMETERS_BYTES,
+         DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:480:
+         DISTANN_NODE_FLAGS_OFFSET, DISTANN_NODE_FORMAT_VERSION, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+         DISTANN_NODE_HEADER_BYTES, DISTANN_NODE_HEAP_TID_OFFSET,
+         DISTANN_NODE_NEIGHBOR_COUNT_OFFSET, DISTANN_NODE_SEARCH_CODE_OFFSET,
+-        DISTANN_NODE_TAG_OFFSET, DISTANN_NODE_VEC_ID_OFFSET, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B+        DISTANN_NODE_TAG_OFFSET, DISTANN_NODE_VEC_ID_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_OFFSET, DISTANN_OWNER_STREAM_HASH_STATE_BYTES,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_CHAIN_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_IMPLEMENTATION_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B         DISTANN_PLACEMENT_HASH_VERSION, DISTANN_READY_RECEIPT_BYTES, DISTANN_READY_RECEIPT_STATE,
+         DISTANN_READY_RECEIPT_VERSION, DISTANN_READY_RECEIPT_VERSION_OFFSET,
+         DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET, DISTANN_RETIRE_DECISION_EPOCH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/storage/page.rs:341:
+         assert_eq!(second.block_number, base, "same page while it fits");
+         assert_eq!(third.block_number, base + 1, "next page is base+1");
+         // Lookups resolve against the base.
+-        assert_eq!(chain.get_page(first.block_number).unwrap().raw_tuple(first).unwrap(), &[1; 32]);
+(B-        assert_eq!(chain.get_page(third.block_number).unwrap().raw_tuple(third).unwrap(), &[3; 32]);
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(first.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(first)
+(B+                .unwrap(),
+(B+            &[1; 32]
+(B+        );
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(third.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(third)
+(B+                .unwrap(),
+(B+            &[3; 32]
+(B+        );
+(B         // Below-base blocks are not in this chain.
+         assert!(chain.get_page(base - 1).is_none());
+         // pages() carry the base-relative block numbers for write_data_pages.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/tests/on_disk_fixtures.rs:9:
+     spire_decode_partition_object_v2_chain_segment_fixture,
+     spire_decode_routing_partition_object_fixture, spire_decode_top_graph_partition_object_fixture,
+     vamana_decode_overflow_tuple_fixture, DistannAbandonBindingAuditV1,
+-    DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildSpec, DistannCodecArtifact,
+(B-    DistannCancelPublishAuditV1, DistannEpochFingerprint, DistannEpochManifestV2,
+(B-    DistannGenerationDescriptor,
+(B-    DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape, DistannManifestBuildOptions,
+(B-    DistannManifestCodecParameters, DistannMetadataPage, DistannNodeTuple, DistannReadyReceipt,
+(B-    DistannRetireDecisionV1, DistannRowSchemaDescriptor, DistannSourceSnapshot,
+(B-    DistannSuccessorActivationV1, ItemPointer, IvfBlockRef, IvfCentroidTuple,
+(B-    IvfListDirectoryTuple, IvfMetadataPage, IvfPostingTuple, IvfPqCodebookTuple, IvfRerankMode,
+(B-    IvfRerankScoreMode, IvfStorageFormat, MetadataPage, SpireConsistencyMode, SpireEpochManifest,
+(B-    SpireEpochState, SpireLocalStoreConfig, SpireLocalStoreState, SpireManifestEntry,
+(B-    SpireObjectManifest, SpirePlacementDirectory, SpirePlacementEntry, SpirePlacementState,
+(B-    TqElementTuple, TqGroupedCodebookTuple, TqGroupedHotTuple, TqNeighborTuple, TqRerankTuple,
+(B-    TqTurboHotTuple, VamanaCodebookTuple, VamanaMetadataPage, VamanaNodeTuple,
+(B-    DISTANN_CONTROL_METADATA_BYTES, DISTANN_EPOCH_FINGERPRINT_BYTES, DISTANN_METADATA_BYTES,
+(B+    DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildSpec,
+(B+    DistannCancelPublishAuditV1, DistannCodecArtifact, DistannEpochFingerprint,
+(B+    DistannEpochManifestV2, DistannGenerationDescriptor, DistannHandoffBatch, DistannHandoffEntry,
+(B+    DistannHandoffShape, DistannManifestBuildOptions, DistannManifestCodecParameters,
+(B+    DistannMetadataPage, DistannNodeTuple, DistannReadyReceipt, DistannRetireDecisionV1,
+(B+    DistannRowSchemaDescriptor, DistannSourceSnapshot, DistannSuccessorActivationV1, ItemPointer,
+(B+    IvfBlockRef, IvfCentroidTuple, IvfListDirectoryTuple, IvfMetadataPage, IvfPostingTuple,
+(B+    IvfPqCodebookTuple, IvfRerankMode, IvfRerankScoreMode, IvfStorageFormat, MetadataPage,
+(B+    SpireConsistencyMode, SpireEpochManifest, SpireEpochState, SpireLocalStoreConfig,
+(B+    SpireLocalStoreState, SpireManifestEntry, SpireObjectManifest, SpirePlacementDirectory,
+(B+    SpirePlacementEntry, SpirePlacementState, TqElementTuple, TqGroupedCodebookTuple,
+(B+    TqGroupedHotTuple, TqNeighborTuple, TqRerankTuple, TqTurboHotTuple, VamanaCodebookTuple,
+(B+    VamanaMetadataPage, VamanaNodeTuple, DISTANN_CONTROL_METADATA_BYTES,
+(B+    DISTANN_EPOCH_FINGERPRINT_BYTES, DISTANN_METADATA_BYTES,
+(B     DISTANN_METADATA_FORMAT_VERSION_OFFSET, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.

--- a/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/distann-simd-diff.log
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/distann-simd-diff.log
@@ -1,0 +1,34 @@
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.10s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 2 tests
+test am::ec_distann::insert::tests::simd_diff_exact_distance_is_shared_diskann_inner_product_negation ... task36_distann source_inner_product_backend=neon
+ok
+test am::ec_distann::quantizer::tests::simd_diff_distann_codec_batches_match_direct_scalar_scores_across_widths ... task36_distann format=grouped_pq dimensions=64 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=rabitq dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=turboquant dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2517 filtered out; finished in 0.06s

--- a/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/make-simd-diff.log
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/make-simd-diff.log
@@ -1,0 +1,407 @@
+task36 simd-diff: public bench hooks (Prod/FWHT/HNSW/DiskANN)
+cargo test --features bench --test simd_diff -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 25s
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-3eb2e7ac5b649314)
+
+running 10 tests
+test am_source_inner_product_simd_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_code_to_code_score_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_fwht_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_score_ip_from_parts_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test forced_neon_fwht_matches_scalar_reference_when_available ... ok
+test forced_neon_score_paths_match_scalar_reference_when_available ... ok
+test host_backend_inventory_is_visible ... task36_host arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false unavailable=x86_avx2_fma,x86_avx512
+ok
+test packed_mse_indices_roundtrip_across_widths ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test production_1536_4bit_score_path_matches_scalar_reference ... ok
+test three_bit_unpack_fixture_stays_bit_exact ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 16.33s
+
+task36 simd-diff: RaBitQ arithmetic SIMD inventory
+cargo test --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 04s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 2 tests
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... task36_rabitq kernel=scalar_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=1536 status=exercised
+ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2517 filtered out; finished in 0.01s
+
+task36 simd-diff: rabitq32 bits=1/2/4 block and partial kernels
+cargo test --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.31s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 7 tests
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... task36_rabitq32 bits=2 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=2 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 2512 filtered out; finished in 0.05s
+
+task36 simd-diff: qjl32 block/octet/remainder kernels
+cargo test --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 10 tests
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_batch_with_blocks_and_tail_matches_pre_slice_scorer_bits ... task36_qjl32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2509 filtered out; finished in 0.25s
+
+task36 simd-diff: lut32 block/partial/tiled kernels
+cargo test --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 9 tests
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 2510 filtered out; finished in 0.03s
+
+task36 simd-diff: grouped-PQ block/partial kernels
+cargo test --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 8 tests
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2511 filtered out; finished in 0.00s
+
+task36 simd-diff: int8/SDOT block/partial kernels
+cargo test --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 5 tests
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... ok
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... ok
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... task36_int8_approx32 neon=true dotprod=true widths=1,7,8,9,16,17,31,32,33
+ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2514 filtered out; finished in 0.05s
+
+task36 simd-diff: real hamming32 SIMD kernels
+cargo test --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.12s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 3 tests
+test quant::hamming32::tests::block32_is_integer_exact_with_scalar_reference ... ok
+test quant::hamming32::tests::partial_is_integer_exact_with_scalar_reference ... task36_hamming32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::hamming32::tests::scalar_reference_is_xor_popcount ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2516 filtered out; finished in 0.00s
+
+task36 simd-diff: DistANN codec composition, stride, and source IP
+cargo test --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 2 tests
+test am::ec_distann::insert::tests::simd_diff_exact_distance_is_shared_diskann_inner_product_negation ... task36_distann source_inner_product_backend=neon
+ok
+test am::ec_distann::quantizer::tests::simd_diff_distann_codec_batches_match_direct_scalar_scores_across_widths ... task36_distann format=grouped_pq dimensions=64 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=rabitq dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=turboquant dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2517 filtered out; finished in 0.06s

--- a/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/manifest.md
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/manifest.md
@@ -71,3 +71,35 @@
 This packet makes a local Apple arm64 claim only. It does not claim CI coverage
 or execution on Intel or Graviton. AVX2/AVX-512 and SVE/SVE2 implementations
 that exist in the source inventory remain hardware validation follow-ups.
+
+## Reviewer verification artifacts (2026-07-25)
+
+Added by `feedback/2026-07-25-01-reviewer.md`. Head reviewed `c373eb51f`,
+verified in a clean worktree on Apple M5 (aarch64, NEON + dotprod, no SVE).
+
+### `2026-07-25-reviewer-make-simd-diff-repro.log`
+
+- Command: `make simd-diff`
+- Status: PASS (exit 0), independently reproducing the coder's
+  `make-simd-diff.log`.
+- Key result: all nine stages green with counts matching this manifest exactly
+  (10 / 2 / 7 / 10 / 9 / 8 / 5 / 3 / 2); host line
+  `task36_host arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false`.
+
+### `2026-07-25-reviewer-prod-tests-red.log`
+
+- Command: `cargo test --lib --features bench quant::prod::tests:: -- --test-threads=1`
+- Status: FAIL (1 of 44) at the same head where `make simd-diff` is green.
+- Key result: `quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane`
+  fails at `src/quant/prod.rs:1842`. The `prod` family is listed in the
+  `docs/hardening.md` inventory but its in-library suite has no stage in the
+  make lane, so the lane does not see this. Underlying cause is `3d66bdcf3`
+  (task-125, now on `main`) dropping the lane guard and length assert from
+  `prepare_ip_query_tiled_lut_no_qjl_4bit`.
+
+### `2026-07-25-reviewer-empty-filter-exit0.log`
+
+- Command: `cargo test --features bench --test simd_diff -- --test-threads=1 quant::nonexistent_zzz`
+- Status: exit 0 with `0 passed; ...; 10 filtered out`.
+- Key result: demonstrates that the eight name-filter stages in `make simd-diff`
+  fail open — a renamed or moved test drops out of the lane silently.

--- a/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/manifest.md
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/manifest.md
@@ -1,0 +1,73 @@
+# Artifact manifest
+
+- Head SHA: `c373eb51f61654226f81b489a4be4a40e6e45025`
+- Task bucket: `reviews/task-36/`
+- Packet: `reviews/task-36/002-current-quant-distann-simd-differential/`
+- Captured: 2026-07-25 UTC
+- Host: Apple arm64 (`Darwin 25.4.0`, `RELEASE_ARM64_T6050`)
+- Scope: local differential tests and review evidence; no benchmark corpus, index,
+  rerank, or storage-format measurement applies because the checkpoint changes
+  only test/bench hooks, test cases, the local make lane, and documentation.
+- Isolation: unit/integration process only; no PostgreSQL table or index was used.
+
+## Artifacts
+
+### `make-simd-diff.log`
+
+- Command: `make simd-diff`
+- Status: PASS
+- Locally executed ISA: AArch64 NEON and dot-product/SDOT.
+- Reported unavailable on this host: x86 AVX2/FMA, x86 AVX-512, AArch64
+  SVE/SVE2.
+- Key results:
+  - public bench-hook integration: 10 passed
+  - RaBitQ arithmetic inventory: 2 passed
+  - `rabitq32`: 7 passed
+  - `qjl32`: 10 passed
+  - `lut32`: 9 passed
+  - grouped PQ: 8 passed
+  - int8/SDOT: 5 passed
+  - `hamming32`: 3 passed
+  - DistANN composition: 2 passed
+
+### `distann-simd-diff.log`
+
+- Command:
+  `cargo test --lib --features bench simd_diff_ -- --test-threads=1 --nocapture`
+- Status: PASS (2 passed)
+- Key results:
+  - exact DistANN distance is the negation of the shared DiskANN source-inner-
+    product path
+  - grouped PQ (64 dimensions), RaBitQ (1536), and TurboQuant (1536) prepared
+    batch scores match direct per-code scores for widths
+    `1,7,8,9,16,17,31,32,33`
+  - poison payload beyond `count * stride` is ignored
+
+### `mutation-control-failure.log`
+
+- Command: `make simd-diff`
+- Temporary mutation:
+  `score_candidate_neon_dotprod` returned
+  `sum as f32 * prepared.score_scale + 1.0`.
+- Status: EXPECTED FAILURE (`make` exit 2; Rust test exit 101).
+- Key result: four int8/SDOT differential tests failed, covering direct
+  legacy-vs-SDOT, block/partial dispatch, extreme i8 inputs, and dimension
+  tails. The mutation was then reverted; `git diff --exit-code --
+  src/quant/int8_approx32/neon.rs` passed before the final green lane.
+
+### `cargo-fmt-check.log`
+
+- Command: `cargo fmt --all -- --check`
+- Status: FAIL (pre-existing repository-wide formatting drift).
+- The output includes many files and older regions outside this checkpoint.
+  It also reports older formatting drift elsewhere in the two DistANN files
+  that received narrowly appended tests. A repository-wide rewrite was not
+  included in Task 36.
+- `git diff --cached --check` passed before the implementation commit, and the
+  committed checkpoint has no whitespace errors reported by `git diff`.
+
+## Claim boundary
+
+This packet makes a local Apple arm64 claim only. It does not claim CI coverage
+or execution on Intel or Graviton. AVX2/AVX-512 and SVE/SVE2 implementations
+that exist in the source inventory remain hardware validation follow-ups.

--- a/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/mutation-control-failure.log
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/artifacts/mutation-control-failure.log
@@ -1,0 +1,366 @@
+task36 simd-diff: public bench hooks (Prod/FWHT/HNSW/DiskANN)
+cargo test --features bench --test simd_diff -- --test-threads=1 --nocapture
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 2m 31s
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-3eb2e7ac5b649314)
+
+running 10 tests
+test am_source_inner_product_simd_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_code_to_code_score_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_fwht_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_score_ip_from_parts_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test forced_neon_fwht_matches_scalar_reference_when_available ... ok
+test forced_neon_score_paths_match_scalar_reference_when_available ... ok
+test host_backend_inventory_is_visible ... task36_host arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false unavailable=x86_avx2_fma,x86_avx512
+ok
+test packed_mse_indices_roundtrip_across_widths ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test production_1536_4bit_score_path_matches_scalar_reference ... ok
+test three_bit_unpack_fixture_stays_bit_exact ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.89s
+
+task36 simd-diff: RaBitQ arithmetic SIMD inventory
+cargo test --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 57.48s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 2 tests
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... task36_rabitq kernel=scalar_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=1536 status=exercised
+ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2517 filtered out; finished in 0.01s
+
+task36 simd-diff: rabitq32 bits=1/2/4 block and partial kernels
+cargo test --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.31s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 7 tests
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... task36_rabitq32 bits=2 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=2 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 2512 filtered out; finished in 0.04s
+
+task36 simd-diff: qjl32 block/octet/remainder kernels
+cargo test --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 10 tests
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_batch_with_blocks_and_tail_matches_pre_slice_scorer_bits ... task36_qjl32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2509 filtered out; finished in 0.23s
+
+task36 simd-diff: lut32 block/partial/tiled kernels
+cargo test --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 9 tests
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 2510 filtered out; finished in 0.02s
+
+task36 simd-diff: grouped-PQ block/partial kernels
+cargo test --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 8 tests
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2511 filtered out; finished in 0.00s
+
+task36 simd-diff: int8/SDOT block/partial kernels
+cargo test --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 5 tests
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ...
+thread 'quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits' (33712970) panicked at src/quant/int8_approx32/neon.rs:228:17:
+assertion `left == right` failed: dims=7
+  left: 3307322368
+ right: 3307326464
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+FAILED
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ...
+thread 'quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference' (33712971) panicked at src/quant/int8_approx32/mod.rs:132:13:
+assertion `left == right` failed
+  left: 1082322044
+ right: 1078319353
+FAILED
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ...
+thread 'quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values' (33712972) panicked at src/quant/int8_approx32/mod.rs:250:13:
+assertion `left == right` failed
+  left: 1253139202
+ right: 1253139200
+FAILED
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ...
+thread 'quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference' (33712974) panicked at src/quant/int8_approx32/mod.rs:204:21:
+assertion `left == right` failed
+  left: 1164825600
+ right: 1164821504
+FAILED
+
+failures:
+
+failures:
+    quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits
+    quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference
+    quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values
+    quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference
+
+test result: FAILED. 1 passed; 4 failed; 0 ignored; 0 measured; 2514 filtered out; finished in 0.05s
+
+error: test failed, to rerun pass `--lib`
+make: *** [simd-diff] Error 101

--- a/reviews/task-36/002-current-quant-distann-simd-differential/feedback/2026-07-25-01-reviewer.md
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/feedback/2026-07-25-01-reviewer.md
@@ -1,0 +1,258 @@
+---
+agent: claude
+role: reviewer
+model: claude-opus-5[1m]
+date: 2026-07-25
+seq: 01
+---
+
+# Review Feedback: Task 36 packet 002 — current quant / DistANN SIMD differential
+
+Reviewed checkpoint `c373eb51f`, packet
+`reviews/task-36/002-current-quant-distann-simd-differential/`.
+Host: Apple M5, aarch64 NEON + dotprod, no SVE. Verification was done in a
+clean worktree at the review head, not in the coder's tree.
+
+## Verdict
+
+**APPROVE WITH FLAGS.** This is a real, well-evidenced expansion of the lane
+and it lands the thing Task 36 most needed: the kernel families that arrived
+after the May packet are now inside `make simd-diff`, with forced-backend
+assertions that turn silent skips into failures on aarch64. The honesty of the
+packet is notably good — the placeholder modules are labelled as placeholders,
+the hardware boundary is stated rather than implied, and the CI overclaim from
+the previous cycle was removed rather than defended.
+
+Flags below are all follow-ups, not blockers, with one exception I would like
+fixed before this is cited as the basis for closing anything: the lane's filter
+list is silently lossy, and it is already losing a red test on this very commit
+(Flag 1).
+
+Correction to my own record: my `feedback/2026-07-25-01-reviewer.md` under
+packet 001 reviewed `48fc8ee21` on `task-132-134-tq-optimization-tests` — it
+predates and misses this branch entirely. Findings 1, 4 and 5 there are
+addressed or partly addressed by this checkpoint. Finding 3 there is still live
+and is repeated as Flag 1 below, because it reproduces on *this* branch too.
+
+## Independently reproduced
+
+`make simd-diff` at `c373eb51f` in a clean worktree, exit 0, all nine stages,
+counts matching `artifacts/manifest.md` exactly:
+
+    artifacts/2026-07-25-reviewer-make-simd-diff-repro.log
+
+    task36_host arch=aarch64 backend=neon neon=true dotprod=true
+      sve=false sve2=false unavailable=x86_avx2_fma,x86_avx512
+    public bench hooks .......... 10 passed
+    RaBitQ arithmetic ...........  2 passed
+    rabitq32 ....................  7 passed
+    qjl32 ....................... 10 passed
+    lut32 .......................  9 passed
+    grouped-PQ ..................  8 passed
+    int8/SDOT ...................  5 passed
+    hamming32 ...................  3 passed
+    DistANN composition .........  2 passed
+
+The `cargo fmt` claim also checks out and I want to record that, because
+"inherited drift" is the kind of claim that deserves verification rather than
+trust. Running rustfmt per-file against the merge base `1b4be76d0`:
+`src/am/ec_distann/insert.rs` has 16 hunks before and 16 after;
+`quantizer.rs` has 5 before and 5 after. The diffs land in pre-existing code
+(`insert.rs:100`, `:183`, `quantizer.rs:209`, `:249`), never in the added test
+blocks. 125 files repo-wide are affected, consistent with a rustfmt version
+skew rather than anything in this change. The packet's characterisation is
+accurate and declining to do a 125-file reformat inside a test packet is the
+right call.
+
+## Flag 1 (MEDIUM, please fix) — the lane's name filters fail open, and are already failing open
+
+Eight of the nine stages select tests by name substring. `cargo test` exits **0**
+when a filter matches nothing:
+
+    artifacts/2026-07-25-reviewer-empty-filter-exit0.log
+    $ cargo test --features bench --test simd_diff -- quant::nonexistent_zzz
+    test result: ok. 0 passed; 0 failed; ...; 10 filtered out
+    EXIT=0
+
+So renaming a test, renaming a module, or moving a kernel silently removes that
+family from the lane while the lane stays green. For a lane whose entire
+purpose is "coverage must not disappear quietly", that is the wrong default —
+and it is not hypothetical. The filter list has no `quant::prod::tests::`
+stage, and on this very commit that suite is **red**:
+
+    artifacts/2026-07-25-reviewer-prod-tests-red.log
+
+    test quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane
+      - should panic ... FAILED
+    panicked at src/quant/prod.rs:1842:5
+    test result: FAILED. 43 passed; 1 failed; 1 ignored; 2474 filtered out
+
+`make simd-diff` is green on the same commit. The inventory in
+`docs/hardening.md` lists "`prod` TurboQuant split-score and code-to-code
+score: scalar, AVX2+FMA, and NEON" as covered, and it is — but only through the
+public hooks in `tests/simd_diff.rs`. The in-library `prod` suite, where the
+TurboQuant query-prep guards live, is in no stage.
+
+The underlying failure is from `3d66bdcf3` (task-125 int16-LUT work, now on
+`main`), which rewrote `prepare_ip_query_tiled_lut_no_qjl_4bit` to build the
+f32 LUT inline and dropped the query-length assert and the no-QJL/4-bit lane
+guard it had inherited by delegating to `prepare_ip_query_lut_no_qjl_4bit`
+(`src/quant/prod.rs:378` still has both; `:401` has neither). Production call
+sites remain guarded — `src/am/ec_hnsw/scan.rs:2146` raises `pgrx::error!`
+first — so this is not a live wrong-answer path. But unguarded it builds a
+stride-16 LUT from an 8-entry codebook, caught by a `debug_assert` that release
+compiles out. Fixing it is not this packet's job; noticing it is exactly what
+this lane is for, and the lane did not.
+
+Two asks:
+
+1. Add a `quant::prod::tests::` stage (the family is already in the documented
+   inventory, so this is closing a stated-vs-actual gap, not scope creep).
+2. Make the filters fail closed. The cheapest version that works is asserting
+   the expected count per stage, e.g. piping through a check on
+   `test result: ok. N passed`, or a single guard test that enumerates the
+   expected suite names and fails when one vanishes. Either turns a silent
+   coverage loss into a red lane.
+
+## Flag 2 (MEDIUM) — the "not a skip" rule is documented for x86 but implemented only for aarch64
+
+`docs/hardening.md` now says:
+
+> A host-reachable primary backend (NEON on aarch64 or AVX2+FMA on x86)
+> returning "unavailable" is a test failure, not a skip.
+
+True on aarch64 after this change — converting the `if let Some(..)` guards to
+`.expect("aarch64 Task 36 lane requires ...")` in `tests/simd_diff.rs` is the
+right fix and I checked that both forced-NEON tests genuinely executed here
+rather than passing vacuously. But every x86 branch in the same file is
+untouched and still `if let Some(..)`:
+`hnsw_source_inner_product_avx2_fma_for_test`,
+`diskann_source_inner_product_avx2_fma_for_test`,
+`forced_avx2_fma_score_paths_...`, `forced_avx2_fwht_...`.
+
+`host_backend_inventory_is_visible` does assert `avx2 && fma` on x86, which
+limits the blast radius, but it asserts *feature detection*, not that the
+kernels ran. Given the stated M5 scope I am not asking for x86 work to be done
+blind — either mirror the `.expect()` (mechanical, and the Intel host will tell
+you immediately if it is wrong) or narrow the sentence to say the rule is
+enforced on aarch64 today and is owed on x86. As written the doc describes a
+guarantee the x86 lane does not have.
+
+## Flag 3 (MEDIUM) — `int8_approx32` is the one family with no ISA assertion, and it is the family the mutation control rests on
+
+`docs/hardening.md` says the lane "prints the detected host features and the
+ISA each family exercised". For `int8_approx32` it prints host features only:
+
+    eprintln!("task36_int8_approx32 neon={} dotprod={} widths=...",
+              is_aarch64_feature_detected!("neon"),
+              is_aarch64_feature_detected!("dotprod"));
+
+That is a statement about the CPU, not about what the kernel did. Both
+`score_int8_approx_block32` and `score_int8_approx_partial` return
+`crate::quant::isa::Isa` (`src/quant/int8_approx32/mod.rs:39`, `:63`) and the
+tests discard it. `rabitq32` does this correctly — `assert_eq!(block_isa,
+multibit_block_isa())`, now extended to the partial path too — and `hamming32`
+asserts `assert_eq!(isa, host_expected_simd_isa())`. `int8_approx32` is the
+only holdout, and the fix is binding the return value.
+
+This matters more than its size suggests: `int8/SDOT` is the family the
+mutation control used (`score_candidate_neon_dotprod` returning `+ 1.0`, four
+tests failing). That evidence proves the comparisons are live *on a host where
+dispatch chose SDOT*. Without an ISA assertion it does not prove the lane would
+stay honest if dispatch ever routed elsewhere — `ECAZ_SIMD=scalar` in the
+environment turns those five tests into scalar-vs-scalar passes while the lane
+prints `neon=true dotprod=true`. Pin it and the mutation control means what the
+manifest says it means.
+
+## Flag 4 (LOW) — a bit-exact assertion was demoted to 4 ULP without saying so
+
+`src/quant/qjl32/mod.rs`, `qjl32_scalar_matches_pre_slice_scorer_bits`:
+
+    -   assert_eq!(score.to_bits(), pre_slice.to_bits());
+    +   assert_close(*score, pre_slice, 4);
+
+`docs/hardening.md` documents "QJL allows 4 ULP or relative `1e-6`" in the new
+equality-contract list, so the end state is disclosed — but neither
+`request.md` nor `manifest.md` flags that this is a *loosening* of an
+assertion that was previously bit-exact, and the repo rule is that tolerance
+changes come with a packet explaining the numeric reason. I assume the reason
+is that the new sub-block widths route through the octet and remainder paths,
+whose accumulation order differs from the batch path that the old single-width
+(39) fixture exercised. If so, say that in the packet — and consider keeping
+`to_bits()` equality for the widths where it still holds (32, 33) and applying
+the 4 ULP slack only below an octet. A tolerance that is wider than the math
+requires is a place future regressions hide.
+
+Same file, smaller: the new `eprintln!` reports
+`crate::quant::isa::current_isa().label()`, which is the host's dispatch
+choice, not the ISA the QJL batch actually took. `hamming32`'s partial test has
+the same shape — it prints `host_expected_simd_isa()`, an expectation, because
+`score_hamming_partial` returns no ISA. Both are honest-ish but they read as
+observations. Worth a word in the doc distinguishing "printed expectation" from
+"asserted observation".
+
+## Flag 5 (LOW) — the CI job now covers strictly less than the local lane
+
+Removing the "PR-visible" claim was the right call and I want to credit it: at
+HEAD `.github/workflows/ci.yml` is `on: workflow_dispatch:` only (`push` and
+`pull_request` removed in `1c22a8329`, the crons in `67f23b56b`, 2026-06-29),
+so nothing in it gates a PR. The new wording — "This local lane does not by
+itself claim CI coverage" — is accurate.
+
+The leftover is that the `simd-diff` job still runs only
+`cargo test --features bench --test simd_diff`, i.e. the public-hook stage
+alone, while `make simd-diff` is now nine stages. Whenever that workflow is
+re-armed it will silently under-cover. Change the job step to `make simd-diff`
+so the two cannot drift, and note in the task file that the arm64 leg of that
+matrix is the only NEON coverage in CI — the `full` job in
+`build-matrix-aarch64-linux-gnu.yml` that would run the library suites on
+arm64 is gated `if: github.event_name == 'schedule'` on a workflow whose
+trigger block has no `schedule`, so it is unreachable except by manual
+dispatch.
+
+## Review-focus answers
+
+1. **Does the lane enumerate current kernel families without presenting
+   placeholders as real SIMD?** Yes, and this is the strongest part of the
+   packet. Calling `hamming32`'s AVX2/SVE modules and `rabitq32`'s SVE module
+   routing placeholders, while claiming real SVE only for `qjl32`, `lut32`, and
+   `grouped_pq_block`, is the correct distinction and one that is easy to blur.
+   The one enumeration gap is `prod`'s in-library suite (Flag 1).
+2. **Do the DistANN tests validate composition rather than retest kernels?**
+   Yes. `simd_diff_distann_codec_batches_match_direct_scalar_scores_across_widths`
+   tests the binding, not the kernel: prepared-batch vs direct per-code,
+   `count × stride` slicing, and the `0xA5` poison payload past the requested
+   count, which is a genuinely good way to catch a slab over-read that a
+   scores-match assertion alone would miss.
+   `simd_diff_exact_distance_is_shared_diskann_inner_product_negation` pinning
+   `exact_distance == -source_inner_product` bit-for-bit is the right shape for
+   an intentional delegation.
+3. **Are exact equality and `1e-5` used at the right boundaries?** Mostly yes.
+   Integer/LUT paths bit-exact, RaBitQ block-vs-scalar-anchor at `1e-5`, and
+   the DistANN split (bit-exact for GroupedPq/TurboQuant where batch and direct
+   share accumulation order, `1e-5` for RaBitQ where they do not) is correctly
+   reasoned. The unexplained QJL demotion is the exception (Flag 4).
+4. **Is the local-only hardware claim clear enough?** Yes. "Unavailable paths
+   must be listed as unexecuted rather than inferred from compilation" is the
+   right standard and the manifest follows it. Agreed that Intel AVX2/AVX-512
+   and Graviton SVE/SVE2 execution stay owed; SVE in particular is currently
+   proven on no host in this project, which is worth stating in the task file
+   rather than leaving implied.
+
+## Agreed: this is not closeout
+
+Concur with the request's own framing. Task 36 stays open. The additions here
+are test/bench-only and change no production scoring path, so the 10/50/100k
+benchmark rule does not attach to this checkpoint — the manifest says exactly
+that, correctly.
+
+## Suggested order
+
+1. Flag 1 — add the `prod` stage and make filters fail closed.
+2. Flag 3 — one-line ISA pin on `int8_approx32`.
+3. Flag 2 — mirror `.expect()` on x86 or narrow the doc sentence.
+4. Flag 4 — justify or tighten the QJL tolerance.
+5. Flag 5 — point the CI job at `make simd-diff`.
+
+Nice work on this one. The inventory table and the placeholder honesty are the
+parts I would keep as the template for the Intel and Graviton packets.

--- a/reviews/task-36/002-current-quant-distann-simd-differential/request.md
+++ b/reviews/task-36/002-current-quant-distann-simd-differential/request.md
@@ -1,0 +1,61 @@
+---
+task: 36
+agent: codex
+role: coder
+model: GPT-5
+date: 2026-07-24
+head: c373eb51f61654226f81b489a4be4a40e6e45025
+---
+
+# Review request: current quant, DistANN, and SIMD differential coverage
+
+Please review checkpoint `c373eb51f61654226f81b489a4be4a40e6e45025`.
+This is a review request, not Task 36 closeout.
+
+## What changed
+
+- Made `make simd-diff` the explicit local inventory lane for current product
+  scoring/FWHT hooks, RaBitQ arithmetic and `rabitq32`, QJL, LUT, grouped PQ,
+  int8/SDOT, Hamming, HNSW/DiskANN source scoring, and DistANN composition.
+- Added forced host-backend assertions so locally available NEON paths cannot
+  silently skip.
+- Expanded block/tail coverage over candidate widths
+  `1,7,8,9,16,17,31,32,33`, dimension tails, and production dimensions up to
+  1536.
+- Added DistANN codec-composition tests for grouped PQ, RaBitQ, and TurboQuant,
+  including prepared-vs-direct scoring, `count * stride` slicing, poison
+  payload, and exact-distance sign composition.
+- Documented the kernel-to-access-method inventory, equality/tolerance policy,
+  and the boundary between local Apple evidence and future Intel/Graviton
+  hardware evidence.
+
+All Rust source additions are test-only or test/bench hooks; production scoring
+behavior is unchanged.
+
+## Evidence
+
+See [artifacts/manifest.md](artifacts/manifest.md) for provenance and exact
+commands.
+
+- [make-simd-diff.log](artifacts/make-simd-diff.log): full post-revert lane
+  passed on AArch64 NEON + dot-product/SDOT.
+- [distann-simd-diff.log](artifacts/distann-simd-diff.log): focused DistANN
+  composition passed (2 tests).
+- [mutation-control-failure.log](artifacts/mutation-control-failure.log):
+  deliberate `+1.0` SDOT scoring defect was caught by four comparisons.
+- [cargo-fmt-check.log](artifacts/cargo-fmt-check.log): required global check
+  captured; it fails on inherited repository-wide formatting drift. No broad
+  formatting rewrite is included here.
+
+## Review focus
+
+1. Does the make lane accurately enumerate the current implemented kernel
+   families without presenting placeholders as real SIMD?
+2. Do the DistANN tests validate access-method composition rather than merely
+   retesting isolated quantizer kernels?
+3. Are exact equality and `1e-5` tolerance used at the correct boundaries?
+4. Is the local-only hardware claim sufficiently clear? Intel AVX2/AVX-512 and
+   Graviton SVE/SVE2 execution are intentionally left for later host runs.
+
+Task 36 should remain open until an outside reviewer responds and the deferred
+hardware lanes are handled.

--- a/reviews/task-36/003-review-findings-corrections/artifacts/cargo-fmt-check.log
+++ b/reviews/task-36/003-review-findings-corrections/artifacts/cargo-fmt-check.log
@@ -1,0 +1,1828 @@
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/crates/ecaz-cli/src/commands/corpus/load.rs:2191:
+         stop.store(true, Ordering::SeqCst);
+         task.await
+             .map_err(|error| eyre!("build memory monitor task failed: {error}"))??;
+-        if let Some(after) = crate::commands::bench::latency::read_proc_status_memory(backend_pid)
+(B-            .await?
+(B+        if let Some(after) =
+(B+            crate::commands::bench::latency::read_proc_status_memory(backend_pid).await?
+(B         {
+             peak.lock().await.merge(after);
+         }
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/am/ec_diskann/scan.rs:1591:
+         // A chain graph exposes few admissible frontier entries per
+         // round, so the beam cannot widen flushes much here — but
+         // batching rounds must never *increase* the flush count.
+-        let flushes = |p: &FrontierProfile| {
+(B-            p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>()
+(B-        };
+(B+        let flushes =
+(B+            |p: &FrontierProfile| p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>();
+(B         assert!(
+             flushes(&profile) <= flushes(&sequential_profile),
+             "batched rounds must not exceed the sequential flush count"
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/am/ec_ivf/page.rs:3507:
+         "ec_ivf posting entry block sequence",
+         |buffer, block_number| {
+             let decode_started = std::time::Instant::now();
+-            let result =
+(B-                visit_all_ivf_posting_entries_from_buffer(buffer, block_number, payload_len, visitor);
+(B+            let result = visit_all_ivf_posting_entries_from_buffer(
+(B+                buffer,
+(B+                block_number,
+(B+                payload_len,
+(B+                visitor,
+(B+            );
+(B             decode_elapsed += decode_started.elapsed();
+             result
+         },
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/quant/int8_approx32/mod.rs:97:
+     use crate::quant::prod::ProdQuantizer;
+
+     fn assert_host_simd_isa(actual: crate::quant::isa::Isa) {
+-        let expected = crate::quant::isa::select_highest_isa(
+(B-            crate::quant::isa::HostIsaFeatures::detect(),
+(B-        );
+(B+        let expected =
+(B+            crate::quant::isa::select_highest_isa(crate::quant::isa::HostIsaFeatures::detect());
+(B         assert_eq!(
+             actual, expected,
+             "int8 differential test did not execute the host's preferred SIMD ISA"
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/quant/int8_approx32/mod.rs:136:
+
+         let block: &[&[u8]; BLOCK_WIDTH] = code_refs[..BLOCK_WIDTH].try_into().unwrap();
+         let mut block_scores = vec![0.0; BLOCK_WIDTH];
+-        let block_isa =
+(B-            score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+(B+        let block_isa = score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+(B         assert_host_simd_isa(block_isa);
+         for (score, code) in block_scores.iter().zip(code_refs[..BLOCK_WIDTH].iter()) {
+             let reference = score_int8_approx_scalar(&prepared, dimensions, code);
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/storage/page.rs:341:
+         assert_eq!(second.block_number, base, "same page while it fits");
+         assert_eq!(third.block_number, base + 1, "next page is base+1");
+         // Lookups resolve against the base.
+-        assert_eq!(chain.get_page(first.block_number).unwrap().raw_tuple(first).unwrap(), &[1; 32]);
+(B-        assert_eq!(chain.get_page(third.block_number).unwrap().raw_tuple(third).unwrap(), &[3; 32]);
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(first.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(first)
+(B+                .unwrap(),
+(B+            &[1; 32]
+(B+        );
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(third.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(third)
+(B+                .unwrap(),
+(B+            &[3; 32]
+(B+        );
+(B         // Below-base blocks are not in this chain.
+         assert!(chain.get_page(base - 1).is_none());
+         // pages() carry the base-relative block numbers for write_data_pages.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/src/am/ec_diskann/options.rs:194:
+ }
+
+ pub(super) fn current_beam_width() -> usize {
+-    usize::try_from(ECDISKANN_BEAM_WIDTH_GUC.get()).unwrap_or(1).max(1)
+(B+    usize::try_from(ECDISKANN_BEAM_WIDTH_GUC.get())
+(B+        .unwrap_or(1)
+(B+        .max(1)
+(B }
+
+ pub(super) fn scan_profile_notice_enabled() -> bool {
+Diff in /Users/peter/dev/tqvector/src/am/ec_diskann/scan.rs:1591:
+         // A chain graph exposes few admissible frontier entries per
+         // round, so the beam cannot widen flushes much here — but
+         // batching rounds must never *increase* the flush count.
+-        let flushes = |p: &FrontierProfile| {
+(B-            p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>()
+(B-        };
+(B+        let flushes =
+(B+            |p: &FrontierProfile| p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>();
+(B         assert!(
+             flushes(&profile) <= flushes(&sequential_profile),
+             "batched rounds must not exceed the sequential flush count"
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/build_gate.rs:358:
+         if rt_index <= 0 || rt_index > table_length {
+             continue;
+         }
+-        let rte = unsafe {
+(B-            pg_sys::list_nth(stmt.rtable, rt_index - 1).cast::<pg_sys::RangeTblEntry>()
+(B-        };
+(B+        let rte =
+(B+            unsafe { pg_sys::list_nth(stmt.rtable, rt_index - 1).cast::<pg_sys::RangeTblEntry>() };
+(B         let Some(rte) = (unsafe { rte.as_ref() }) else {
+             continue;
+         };
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/canonical_wire.rs:20:
+     code: &str,
+     field: &str,
+ ) -> Result<[u8; N], String> {
+-    bytes.try_into().map_err(|bytes: Vec<u8>| {
+(B-        format!(
+(B-            "{code}: {field} is {} bytes, expected {N}",
+(B-            bytes.len()
+(B-        )
+(B-    })
+(B+    bytes
+(B+        .try_into()
+(B+        .map_err(|bytes: Vec<u8>| format!("{code}: {field} is {} bytes, expected {N}", bytes.len()))
+(B }
+
+-pub(crate) fn fixed_digest(
+(B-    bytes: Vec<u8>,
+(B-    code: &str,
+(B-    field: &str,
+(B-) -> Result<[u8; 32], String> {
+(B+pub(crate) fn fixed_digest(bytes: Vec<u8>, code: &str, field: &str) -> Result<[u8; 32], String> {
+(B     fixed_bytes(bytes, code, field)
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/coordinator_retirement.rs:508:
+                             .value::<Vec<u8>>()
+                             .map_err(|_| "EC_EPOCH_STATE: retire digest decode failed".to_owned())?
+                             .ok_or_else(|| "EC_EPOCH_STATE: retire digest is NULL".to_owned())?,
+-                        state: RetireDecisionState::parse(&row["decision_state"]
+(B-                            .value::<String>()
+(B-                            .map_err(|_| "EC_EPOCH_STATE: retire state decode failed".to_owned())?
+(B-                            .ok_or_else(|| "EC_EPOCH_STATE: retire state is NULL".to_owned())?)?,
+(B+                        state: RetireDecisionState::parse(
+(B+                            &row["decision_state"]
+(B+                                .value::<String>()
+(B+                                .map_err(|_| {
+(B+                                    "EC_EPOCH_STATE: retire state decode failed".to_owned()
+(B+                                })?
+(B+                                .ok_or_else(|| "EC_EPOCH_STATE: retire state is NULL".to_owned())?,
+(B+                        )?,
+(B                         xmin: row["decision_xmin"]
+                             .value::<String>()
+                             .map_err(|_| {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/coordinator_retirement.rs:658:
+                         stored.build_id.into(),
+                     ],
+                 )
+-                .map_err(|error| {
+(B-                    format!("EC_EPOCH_STATE: head-sample reclaim failed: {error}")
+(B-                })?;
+(B+                .map_err(|error| format!("EC_EPOCH_STATE: head-sample reclaim failed: {error}"))?;
+(B             Ok::<(), String>(())
+         })?;
+         let updated = Spi::connect_mut(|client| {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/cost.rs:67:
+                 let constants = unsafe { current_planner_cost_constants() };
+                 // Per-query work is BW x H expansions (NFR-019); model the
+                 // search breadth as that product.
+-                let ef_search = i32::try_from(
+(B-                    options::current_beam_width() * options::current_hop_rounds(),
+(B-                )
+(B-                .unwrap_or(i32::MAX);
+(B+                let ef_search =
+(B+                    i32::try_from(options::current_beam_width() * options::current_hop_rounds())
+(B+                        .unwrap_or(i32::MAX);
+(B                 estimate_planner_cost(
+                     PlannerCostInputs {
+                         index_pages: index_pages_value,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/custom_scan.rs:1208:
+         .iter()
+         .take(previous_proven)
+         .position(|output| {
+-            output
+(B-                .as_ref()
+(B-                .and_then(materialized_remote_output_vec_id)
+(B-                == Some(vec_id)
+(B+            output.as_ref().and_then(materialized_remote_output_vec_id) == Some(vec_id)
+(B         })?;
+     previous_outputs.get_mut(position)?.take()
+ }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/custom_scan.rs:1773:
+ #[cfg(test)]
+ mod materialization_candidate_tests {
+     use super::{
+-        pending_materialization_window, take_materialized_remote_output_by_id,
+(B-        CustomScanOutputRow,
+(B+        pending_materialization_window, take_materialized_remote_output_by_id, CustomScanOutputRow,
+(B     };
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:85:
+     // are not already tombstoned (monotone: never re-flip).
+     let mut to_tombstone: Vec<ItemPointer> = Vec::new();
+     for (_vec_id, record_tid) in &directory {
+-        let raw = read_raw_tuple_bytes_from_relation(
+(B-            handle,
+(B-            *record_tid,
+(B-            "ec_distann tombstone scan",
+(B-        )?;
+(B+        let raw =
+(B+            read_raw_tuple_bytes_from_relation(handle, *record_tid, "ec_distann tombstone scan")?;
+(B         if raw.first().copied() != Some(DISTANN_NODE_TAG)
+             || raw.len() < DISTANN_NODE_HEAP_TID_OFFSET + 6
+         {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:180:
+     let handle = NonNull::new(index_relation).ok_or_else(|| {
+         DistannExpandError::Internal("ec_distann tombstone needs a valid index relation".to_owned())
+     })?;
+-    let metadata =
+(B-        read_metadata_from_index_handle(handle).map_err(DistannExpandError::Internal)?;
+(B+    let metadata = read_metadata_from_index_handle(handle).map_err(DistannExpandError::Internal)?;
+(B     super::require_legacy_local_storage(&metadata, "ec_distann tombstone")
+         .map_err(DistannExpandError::GenerationMissing)?;
+     if vec_ids.is_empty() {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:205:
+                 "ec_distann tombstone: vec_id {vec_id:#018x} is not in the directory"
+             ))
+         })?;
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, record_tid, "ec_distann tombstone by vec_id")
+(B-                .map_err(DistannExpandError::Internal)?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(
+(B+            handle,
+(B+            record_tid,
+(B+            "ec_distann tombstone by vec_id",
+(B+        )
+(B+        .map_err(DistannExpandError::Internal)?;
+(B         let flags = u16::from_le_bytes(
+             raw[DISTANN_NODE_FLAGS_OFFSET..DISTANN_NODE_FLAGS_OFFSET + 2]
+                 .try_into()
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:358:
+ /// Append one delta tuple on a freshly-extended page (one entry per page: a
+ /// dim-1536 entry is ~6 KB, near a page anyway, and the buffer is bounded).
+ /// WAL-logged. Returns the new tuple's TID.
+-fn append_delta_tuple(
+(B-    handle: RelationHandle,
+(B-    payload: Vec<u8>,
+(B-) -> Result<ItemPointer, String> {
+(B+fn append_delta_tuple(handle: RelationHandle, payload: Vec<u8>) -> Result<ItemPointer, String> {
+(B     let buffer = LockedBufferGuard::read_main_locked_handle(
+         handle,
+         P_NEW,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch.rs:214:
+             let mut id = base_identity();
+             mutate(&mut id);
+             let changed = compute_epoch_fingerprint(&id, DISTANN_EPOCH_FINGERPRINT_V1);
+-            assert_ne!(base, changed, "mutator {index} did not change the fingerprint");
+(B+            assert_ne!(
+(B+                base, changed,
+(B+                "mutator {index} did not change the fingerprint"
+(B+            );
+(B             assert!(!fingerprints_match(&base, &changed));
+         }
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch_manifest.rs:57:
+     Ok(result)
+ }
+
+-fn read_metadata(index_oid: pg_sys::Oid, caller: &'static str) -> Result<DistannMetadataPage, String> {
+(B+fn read_metadata(
+(B+    index_oid: pg_sys::Oid,
+(B+    caller: &'static str,
+(B+) -> Result<DistannMetadataPage, String> {
+(B     let guard = IndexRelationGuard::open(
+         index_oid,
+         pg_sys::AccessShareLock as pg_sys::LOCKMODE,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch_manifest.rs:175:
+         name!(in_flight_count, i64),
+     ),
+ > {
+-    let metadata =
+(B-        read_metadata(index_regclass, "ec_distann_epoch_status").unwrap_or_else(|e| pgrx::error!("{e}"));
+(B+    let metadata = read_metadata(index_regclass, "ec_distann_epoch_status")
+(B+        .unwrap_or_else(|e| pgrx::error!("{e}"));
+(B     TableIterator::new(std::iter::once((
+         epoch_state_name(metadata.epoch_state).to_owned(),
+         metadata.active_epoch as i64,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch_manifest.rs:192:
+ fn ec_distann_debug_set_in_flight(index_regclass: pg_sys::Oid, count: i64) {
+     let count = u32::try_from(count)
+         .unwrap_or_else(|_| pgrx::error!("ec_distann_debug_set_in_flight: count out of range"));
+-    with_metadata_mut(index_regclass, "ec_distann_debug_set_in_flight", |metadata| {
+(B-        metadata.in_flight_count = count;
+(B-        Ok(())
+(B-    })
+(B+    with_metadata_mut(
+(B+        index_regclass,
+(B+        "ec_distann_debug_set_in_flight",
+(B+        |metadata| {
+(B+            metadata.in_flight_count = count;
+(B+            Ok(())
+(B+        },
+(B+    )
+(B     .unwrap_or_else(|e| pgrx::error!("{e}"));
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/expand.rs:58:
+                     tid.block_number, tid.offset_number
+                 ));
+             }
+-            DistannNodeTuple::decode_into(raw, self.graph_degree_r, self.code_len, &mut self.pooled_node)
+(B+            DistannNodeTuple::decode_into(
+(B+                raw,
+(B+                self.graph_degree_r,
+(B+                self.code_len,
+(B+                &mut self.pooled_node,
+(B+            )
+(B         })?;
+         match visit {
+             LockedPageTupleVisit::Present(()) => Ok(()),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/handoff_wire.rs:79:
+     pub(crate) fn from_descriptor(
+         descriptor: &super::generation_descriptor::DistannGenerationDescriptor,
+     ) -> Result<Self, String> {
+-        let binding = super::quantizer::DistannCodecBinding::from_artifact(
+(B-            &descriptor.codec_artifact,
+(B-        )?;
+(B+        let binding =
+(B+            super::quantizer::DistannCodecBinding::from_artifact(&descriptor.codec_artifact)?;
+(B         Self::new(
+             binding.code_len(usize::from(descriptor.dimensions))?,
+             usize::from(descriptor.graph_degree),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/head_cache.rs:132:
+         )
+     };
+     let head_seed = metadata.seed ^ DISTANN_HEAD_GRAPH_SEED_WRAP;
+-    let head_entry = crate::am::approximate_medoid(
+(B-        head_vectors.len(),
+(B-        head_vectors.len(),
+(B-        head_seed,
+(B-        head_dist,
+(B-    );
+(B+    let head_entry =
+(B+        crate::am::approximate_medoid(head_vectors.len(), head_vectors.len(), head_seed, head_dist);
+(B     let (head_graph, _stats) = crate::am::build_vamana_graph_with_stats(
+         head_vectors.len(),
+         head_entry,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/identity.rs:43:
+
+ /// vec_id for a heap TID (local mode; single-node posture only).
+ pub(crate) fn vec_id_from_local_heap_tid(heap_tid: ItemPointer) -> u64 {
+-    let packed =
+(B-        (u64::from(heap_tid.block_number) << 16) | u64::from(heap_tid.offset_number);
+(B+    let packed = (u64::from(heap_tid.block_number) << 16) | u64::from(heap_tid.offset_number);
+(B     fmix64(packed ^ DISTANN_VEC_ID_DOMAIN_LOCAL)
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:100:
+     let mut pairwise = vec![vec![0.0_f32; n]; n];
+     for left in 0..n {
+         for right in (left + 1)..n {
+-            let distance =
+(B-                exact_distance(&candidates[left].source_vector, &candidates[right].source_vector);
+(B+            let distance = exact_distance(
+(B+                &candidates[left].source_vector,
+(B+                &candidates[right].source_vector,
+(B+            );
+(B             pairwise[left][right] = distance;
+             pairwise[right][left] = distance;
+         }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:183:
+         return Err("ec_distann backlink planning max_degree must be > 0".to_owned());
+     }
+     // Already linked (idempotent — a re-inserted/duplicate edge is a no-op).
+-    if target.current_neighbors.iter().any(|n| n.vec_id == new_vec_id) {
+(B+    if target
+(B+        .current_neighbors
+(B+        .iter()
+(B+        .any(|n| n.vec_id == new_vec_id)
+(B+    {
+(B         return Ok(target.current_neighbors.iter().map(|n| n.vec_id).collect());
+     }
+     // Free slot: append, preserving existing edges.
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:306:
+     let new_code = binding.encode(new_source_vector);
+
+     // Directory first — the descent and the collision guard both need it.
+-    let directory =
+(B-        read_directory_from_relation(handle, metadata.directory_head, metadata.node_count as usize)?;
+(B+    let directory = read_directory_from_relation(
+(B+        handle,
+(B+        metadata.directory_head,
+(B+        metadata.node_count as usize,
+(B+    )?;
+(B     // 167-003-P2: reject a vec_id collision BEFORE appending. The directory is a
+     // strict-ascending vec_id set (the reader rejects duplicates); a duplicate
+     // insert (e.g. a retried fold) must error, never append a second record for
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:395:
+         })?;
+         let raw = read_raw_tuple_bytes_from_relation(handle, tid, "ec_distann insert forward")?;
+         let node = DistannNodeTuple::decode(&raw, graph_degree_r, code_len)?;
+-        forward.push(DistannInsertNeighbor { vec_id: fid, code: node.search_code });
+(B+        forward.push(DistannInsertNeighbor {
+(B+            vec_id: fid,
+(B+            code: node.search_code,
+(B+        });
+(B         forward_tids.push(tid);
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:527:
+             .map_err(|e| format!("ec_distann graph insert node add failed: {e:?}"))?
+     };
+     wal_txn.finish();
+-    Ok(ItemPointer { block_number, offset_number })
+(B+    Ok(ItemPointer {
+(B+        block_number,
+(B+        offset_number,
+(B+    })
+(B }
+
+ /// Amend a forward neighbor's adjacency to include `new_vec_id`, WAL-logged in
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:556:
+         pg_sys::BUFFER_LOCK_EXCLUSIVE as i32,
+     )
+     .ok_or_else(|| {
+-        format!("ec_distann backlink: could not open block {}", neighbor_tid.block_number)
+(B+        format!(
+(B+            "ec_distann backlink: could not open block {}",
+(B+            neighbor_tid.block_number
+(B+        )
+(B     })?;
+     let r = usize::from(graph_degree_r);
+     let vec_ids_off = distann_node_neighbor_vec_ids_offset(code_len);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:738:
+         let samples = vec![
+             (10_u64, vec![0.99, 0.01, 0.0]), // closest
+             (20, vec![0.0, 1.0, 0.0]),
+-            (30, vec![0.9, 0.1, 0.0]),   // 2nd closest
+(B-            (40, vec![-1.0, 0.0, 0.0]),  // farthest
+(B+            (30, vec![0.9, 0.1, 0.0]),  // 2nd closest
+(B+            (40, vec![-1.0, 0.0, 0.0]), // farthest
+(B         ];
+         let ranked = rank_insert_candidates(&new_vec, &samples, 2).unwrap();
+         assert_eq!(ranked.len(), 2, "limit respected");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:765:
+         let r: u16 = 4;
+         let code_len = 8;
+         let fwd = vec![
+-            DistannInsertNeighbor { vec_id: 111, code: vec![1_u8; code_len] },
+(B-            DistannInsertNeighbor { vec_id: 222, code: vec![2_u8; code_len] },
+(B+            DistannInsertNeighbor {
+(B+                vec_id: 111,
+(B+                code: vec![1_u8; code_len],
+(B+            },
+(B+            DistannInsertNeighbor {
+(B+                vec_id: 222,
+(B+                code: vec![2_u8; code_len],
+(B+            },
+(B         ];
+         let node = build_insert_node_tuple(
+             999,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:773:
+-            ItemPointer { block_number: 3, offset_number: 7 },
+(B+            ItemPointer {
+(B+                block_number: 3,
+(B+                offset_number: 7,
+(B+            },
+(B             vec![9_u8; code_len],
+             &fwd,
+             r,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:778:
+         )
+         .unwrap();
+         assert_eq!(node.vec_id, 999);
+-        assert_eq!(node.neighbor_count, 2, "count = real neighbors, not padding");
+(B+        assert_eq!(
+(B+            node.neighbor_count, 2,
+(B+            "count = real neighbors, not padding"
+(B+        );
+(B         assert_eq!(node.neighbor_vec_ids.len(), r as usize, "fixed R slots");
+         assert_eq!(node.neighbor_vec_ids[0], 111);
+-        assert_eq!(node.neighbor_vec_ids[2], 0, "slots past count are zero-padded");
+(B+        assert_eq!(
+(B+            node.neighbor_vec_ids[2], 0,
+(B+            "slots past count are zero-padded"
+(B+        );
+(B         assert!(!node.tombstoned);
+         // Round-trips through the on-disk encoding at fixed length.
+         let encoded = node.encode(r, code_len).unwrap();
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:788:
+         assert_eq!(encoded.len(), DistannNodeTuple::encoded_len(r, code_len));
+-        assert_eq!(DistannNodeTuple::decode(&encoded, r, code_len).unwrap(), node);
+(B+        assert_eq!(
+(B+            DistannNodeTuple::decode(&encoded, r, code_len).unwrap(),
+(B+            node
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:794:
+         let code_len = 8;
+         // Too many neighbors for R.
+         let many: Vec<_> = (0..5)
+-            .map(|i| DistannInsertNeighbor { vec_id: i, code: vec![0_u8; code_len] })
+(B+            .map(|i| DistannInsertNeighbor {
+(B+                vec_id: i,
+(B+                code: vec![0_u8; code_len],
+(B+            })
+(B             .collect();
+         assert!(
+-            build_insert_node_tuple(1, ItemPointer::INVALID, vec![0; code_len], &many, 4, code_len)
+(B-                .is_err(),
+(B+            build_insert_node_tuple(
+(B+                1,
+(B+                ItemPointer::INVALID,
+(B+                vec![0; code_len],
+(B+                &many,
+(B+                4,
+(B+                code_len
+(B+            )
+(B+            .is_err(),
+(B             "neighbors > R rejected"
+         );
+         // Wrong search_code length.
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:807:
+             "search_code len mismatch rejected"
+         );
+         // Wrong neighbor code length.
+-        let bad = vec![DistannInsertNeighbor { vec_id: 1, code: vec![0_u8; 4] }];
+(B+        let bad = vec![DistannInsertNeighbor {
+(B+            vec_id: 1,
+(B+            code: vec![0_u8; 4],
+(B+        }];
+(B         assert!(
+-            build_insert_node_tuple(1, ItemPointer::INVALID, vec![0; code_len], &bad, 4, code_len)
+(B-                .is_err(),
+(B+            build_insert_node_tuple(
+(B+                1,
+(B+                ItemPointer::INVALID,
+(B+                vec![0; code_len],
+(B+                &bad,
+(B+                4,
+(B+                code_len
+(B+            )
+(B+            .is_err(),
+(B             "neighbor code len mismatch rejected"
+         );
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:827:
+             ],
+         };
+         let kept = plan_insert_backlink(&target, 999, &[0.95, 0.05, 0.0], 1.2, 4).unwrap();
+-        assert_eq!(kept, vec![10, 20, 999], "free slot -> append, edges preserved");
+(B+        assert_eq!(
+(B+            kept,
+(B+            vec![10, 20, 999],
+(B+            "free slot -> append, edges preserved"
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:853:
+         let target = DistannBacklinkTarget {
+             vec_id: 100,
+             source_vector: vec![1.0, 0.0, 0.0],
+-            current_neighbors: vec![candidate(999, &[0.9, 0.1, 0.0]), candidate(10, &[0.8, 0.2, 0.0])],
+(B+            current_neighbors: vec![
+(B+                candidate(999, &[0.9, 0.1, 0.0]),
+(B+                candidate(10, &[0.8, 0.2, 0.0]),
+(B+            ],
+(B         };
+         let kept = plan_insert_backlink(&target, 999, &[0.9, 0.1, 0.0], 1.2, 4).unwrap();
+-        assert_eq!(kept, vec![999, 10], "already-linked -> unchanged (idempotent)");
+(B+        assert_eq!(
+(B+            kept,
+(B+            vec![999, 10],
+(B+            "already-linked -> unchanged (idempotent)"
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:863:
+     fn select_rejects_bad_input() {
+         let source = [1.0_f32, 0.0];
+-        assert!(select_insert_forward_neighbors(&[], &[], 1.2, 3).is_err(), "empty source");
+(B+        assert!(
+(B+            select_insert_forward_neighbors(&[], &[], 1.2, 3).is_err(),
+(B+            "empty source"
+(B+        );
+(B         assert!(
+             select_insert_forward_neighbors(&source, &[], 0.5, 3).is_err(),
+             "alpha < 1.0"
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:11:
+ //! materialization (Tasks 162–179).
+
+ mod ambuild;
+-mod build_gate;
+(B mod build_coordinator;
++mod build_gate;
+(B mod coordinator_abandonment;
+ #[cfg(any(test, feature = "pg_test"))]
++pub(crate) use self::ambuild::read_metadata_from_index;
+(B+#[cfg(any(test, feature = "pg_test"))]
+(B+pub(crate) use self::ambuild::test_physical_capture_dead_callback_does_not_access_datums;
+(B+pub(crate) use self::ambuild::{build_physical_graph_workspace, capture_physical_source_rows};
+(B+#[cfg(any(test, feature = "pg_test"))]
+(B pub(crate) use self::build_coordinator::build_session_lock_count_for_test;
+ #[cfg(any(test, feature = "pg_test"))]
+ pub(crate) use self::custom_scan::{
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:21:
+     exec_state_context_cleanups_for_test, reset_exec_state_context_cleanups_for_test,
+ };
+-#[cfg(any(test, feature = "pg_test"))]
+(B-pub(crate) use self::ambuild::read_metadata_from_index;
+(B-pub(crate) use self::ambuild::{
+(B-    build_physical_graph_workspace, capture_physical_source_rows,
+(B-};
+(B-#[cfg(any(test, feature = "pg_test"))]
+(B-pub(crate) use self::ambuild::{
+(B-    test_physical_capture_dead_callback_does_not_access_datums,
+(B-};
+(B mod canonical_wire;
+-mod cost;
+(B mod coordinator_retirement;
++mod cost;
+(B mod custom_scan;
+ mod dml;
+ mod epoch;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:51:
+ mod head_sample;
+ mod identity;
+ mod insert;
+-mod lifecycle_wire;
+(B mod lifecycle_guard;
+ mod lifecycle_state;
++mod lifecycle_wire;
+(B mod manifest_v2;
+ mod node_registry;
+ mod options;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:80:
+ pub(crate) mod scan;
+ mod shard_build;
+ mod source_spool;
+-mod traversal_replica;
+(B #[cfg(feature = "distann-head-attribution-benchmark")]
+ pub(crate) mod stage_counters;
++mod traversal_replica;
+(B pub mod tuple;
+
+ pub(crate) fn quote_ident(identifier: &str) -> String {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:90:
+ }
+
+ #[cfg(any(test, feature = "pg_test"))]
+-pub(crate) use self::generation_catalog::extension_relation_name as catalog_relation_name;
+(B-#[cfg(any(test, feature = "pg_test"))]
+(B pub(crate) use self::coordinator_retirement::ensure_fingerprint_not_retiring as ensure_fingerprint_not_retiring_for_test;
++#[cfg(any(test, feature = "pg_test"))]
+(B+pub(crate) use self::generation_catalog::extension_relation_name as catalog_relation_name;
+(B pub use self::generation_descriptor::{
+     roster_digest, DistannBuildOptions, DistannBuildSpec, DistannCodecArtifact,
+     DistannGenerationDescriptor, DistannHeadPolicy, DistannOwnerExpectation, DistannRosterEntry,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:107:
+     DISTANN_GENERATION_DESCRIPTOR_PLACEMENT_HASH_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET, DISTANN_GENERATION_DESCRIPTOR_VERSION,
+     DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET, DISTANN_GRAPH_RECORD_VERSION,
+-    DISTANN_HANDOFF_WIRE_VERSION,
+(B-    DISTANN_PHYSICAL_INDEX_FORMAT_VERSION, DISTANN_PLACEMENT_HASH_VERSION,
+(B+    DISTANN_HANDOFF_WIRE_VERSION, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B+    DISTANN_PLACEMENT_HASH_VERSION,
+(B };
++#[cfg(any(test, feature = "pg_test"))]
+(B+pub(crate) use self::handoff_router::{DistannHandoffRouteIdentity, DistannStageAck};
+(B+pub(crate) use self::handoff_wire::restore_owner_stream_hash_state;
+(B pub use self::handoff_wire::{
+     owner_stream_digest, DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape,
+     DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:122:
+     DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET,
+ };
+ #[cfg(any(test, feature = "pg_test"))]
+-pub(crate) use self::handoff_router::{DistannHandoffRouteIdentity, DistannStageAck};
+(B-pub(crate) use self::handoff_wire::restore_owner_stream_hash_state;
+(B-#[cfg(any(test, feature = "pg_test"))]
+(B pub(crate) use self::identity::vec_id_from_source_identity;
+ pub use self::lifecycle_wire::{
+     DistannAbandonBindingAuditV1, DistannAbandonedBinding, DistannAbandonedBindingSetV1,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:131:
+     DistannBuildCandidateV1, DistannCancelPublishAuditV1, DistannPublishedEpochIdentity,
+-    DistannRetireDecisionV1,
+(B-    DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+(B+    DistannRetireDecisionV1, DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+(B     DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET, DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES,
+     DISTANN_ABANDONED_BINDING_SET_VERSION, DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+     DISTANN_ABANDON_BINDING_AUDIT_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:140:
+     DISTANN_ABANDON_BINDING_AUDIT_VERSION, DISTANN_ABANDON_BINDING_AUDIT_VERSION_OFFSET,
+     DISTANN_BUILD_CANDIDATE_BUILD_SPEC_LENGTH_OFFSET, DISTANN_BUILD_CANDIDATE_FIXED_PREFIX_BYTES,
+     DISTANN_BUILD_CANDIDATE_REGISTRATION_DIGEST_OFFSET, DISTANN_BUILD_CANDIDATE_VERSION,
+-    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET,
+(B-    DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B+    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B     DISTANN_CANCEL_PUBLISH_AUDIT_COORDINATOR_UUID_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_EPOCH_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_FINGERPRINT_LENGTH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:148:
+     DISTANN_CANCEL_PUBLISH_AUDIT_FIXED_PREFIX_BYTES, DISTANN_CANCEL_PUBLISH_AUDIT_VERSION,
+-    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET,
+(B+    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET, DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET,
+(B     DISTANN_RETIRE_DECISION_EPOCH_OFFSET, DISTANN_RETIRE_DECISION_FINGERPRINT_LENGTH_OFFSET,
+     DISTANN_RETIRE_DECISION_FIXED_PREFIX_BYTES, DISTANN_RETIRE_DECISION_TARGET_BUILD_ID_OFFSET,
+     DISTANN_RETIRE_DECISION_VERSION, DISTANN_RETIRE_DECISION_VERSION_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:263:
+     }
+
+     pub fn decode(input: &[u8]) -> Result<Self, String> {
+-        if !matches!(input.len(), DISTANN_METADATA_BYTES | DISTANN_CONTROL_METADATA_BYTES) {
+(B+        if !matches!(
+(B+            input.len(),
+(B+            DISTANN_METADATA_BYTES | DISTANN_CONTROL_METADATA_BYTES
+(B+        ) {
+(B             return Err(format!(
+                 "distann metadata length mismatch: got {}, expected {DISTANN_METADATA_BYTES} or {DISTANN_CONTROL_METADATA_BYTES}",
+                 input.len()
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:332:
+             head_sample_head: ItemPointer::decode(&input[44..50])?,
+             delta_buffer_head: ItemPointer::decode(&input[50..56])?,
+             codec_subvector_count: u16::from_le_bytes(
+-                input[56..58].try_into().expect("codec_subvector_count bytes"),
+(B+                input[56..58]
+(B+                    .try_into()
+(B+                    .expect("codec_subvector_count bytes"),
+(B             ),
+             codec_subvector_dim: u16::from_le_bytes(
+                 input[58..60].try_into().expect("codec_subvector_dim bytes"),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:342:
+             content_digest: u64::from_le_bytes(
+                 input[72..80].try_into().expect("content_digest bytes"),
+             ),
+-            delta_count: u32::from_le_bytes(
+(B-                input[80..84].try_into().expect("delta_count bytes"),
+(B-            ),
+(B+            delta_count: u32::from_le_bytes(input[80..84].try_into().expect("delta_count bytes")),
+(B             epoch_state: input[DISTANN_METADATA_EPOCH_STATE_OFFSET],
+-            active_epoch: u64::from_le_bytes(
+(B-                input[85..93].try_into().expect("active_epoch bytes"),
+(B-            ),
+(B+            active_epoch: u64::from_le_bytes(input[85..93].try_into().expect("active_epoch bytes")),
+(B             in_flight_count: u32::from_le_bytes(
+                 input[93..97].try_into().expect("in_flight_count bytes"),
+             ),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:400:
+ #[cfg(test)]
+ mod tests {
+     use super::{
+-        DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES,
+(B-        DISTANN_METADATA_BYTES, DISTANN_METADATA_LOGICAL_INDEX_UUID_OFFSET,
+(B-        DISTANN_NEIGHBOR_CODEC_GROUPED_PQ, DISTANN_NEIGHBOR_CODEC_RABITQ,
+(B-        INDEX_FORMAT_V1_DISTANN, INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B+        DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES, DISTANN_METADATA_BYTES,
+(B+        DISTANN_METADATA_LOGICAL_INDEX_UUID_OFFSET, DISTANN_NEIGHBOR_CODEC_GROUPED_PQ,
+(B+        DISTANN_NEIGHBOR_CODEC_RABITQ, INDEX_FORMAT_V1_DISTANN, INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B     };
+     use crate::storage::page::ItemPointer;
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:465:
+         let mut encoded = sample().encode();
+         encoded[0] = 0xFF;
+         encoded[1] = 0xFF;
+-        let error =
+(B-            DistannMetadataPage::decode(&encoded).expect_err("unknown version must fail");
+(B+        let error = DistannMetadataPage::decode(&encoded).expect_err("unknown version must fail");
+(B         assert!(error.contains("format version"));
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:494:
+             u16::from_le_bytes(encoded[0..2].try_into().unwrap()),
+             INDEX_FORMAT_V1_DISTANN
+         );
+-        assert_eq!(encoded, DistannMetadataPage::decode(&encoded).unwrap().encode());
+(B+        assert_eq!(
+(B+            encoded,
+(B+            DistannMetadataPage::decode(&encoded).unwrap().encode()
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:209:
+             usize::from(metadata.dimensions),
+             DISTANN_TURBOQUANT_BITS,
+         )),
+-        other => Err(format!("ec_distann unsupported neighbor codec kind {other}")),
+(B+        other => Err(format!(
+(B+            "ec_distann unsupported neighbor codec kind {other}"
+(B+        )),
+(B     }
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:249:
+         match metadata.neighbor_codec_kind {
+             DISTANN_NEIGHBOR_CODEC_GROUPED_PQ => {
+                 let flat_codebooks = flat_codebooks.ok_or_else(|| {
+-                    "ec_distann grouped_pq query preparation requires the codebook chain"
+(B-                        .to_owned()
+(B+                    "ec_distann grouped_pq query preparation requires the codebook chain".to_owned()
+(B                 })?;
+                 let group_count = usize::from(metadata.codec_subvector_count);
+                 let group_size = usize::from(metadata.codec_subvector_dim);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:257:
+                 if group_count == 0 || group_size == 0 {
+                     return Err(
+-                        "ec_distann grouped_pq metadata is missing subvector parameters".to_owned()
+(B+                        "ec_distann grouped_pq metadata is missing subvector parameters".to_owned(),
+(B                     );
+                 }
+                 let rotated = crate::am::ec_diskann::scan_query::encode_query_srht(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:326:
+                 })
+             }
+             DistannCodecArtifact::RaBitQ { seed, bits, .. } => {
+-                let quantizer =
+(B-                    RaBitQQuantizer::cached_seeded_srht_bits(dimensions, *seed, *bits)?;
+(B+                let quantizer = RaBitQQuantizer::cached_seeded_srht_bits(dimensions, *seed, *bits)?;
+(B                 Ok(Self::RaBitQ {
+                     prepared: quantizer.prepare_estimator(raw_query),
+                 })
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:401:
+                     out_scores,
+                 )?;
+             }
+-            Self::RaBitQ { prepared } => {
+(B-                match prepared.bits1_block_prepared(code_len) {
+(B-                    Some(block_prepared) => {
+(B-                        let mut batch = CandidateBatch::with_capacity(count);
+(B-                        for slot in 0..count {
+(B-                            batch.push(
+(B-                                slot,
+(B-                                CandidatePayload::new(
+(B-                                    &codes[slot * code_len..(slot + 1) * code_len],
+(B-                                    CandidateMeta::RaBitQ,
+(B-                                ),
+(B-                            )?;
+(B-                        }
+(B-                        score_rabitq_bits1_batch_for(
+(B-                            CandidateBatchScoringSurface::Distann,
+(B-                            block_prepared,
+(B-                            &batch,
+(B-                            out_scores,
+(B+            Self::RaBitQ { prepared } => match prepared.bits1_block_prepared(code_len) {
+(B+                Some(block_prepared) => {
+(B+                    let mut batch = CandidateBatch::with_capacity(count);
+(B+                    for slot in 0..count {
+(B+                        batch.push(
+(B+                            slot,
+(B+                            CandidatePayload::new(
+(B+                                &codes[slot * code_len..(slot + 1) * code_len],
+(B+                                CandidateMeta::RaBitQ,
+(B+                            ),
+(B                         )?;
+                     }
+-                    None => {
+(B-                        for slot in 0..count {
+(B-                            out_scores[slot] = prepared.estimate_ip_scalar_only(
+(B-                                &codes[slot * code_len..(slot + 1) * code_len],
+(B-                            );
+(B-                        }
+(B+                    score_rabitq_bits1_batch_for(
+(B+                        CandidateBatchScoringSurface::Distann,
+(B+                        block_prepared,
+(B+                        &batch,
+(B+                        out_scores,
+(B+                    )?;
+(B+                }
+(B+                None => {
+(B+                    for slot in 0..count {
+(B+                        out_scores[slot] = prepared.estimate_ip_scalar_only(
+(B+                            &codes[slot * code_len..(slot + 1) * code_len],
+(B+                        );
+(B                     }
+                 }
+-            }
+(B+            },
+(B             Self::TurboQuant {
+                 quantizer,
+                 prepared,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:81:
+     let mut entries = Vec::with_capacity(expected_entries);
+     let mut cursor = head_tid;
+     while cursor != ItemPointer::INVALID {
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann directory chunk")?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann directory chunk")?;
+(B         let tuple = DistannDirectoryTuple::decode(&raw)?;
+         entries.extend_from_slice(&tuple.entries);
+         cursor = tuple.next_tid;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:115:
+     let mut samples = Vec::new();
+     let mut cursor = head_tid;
+     while cursor != ItemPointer::INVALID {
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann head sample")?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann head sample")?;
+(B         let tuple = DistannHeadSampleTuple::decode(&raw, dimensions)?;
+         cursor = tuple.next_tid;
+         samples.push(tuple);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:169:
+     let mut cursor = head_tid;
+     let mut group_index = 0_usize;
+     while cursor != ItemPointer::INVALID {
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann codebook tuple")?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann codebook tuple")?;
+(B         let tuple = crate::am::VamanaCodebookTuple::decode(&raw, centroid_count)?;
+         if usize::from(tuple.group_index) != group_index {
+             return Err(format!(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:201:
+     graph_degree_r: u16,
+     code_len: usize,
+ ) -> Result<DistannNodeTuple, String> {
+-    let page = chain
+(B-        .get_page(tid.block_number)
+(B-        .ok_or_else(|| format!("ec_distann node block {} not materialized", tid.block_number))?;
+(B+    let page = chain.get_page(tid.block_number).ok_or_else(|| {
+(B+        format!(
+(B+            "ec_distann node block {} not materialized",
+(B+            tid.block_number
+(B+        )
+(B+    })?;
+(B     let raw = page.raw_tuple(tid)?;
+     if raw.first().copied() != Some(DISTANN_NODE_TAG) {
+         return Err(format!(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/remote_endpoint.rs:30:
+ use crate::storage::slot_guard::TupleTableSlotGuard;
+
+ use super::ambuild::read_metadata_from_index_handle;
+-use super::quote_ident;
+(B use super::epoch::{
+     compute_epoch_fingerprint, fingerprint_from_bytes, fingerprints_match,
+     DISTANN_EPOCH_FINGERPRINT_V1,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/remote_endpoint.rs:40:
+ use super::head_cache::cached_index_entry;
+ use super::placement::owning_node;
+ use super::quantizer::{metadata_code_len, DistannPreparedQuery};
++use super::quote_ident;
+(B use super::reader::{
+     directory_lookup, read_directory_from_relation, read_raw_tuple_bytes_from_relation,
+ };
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/remote_endpoint.rs:765:
+     let entry = cached_index_entry(index_oid.into(), handle, &metadata)?;
+     let prepared_query =
+         DistannPreparedQuery::prepare(&metadata, entry.flat_codebooks.as_deref(), query)?;
+-    let owner_open_validate_ns = i64::try_from(open_validate_started.elapsed().as_nanos())
+(B-        .unwrap_or(i64::MAX);
+(B+    let owner_open_validate_ns =
+(B+        i64::try_from(open_validate_started.elapsed().as_nanos()).unwrap_or(i64::MAX);
+(B     let code_len = metadata_code_len(&metadata)?;
+
+     let heap_oid = index_heap_relation_oid_handle(handle);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/roster.rs:29:
+
+ use super::epoch::DistannEpochIdentity;
+ use super::page::DistannMetadataPage;
+-use super::placement::{
+(B-    DistannPlacementDirectory, DistannRosterNode, DISTANN_PLACEMENT_HASH_V1,
+(B-};
+(B+use super::placement::{DistannPlacementDirectory, DistannRosterNode, DISTANN_PLACEMENT_HASH_V1};
+(B
+-static ECDISTANN_ROSTER_GUC: GucSetting<Option<CString>> =
+(B-    GucSetting::<Option<CString>>::new(None);
+(B+static ECDISTANN_ROSTER_GUC: GucSetting<Option<CString>> = GucSetting::<Option<CString>>::new(None);
+(B static ECDISTANN_LOCAL_NODE_ID_GUC: GucSetting<i32> = GucSetting::<i32>::new(0);
+ /// PostgreSQL int GUCs are 32-bit; epoch numbers at research scale fit easily.
+ static ECDISTANN_EPOCH_GUC: GucSetting<i32> = GucSetting::<i32>::new(0);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/roster.rs:123:
+             continue;
+         }
+         let (id_str, conninfo) = entry.split_once('@').ok_or_else(|| {
+-            format!(
+(B-                "ec_distann.roster entry {index} ({entry:?}) must be `node_id@conninfo`"
+(B-            )
+(B+            format!("ec_distann.roster entry {index} ({entry:?}) must be `node_id@conninfo`")
+(B         })?;
+         let node_id: u32 = id_str.trim().parse().map_err(|_| {
+             format!("ec_distann.roster entry {index} has non-numeric node_id {id_str:?}")
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/roster.rs:189:
+             DistannRosterNode {
+                 node_id: entry.node_id,
+                 is_local,
+-                conninfo: if is_local { String::new() } else { entry.conninfo },
+(B+                conninfo: if is_local {
+(B+                    String::new()
+(B+                } else {
+(B+                    entry.conninfo
+(B+                },
+(B             }
+         })
+         .collect();
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/routine.rs:14:
+     ambuild, cost,
+     expand::LocalNodeExpander,
+     head_cache, options,
+-    quote_ident,
+(B     quantizer::{self, DistannPreparedQuery},
++    quote_ident,
+(B     scan::{
+         distann_orchestrated_search, DistannOrchestrationParams, DistannScanCounters,
+         DistannScanHit, DistannSeedCandidate,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/row_schema.rs:49:
+     pub(crate) columns: Vec<ResolvedRowSchemaColumn>,
+ }
+
+-pub(crate) fn resolve_relation_schema(relation_oid: pg_sys::Oid) -> Result<ResolvedRowSchema, String> {
+(B+pub(crate) fn resolve_relation_schema(
+(B+    relation_oid: pg_sys::Oid,
+(B+) -> Result<ResolvedRowSchema, String> {
+(B     let rows = Spi::connect(|client| {
+         client
+             .select(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:338:
+ #[cfg(test)]
+ mod tests {
+     use super::{
+-        distann_orchestrated_search, run_scan_attempt_with_restart, DistannExpandedNode,
+(B-        DistannExpandError, DistannNodeExpander, DistannOrchestrationParams, DistannSeedCandidate,
+(B+        distann_orchestrated_search, run_scan_attempt_with_restart, DistannExpandError,
+(B+        DistannExpandedNode, DistannNodeExpander, DistannOrchestrationParams, DistannSeedCandidate,
+(B     };
+     use crate::storage::page::ItemPointer;
+     use std::cell::Cell;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:379:
+         let calls = Cell::new(0);
+         let result = run_scan_attempt_with_restart(|| {
+             calls.set(calls.get() + 1);
+-            Err::<i32, _>(DistannExpandError::EpochMismatch(format!("mismatch {}", calls.get())))
+(B+            Err::<i32, _>(DistannExpandError::EpochMismatch(format!(
+(B+                "mismatch {}",
+(B+                calls.get()
+(B+            )))
+(B         });
+         assert!(matches!(result, Err(DistannExpandError::EpochMismatch(_))));
+         assert_eq!(calls.get(), 2, "capped at two attempts");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:420:
+             vec_ids
+                 .iter()
+                 .map(|vec_id| {
+-                    let (exact, tombstone, neighbors) = self
+(B-                        .nodes
+(B-                        .get(vec_id)
+(B-                        .ok_or_else(|| DistannExpandError::Internal(format!("unknown vec_id {vec_id}")))?;
+(B+                    let (exact, tombstone, neighbors) =
+(B+                        self.nodes.get(vec_id).ok_or_else(|| {
+(B+                            DistannExpandError::Internal(format!("unknown vec_id {vec_id}"))
+(B+                        })?;
+(B                     Ok(DistannExpandedNode {
+                         vec_id: *vec_id,
+                         exact_dist: (!tombstone).then_some(*exact),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:469:
+             vec_id: 1,
+             dist: -0.9,
+         }];
+-        let (hits, counters) =
+(B-            distann_orchestrated_search(&seeds, &mut expander, params(2, 8, 10))
+(B-                .expect("search should succeed");
+(B+        let (hits, counters) = distann_orchestrated_search(&seeds, &mut expander, params(2, 8, 10))
+(B+            .expect("search should succeed");
+(B         assert_eq!(counters.records_expanded, 2);
+         assert!(counters.records_expanded <= 2 * 8);
+         assert!(counters.beam_exhausted, "cycle exhausts the beam");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:493:
+             vec_id: 1,
+             dist: -0.5,
+         }];
+-        let (hits, counters) =
+(B-            distann_orchestrated_search(&seeds, &mut expander, params(4, 8, 10))
+(B-                .expect("search should succeed");
+(B+        let (hits, counters) = distann_orchestrated_search(&seeds, &mut expander, params(4, 8, 10))
+(B+            .expect("search should succeed");
+(B         assert_eq!(hits.len(), 1, "fewer-than-k is a complete result");
+         assert!(counters.beam_exhausted);
+         assert!(!counters.early_exit);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:537:
+             vec_id: 1,
+             dist: -0.9,
+         }];
+-        let (hits, counters) =
+(B-            distann_orchestrated_search(&seeds, &mut expander, params(1, 8, 1))
+(B-                .expect("search should succeed");
+(B+        let (hits, counters) = distann_orchestrated_search(&seeds, &mut expander, params(1, 8, 1))
+(B+            .expect("search should succeed");
+(B         assert!(counters.early_exit);
+         assert_eq!(counters.records_expanded, 1);
+         assert_eq!(hits[0].vec_id, 1);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/shard_build.rs:348:
+                 "ec_distann duplicate or invalid shard spool index {shard_index}"
+             ));
+         }
+-        self.build_peak_completion_bytes = self
+(B-            .build_peak_completion_bytes
+(B-            .max(encoded.bytes.len());
+(B+        self.build_peak_completion_bytes =
+(B+            self.build_peak_completion_bytes.max(encoded.bytes.len());
+(B         let mut io = ShardSpoolIo::create()?;
+         io.write_all(&encoded.bytes);
+         let shard_bytes = u64::try_from(encoded.bytes.len())
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/shard_build.rs:840:
+                 // A send failure means the backend is already unwinding; no
+                 // PostgreSQL API or panic belongs on this worker thread.
+                 if sender.send((shard_index, result)).is_err() {
+-                    let _ = release_completion_bytes(
+(B-                        &retained_completion_bytes,
+(B-                        encoded_bytes,
+(B-                    );
+(B+                    let _ = release_completion_bytes(&retained_completion_bytes, encoded_bytes);
+(B                     return;
+                 }
+             });
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/shard_build.rs:1669:
+     }
+
+     fn raw_entry(node: u32, neighbors: &[u32]) -> Vec<u8> {
+-        let mut bytes = Vec::with_capacity(
+(B-            DISTANN_SHARD_SPILL_HEADER_BYTES + std::mem::size_of_val(neighbors),
+(B-        );
+(B+        let mut bytes =
+(B+            Vec::with_capacity(DISTANN_SHARD_SPILL_HEADER_BYTES + std::mem::size_of_val(neighbors));
+(B         bytes.extend_from_slice(&node.to_le_bytes());
+         bytes.extend_from_slice(&(neighbors.len() as u32).to_le_bytes());
+         for &neighbor in neighbors {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:152:
+                 .iter()
+                 .any(|byte| *byte != 0)
+         {
+-            return Err(
+(B-                "distann physical node record has non-zero adjacency padding".to_owned(),
+(B-            );
+(B+            return Err("distann physical node record has non-zero adjacency padding".to_owned());
+(B         }
+         Ok(())
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:233:
+         expected_version: Option<u16>,
+     ) -> Result<Self, String> {
+         let mut out = Self::empty();
+-        Self::decode_into_version(
+(B-            input,
+(B-            graph_degree_r,
+(B-            code_len,
+(B-            expected_version,
+(B-            &mut out,
+(B-        )?;
+(B+        Self::decode_into_version(input, graph_degree_r, code_len, expected_version, &mut out)?;
+(B         Ok(out)
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:269:
+         }
+         if let Some(expected_version) = expected_version {
+             let format_version = u16::from_le_bytes(
+-                input[DISTANN_NODE_FORMAT_VERSION_OFFSET
+(B-                    ..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B+                input[DISTANN_NODE_FORMAT_VERSION_OFFSET..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B                     .try_into()
+                     .expect("graph record version bytes"),
+             );
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:387:
+                 input[0]
+             ));
+         }
+-        let entry_count =
+(B-            usize::from(u16::from_le_bytes(input[2..4].try_into().expect("count bytes")));
+(B+        let entry_count = usize::from(u16::from_le_bytes(
+(B+            input[2..4].try_into().expect("count bytes"),
+(B+        ));
+(B         let expected = Self::encoded_len(entry_count);
+         if input.len() != expected {
+             return Err(format!(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:536:
+ #[cfg(test)]
+ mod tests {
+     use super::{
+-        DistannDeltaTuple, DistannNodeTuple, DISTANN_FLAG_TOMBSTONE,
+(B-        DISTANN_NODE_FORMAT_VERSION, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+(B-        DISTANN_NODE_HEADER_BYTES,
+(B+        DistannDeltaTuple, DistannNodeTuple, DISTANN_FLAG_TOMBSTONE, DISTANN_NODE_FORMAT_VERSION,
+(B+        DISTANN_NODE_FORMAT_VERSION_OFFSET, DISTANN_NODE_HEADER_BYTES,
+(B     };
+     use crate::storage::page::ItemPointer;
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:577:
+             search_code: (0..CODE_LEN as u8).collect(),
+             neighbor_vec_ids: vec![101, 202, 303, 0],
+             neighbor_codes: (0..R as usize * CODE_LEN)
+-                .map(|offset| if offset < 3 * CODE_LEN { offset as u8 } else { 0 })
+(B+                .map(|offset| {
+(B+                    if offset < 3 * CODE_LEN {
+(B+                        offset as u8
+(B+                    } else {
+(B+                        0
+(B+                    }
+(B+                })
+(B                 .collect(),
+         }
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:603:
+             .expect("physical encode should succeed");
+         assert_eq!(
+             u16::from_le_bytes(
+-                encoded[DISTANN_NODE_FORMAT_VERSION_OFFSET
+(B-                    ..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B+                encoded[DISTANN_NODE_FORMAT_VERSION_OFFSET..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B                     .try_into()
+                     .unwrap()
+             ),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:697:
+                 offset_number: 2,
+             },
+             entries: vec![
+-                (10, ItemPointer { block_number: 1, offset_number: 1 }),
+(B-                (20, ItemPointer { block_number: 1, offset_number: 2 }),
+(B-                (30, ItemPointer { block_number: 2, offset_number: 1 }),
+(B+                (
+(B+                    10,
+(B+                    ItemPointer {
+(B+                        block_number: 1,
+(B+                        offset_number: 1,
+(B+                    },
+(B+                ),
+(B+                (
+(B+                    20,
+(B+                    ItemPointer {
+(B+                        block_number: 1,
+(B+                        offset_number: 2,
+(B+                    },
+(B+                ),
+(B+                (
+(B+                    30,
+(B+                    ItemPointer {
+(B+                        block_number: 2,
+(B+                        offset_number: 1,
+(B+                    },
+(B+                ),
+(B             ],
+         };
+         let encoded = tuple.encode().expect("encode");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:706:
+-        assert_eq!(
+(B-            encoded.len(),
+(B-            super::DistannDirectoryTuple::encoded_len(3)
+(B-        );
+(B+        assert_eq!(encoded.len(), super::DistannDirectoryTuple::encoded_len(3));
+(B         let decoded = super::DistannDirectoryTuple::decode(&encoded).expect("decode");
+         assert_eq!(decoded, tuple);
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:719:
+             vector: vec![0.25, -0.5, 1.0, 0.0],
+         };
+         let encoded = tuple.encode();
+-        assert_eq!(
+(B-            encoded.len(),
+(B-            super::DistannHeadSampleTuple::encoded_len(4)
+(B-        );
+(B-        let decoded =
+(B-            super::DistannHeadSampleTuple::decode(&encoded, 4).expect("decode");
+(B+        assert_eq!(encoded.len(), super::DistannHeadSampleTuple::encoded_len(4));
+(B+        let decoded = super::DistannHeadSampleTuple::decode(&encoded, 4).expect("decode");
+(B         assert_eq!(decoded, tuple);
+         assert!(super::DistannHeadSampleTuple::decode(&encoded, 5).is_err());
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/page.rs:3507:
+         "ec_ivf posting entry block sequence",
+         |buffer, block_number| {
+             let decode_started = std::time::Instant::now();
+-            let result =
+(B-                visit_all_ivf_posting_entries_from_buffer(buffer, block_number, payload_len, visitor);
+(B+            let result = visit_all_ivf_posting_entries_from_buffer(
+(B+                buffer,
+(B+                block_number,
+(B+                payload_len,
+(B+                visitor,
+(B+            );
+(B             decode_elapsed += decode_started.elapsed();
+             result
+         },
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:449:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:663:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:883:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:1144:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:1249:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:1191:
+     capacity: usize,
+ ) -> *mut CandidateDedupPool {
+     if opaque.candidate_dedup.is_null() {
+-        opaque.candidate_dedup = Box::into_raw(Box::new(CandidateDedupPool::with_capacity(
+(B-            capacity,
+(B-        )));
+(B+        opaque.candidate_dedup =
+(B+            Box::into_raw(Box::new(CandidateDedupPool::with_capacity(capacity)));
+(B         return opaque.candidate_dedup;
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:1692:
+     // pure `pre_rerank_candidate_limit` / `ranked_collect_limit` helpers take it
+     // as a parameter so they never touch pgrx GUC FFI off-thread.
+     let effective_rerank_width =
+-        super::options::resolve_scan_rerank_width(index_options.rerank_width).effective_rerank_width;
+(B+        super::options::resolve_scan_rerank_width(index_options.rerank_width)
+(B+            .effective_rerank_width;
+(B     let mut running_top = bound_pruning_active
+         .then(|| pre_rerank_candidate_limit(index_options, effective_rerank_width))
+         .flatten()
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:1944:
+         // the rerank helper validates whether heap_f32 state is present
+         // before use.
+         let rerank_started = should_record_exact_rerank.then(Instant::now);
+-        unsafe { rerank_probe_candidates(scan, index_options, opaque, centroid_scores, candidates) };
+(B+        unsafe {
+(B+            rerank_probe_candidates(scan, index_options, opaque, centroid_scores, candidates)
+(B+        };
+(B         if let Some(rerank_started) = rerank_started {
+             record_stage_elapsed(
+                 opaque,
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:2511:
+         index_options.rerank.v1_effective(),
+         super::options::RerankMode::HeapF32
+     ) {
+-        Some(pre_rerank_candidate_limit(index_options, effective_rerank_width).unwrap_or(candidate_len))
+(B+        Some(
+(B+            pre_rerank_candidate_limit(index_options, effective_rerank_width)
+(B+                .unwrap_or(candidate_len),
+(B+        )
+(B     } else {
+         None
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5408:
+         let mut stream = Vec::new();
+         let mut state = 0x2545F4914F6CDD1D_u64;
+         for i in 0..10_000_u32 {
+-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+(B+            state = state
+(B+                .wrapping_mul(6364136223846793005)
+(B+                .wrapping_add(1442695040888963407);
+(B             let block = (state >> 33) as u32 % 512;
+             let offset = 1 + ((state >> 17) as u16 % 128);
+             let score = ((state >> 40) as f32) / 1e6 - 8.0;
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5446:
+             for (left, right) in from_pool.iter().zip(from_reference.iter()) {
+                 assert_eq!(left.heap_tid, right.heap_tid, "limit {limit:?}");
+                 assert_eq!(left.rerank_tid, right.rerank_tid, "limit {limit:?}");
+-                assert_eq!(left.score.to_bits(), right.score.to_bits(), "limit {limit:?}");
+(B+                assert_eq!(
+(B+                    left.score.to_bits(),
+(B+                    right.score.to_bits(),
+(B+                    "limit {limit:?}"
+(B+                );
+(B             }
+         }
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5495:
+         let mut stream = Vec::with_capacity(CANDIDATES);
+         let mut state = 0x9E3779B97F4A7C15_u64;
+         for i in 0..CANDIDATES as u64 {
+-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+(B+            state = state
+(B+                .wrapping_mul(6364136223846793005)
+(B+                .wrapping_add(1442695040888963407);
+(B             // Unique tids so the map holds the full candidate count.
+             let block = (i / 291) as u32;
+             let offset = 1 + (i % 291) as u16;
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5530:
+         let map_ref = &map;
+         let map_walk = time_ns(
+             "map walk only (values -> black_box)",
+-            Box::new(move || map_ref.values().map(|c| c.heap_tid.offset_number as usize).sum()),
+(B+            Box::new(move || {
+(B+                map_ref
+(B+                    .values()
+(B+                    .map(|c| c.heap_tid.offset_number as usize)
+(B+                    .sum()
+(B+            }),
+(B         );
+         let ranked_len = |ranked: RankedProbeCandidates| match ranked {
+             RankedProbeCandidates::Sorted(candidates) => candidates.len(),
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:38:
+ };
+ pub use self::ec_diskann::{vamana_decode_overflow_tuple_fixture, VamanaOverflowTupleFixture};
+ pub use self::ec_distann::page::{
+-    DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES,
+(B-    DISTANN_METADATA_ACTIVE_EPOCH_OFFSET, DISTANN_METADATA_ALPHA_OFFSET,
+(B-    DISTANN_METADATA_BUILD_LIST_SIZE_L_OFFSET, DISTANN_METADATA_BYTES,
+(B+    DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES, DISTANN_METADATA_ACTIVE_EPOCH_OFFSET,
+(B+    DISTANN_METADATA_ALPHA_OFFSET, DISTANN_METADATA_BUILD_LIST_SIZE_L_OFFSET,
+(B+    DISTANN_METADATA_BYTES, DISTANN_METADATA_CLOSURE_EPSILON_OFFSET,
+(B     DISTANN_METADATA_CODEC_SUBVECTOR_COUNT_OFFSET, DISTANN_METADATA_CODEC_SUBVECTOR_DIM_OFFSET,
+-    DISTANN_METADATA_CLOSURE_EPSILON_OFFSET, DISTANN_METADATA_CONTENT_DIGEST_OFFSET,
+(B-    DISTANN_METADATA_DELTA_BUFFER_HEAD_OFFSET, DISTANN_METADATA_DELTA_COUNT_OFFSET,
+(B+    DISTANN_METADATA_CONTENT_DIGEST_OFFSET, DISTANN_METADATA_DELTA_BUFFER_HEAD_OFFSET,
+(B+    DISTANN_METADATA_DELTA_COUNT_OFFSET, DISTANN_METADATA_DIMENSIONS_OFFSET,
+(B     DISTANN_METADATA_DIRECTORY_HEAD_OFFSET, DISTANN_METADATA_ENTRY_POINT_OFFSET,
+-    DISTANN_METADATA_DIMENSIONS_OFFSET,
+(B     DISTANN_METADATA_EPOCH_STATE_OFFSET, DISTANN_METADATA_FLAGS_OFFSET,
+     DISTANN_METADATA_FORMAT_VERSION_OFFSET, DISTANN_METADATA_GRAPH_DEGREE_R_OFFSET,
+     DISTANN_METADATA_GROUPED_CODEBOOK_HEAD_OFFSET, DISTANN_METADATA_HEAD_INDEX_CAP_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:52:
+     DISTANN_METADATA_HEAD_SAMPLE_HEAD_OFFSET, DISTANN_METADATA_IN_FLIGHT_COUNT_OFFSET,
+     DISTANN_METADATA_LOGICAL_INDEX_UUID_OFFSET, DISTANN_METADATA_NEIGHBOR_CODEC_KIND_OFFSET,
+-    DISTANN_METADATA_NODE_COUNT_OFFSET, DISTANN_METADATA_SEED_OFFSET,
+(B-    INDEX_FORMAT_V1_DISTANN, INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B+    DISTANN_METADATA_NODE_COUNT_OFFSET, DISTANN_METADATA_SEED_OFFSET, INDEX_FORMAT_V1_DISTANN,
+(B+    INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B };
++pub(crate) use self::ec_distann::restore_owner_stream_hash_state;
+(B pub use self::ec_distann::tuple::{
+-    distann_node_neighbor_codes_offset, distann_node_neighbor_vec_ids_offset,
+(B-    DistannNodeTuple, DISTANN_NODE_FLAGS_OFFSET, DISTANN_NODE_FORMAT_VERSION,
+(B-    DISTANN_NODE_FORMAT_VERSION_OFFSET, DISTANN_NODE_HEADER_BYTES,
+(B-    DISTANN_NODE_HEAP_TID_OFFSET, DISTANN_NODE_NEIGHBOR_COUNT_OFFSET,
+(B+    distann_node_neighbor_codes_offset, distann_node_neighbor_vec_ids_offset, DistannNodeTuple,
+(B+    DISTANN_NODE_FLAGS_OFFSET, DISTANN_NODE_FORMAT_VERSION, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+(B+    DISTANN_NODE_HEADER_BYTES, DISTANN_NODE_HEAP_TID_OFFSET, DISTANN_NODE_NEIGHBOR_COUNT_OFFSET,
+(B     DISTANN_NODE_SEARCH_CODE_OFFSET, DISTANN_NODE_TAG_OFFSET, DISTANN_NODE_VEC_ID_OFFSET,
+ };
+ pub use self::ec_distann::{
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:65:
+     owner_stream_digest, DistannAbandonBindingAuditV1, DistannAbandonedBinding,
+     DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildOptions, DistannBuildSpec,
+-    DistannCancelPublishAuditV1,
+(B-    DistannCodecArtifact, DistannEpochFingerprint, DistannEpochManifestV2,
+(B-    DistannGenerationDescriptor, DistannHeadPolicy,
+(B-    DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape,
+(B-    DistannManifestBuildOptions, DistannManifestCodecParameters, DistannOwnerExpectation,
+(B-    DistannPublishedEpochIdentity, DistannReadyReceipt, DistannRetireDecisionV1,
+(B-    DistannRosterEntry, DistannRowSchemaAttribute,
+(B-    DistannRowSchemaDescriptor, DistannSourceSnapshot, DISTANN_BUILD_SPEC_VERSION,
+(B-    DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+(B-    DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET, DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES,
+(B-    DISTANN_ABANDONED_BINDING_SET_VERSION, DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+(B+    DistannCancelPublishAuditV1, DistannCodecArtifact, DistannEpochFingerprint,
+(B+    DistannEpochManifestV2, DistannGenerationDescriptor, DistannHandoffBatch, DistannHandoffEntry,
+(B+    DistannHandoffShape, DistannHeadPolicy, DistannManifestBuildOptions,
+(B+    DistannManifestCodecParameters, DistannOwnerExpectation, DistannPublishedEpochIdentity,
+(B+    DistannReadyReceipt, DistannRetireDecisionV1, DistannRosterEntry, DistannRowSchemaAttribute,
+(B+    DistannRowSchemaDescriptor, DistannSourceSnapshot, DistannSuccessorActivationV1,
+(B+    DISTANN_ABANDONED_BINDING_ENTRY_BYTES, DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET,
+(B+    DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES, DISTANN_ABANDONED_BINDING_SET_VERSION,
+(B+    DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+(B     DISTANN_ABANDON_BINDING_AUDIT_FIXED_PREFIX_BYTES,
+     DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_BUILD_ID_OFFSET,
+     DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_EPOCH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:82:
+     DISTANN_ABANDON_BINDING_AUDIT_VERSION, DISTANN_ABANDON_BINDING_AUDIT_VERSION_OFFSET,
+     DISTANN_BUILD_CANDIDATE_BUILD_SPEC_LENGTH_OFFSET, DISTANN_BUILD_CANDIDATE_FIXED_PREFIX_BYTES,
+     DISTANN_BUILD_CANDIDATE_REGISTRATION_DIGEST_OFFSET, DISTANN_BUILD_CANDIDATE_VERSION,
+-    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET,
+(B-    DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B+    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_BUILD_SPEC_VERSION,
+(B+    DISTANN_BUILD_SPEC_VERSION_OFFSET, DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B     DISTANN_CANCEL_PUBLISH_AUDIT_COORDINATOR_UUID_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_EPOCH_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_FINGERPRINT_LENGTH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:90:
+     DISTANN_CANCEL_PUBLISH_AUDIT_FIXED_PREFIX_BYTES, DISTANN_CANCEL_PUBLISH_AUDIT_VERSION,
+-    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET,
+(B-    DISTANN_BUILD_SPEC_VERSION_OFFSET, DISTANN_CODEC_ARTIFACT_VERSION,
+(B+    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET, DISTANN_CODEC_ARTIFACT_VERSION,
+(B     DISTANN_CODEC_ARTIFACT_VERSION_OFFSET, DISTANN_EPOCH_FINGERPRINT_BYTES,
+     DISTANN_EPOCH_MANIFEST_VERSION, DISTANN_EPOCH_MANIFEST_VERSION_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_COORDINATOR_UUID_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:101:
+     DISTANN_GENERATION_DESCRIPTOR_INDEX_FORMAT_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_PLACEMENT_HASH_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET, DISTANN_GENERATION_DESCRIPTOR_VERSION,
+-    DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET,
+(B-    DISTANN_GRAPH_RECORD_VERSION, DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES,
+(B-    DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_MAX_BYTES,
+(B-    DISTANN_HANDOFF_VERSION_OFFSET, DISTANN_HANDOFF_WIRE_VERSION,
+(B+    DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET, DISTANN_GRAPH_RECORD_VERSION,
+(B+    DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES,
+(B+    DISTANN_HANDOFF_MAX_BYTES, DISTANN_HANDOFF_VERSION_OFFSET, DISTANN_HANDOFF_WIRE_VERSION,
+(B+    DISTANN_MANIFEST_BUILD_OPTIONS_BYTES, DISTANN_MANIFEST_BUILD_OPTIONS_VERSION,
+(B+    DISTANN_MANIFEST_BUILD_OPTIONS_VERSION_OFFSET, DISTANN_MANIFEST_CODEC_PARAMETERS_BYTES,
+(B+    DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION, DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION_OFFSET,
+(B     DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_OFFSET, DISTANN_OWNER_STREAM_HASH_STATE_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:111:
+     DISTANN_OWNER_STREAM_HASH_STATE_CHAIN_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_IMPLEMENTATION_OFFSET,
+-    DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET,
+(B-    DISTANN_MANIFEST_BUILD_OPTIONS_BYTES, DISTANN_MANIFEST_BUILD_OPTIONS_VERSION,
+(B-    DISTANN_MANIFEST_BUILD_OPTIONS_VERSION_OFFSET, DISTANN_MANIFEST_CODEC_PARAMETERS_BYTES,
+(B-    DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION, DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION_OFFSET,
+(B-    DISTANN_PHYSICAL_INDEX_FORMAT_VERSION, DISTANN_PLACEMENT_HASH_VERSION,
+(B-    DISTANN_READY_RECEIPT_BYTES, DISTANN_READY_RECEIPT_STATE,
+(B+    DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B+    DISTANN_PLACEMENT_HASH_VERSION, DISTANN_READY_RECEIPT_BYTES, DISTANN_READY_RECEIPT_STATE,
+(B     DISTANN_READY_RECEIPT_VERSION, DISTANN_READY_RECEIPT_VERSION_OFFSET,
+     DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET, DISTANN_RETIRE_DECISION_EPOCH_OFFSET,
+     DISTANN_RETIRE_DECISION_FINGERPRINT_LENGTH_OFFSET, DISTANN_RETIRE_DECISION_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:122:
+     DISTANN_RETIRE_DECISION_TARGET_BUILD_ID_OFFSET, DISTANN_RETIRE_DECISION_VERSION,
+-    DISTANN_RETIRE_DECISION_VERSION_OFFSET,
+(B-    DISTANN_ROW_SCHEMA_VERSION, DISTANN_ROW_SCHEMA_VERSION_OFFSET,
+(B-    DISTANN_SOURCE_SNAPSHOT_VERSION, DISTANN_SOURCE_SNAPSHOT_VERSION_OFFSET,
+(B-    DISTANN_SUCCESSOR_ACTIVATION_COORDINATOR_UUID_OFFSET,
+(B+    DISTANN_RETIRE_DECISION_VERSION_OFFSET, DISTANN_ROW_SCHEMA_VERSION,
+(B+    DISTANN_ROW_SCHEMA_VERSION_OFFSET, DISTANN_SOURCE_SNAPSHOT_VERSION,
+(B+    DISTANN_SOURCE_SNAPSHOT_VERSION_OFFSET, DISTANN_SUCCESSOR_ACTIVATION_COORDINATOR_UUID_OFFSET,
+(B     DISTANN_SUCCESSOR_ACTIVATION_FIXED_PREFIX_BYTES,
+     DISTANN_SUCCESSOR_ACTIVATION_PREDECESSOR_PRESENT_OFFSET, DISTANN_SUCCESSOR_ACTIVATION_VERSION,
+     DISTANN_SUCCESSOR_ACTIVATION_VERSION_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:130:
+ };
+-pub(crate) use self::ec_distann::restore_owner_stream_hash_state;
+(B #[allow(unused_imports)]
+ pub(crate) use self::ec_hnsw::{
+     graph, index_admin_snapshot, index_cost_snapshot, page, planner_integration_snapshot,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:411:
+         owner_stream_digest, DistannAbandonBindingAuditV1, DistannAbandonedBinding,
+         DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildOptions,
+         DistannBuildSpec, DistannCancelPublishAuditV1, DistannCodecArtifact,
+-        DistannEpochFingerprint, DistannEpochManifestV2,
+(B-        DistannGenerationDescriptor, DistannHeadPolicy,
+(B-        DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape, DistannManifestBuildOptions,
+(B-        DistannManifestCodecParameters, DistannMetadataPage, DistannNodeTuple,
+(B-        DistannOwnerExpectation, DistannPublishedEpochIdentity, DistannReadyReceipt,
+(B-        DistannRetireDecisionV1, DistannRosterEntry,
+(B+        DistannEpochFingerprint, DistannEpochManifestV2, DistannGenerationDescriptor,
+(B+        DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape, DistannHeadPolicy,
+(B+        DistannManifestBuildOptions, DistannManifestCodecParameters, DistannMetadataPage,
+(B+        DistannNodeTuple, DistannOwnerExpectation, DistannPublishedEpochIdentity,
+(B+        DistannReadyReceipt, DistannRetireDecisionV1, DistannRosterEntry,
+(B         DistannRowSchemaAttribute, DistannRowSchemaDescriptor, DistannSourceSnapshot,
+         DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+         DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:423:
+-        DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES,
+(B-        DISTANN_ABANDONED_BINDING_SET_VERSION,
+(B+        DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES, DISTANN_ABANDONED_BINDING_SET_VERSION,
+(B         DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+         DISTANN_ABANDON_BINDING_AUDIT_FIXED_PREFIX_BYTES,
+         DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_BUILD_ID_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:428:
+         DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_EPOCH_OFFSET,
+         DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_FINGERPRINT_LENGTH_OFFSET,
+         DISTANN_ABANDON_BINDING_AUDIT_VERSION, DISTANN_ABANDON_BINDING_AUDIT_VERSION_OFFSET,
+-        DISTANN_BUILD_SPEC_VERSION, DISTANN_BUILD_SPEC_VERSION_OFFSET,
+(B         DISTANN_BUILD_CANDIDATE_BUILD_SPEC_LENGTH_OFFSET,
+         DISTANN_BUILD_CANDIDATE_FIXED_PREFIX_BYTES,
+         DISTANN_BUILD_CANDIDATE_REGISTRATION_DIGEST_OFFSET, DISTANN_BUILD_CANDIDATE_VERSION,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:435:
+-        DISTANN_BUILD_CANDIDATE_VERSION_OFFSET,
+(B-        DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B+        DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_BUILD_SPEC_VERSION,
+(B+        DISTANN_BUILD_SPEC_VERSION_OFFSET, DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B         DISTANN_CANCEL_PUBLISH_AUDIT_COORDINATOR_UUID_OFFSET,
+         DISTANN_CANCEL_PUBLISH_AUDIT_EPOCH_OFFSET,
+         DISTANN_CANCEL_PUBLISH_AUDIT_FINGERPRINT_LENGTH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:440:
+         DISTANN_CANCEL_PUBLISH_AUDIT_FIXED_PREFIX_BYTES, DISTANN_CANCEL_PUBLISH_AUDIT_VERSION,
+-        DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET,
+(B-        DISTANN_CODEC_ARTIFACT_VERSION, DISTANN_CODEC_ARTIFACT_VERSION_OFFSET,
+(B-        DISTANN_CONTROL_METADATA_BYTES, DISTANN_EPOCH_FINGERPRINT_BYTES,
+(B-        DISTANN_EPOCH_MANIFEST_VERSION, DISTANN_EPOCH_MANIFEST_VERSION_OFFSET,
+(B+        DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET, DISTANN_CODEC_ARTIFACT_VERSION,
+(B+        DISTANN_CODEC_ARTIFACT_VERSION_OFFSET, DISTANN_CONTROL_METADATA_BYTES,
+(B+        DISTANN_EPOCH_FINGERPRINT_BYTES, DISTANN_EPOCH_MANIFEST_VERSION,
+(B+        DISTANN_EPOCH_MANIFEST_VERSION_OFFSET,
+(B         DISTANN_GENERATION_DESCRIPTOR_COORDINATOR_UUID_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_DIMENSIONS_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:450:
+         DISTANN_GENERATION_DESCRIPTOR_HANDOFF_WIRE_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_INDEX_FORMAT_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_PLACEMENT_HASH_OFFSET,
+-        DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET,
+(B-        DISTANN_GENERATION_DESCRIPTOR_VERSION, DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET,
+(B-        DISTANN_GRAPH_RECORD_VERSION,
+(B+        DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET, DISTANN_GENERATION_DESCRIPTOR_VERSION,
+(B+        DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET, DISTANN_GRAPH_RECORD_VERSION,
+(B         DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES,
+         DISTANN_HANDOFF_MAX_BYTES, DISTANN_HANDOFF_VERSION_OFFSET, DISTANN_HANDOFF_WIRE_VERSION,
+-        DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_OFFSET, DISTANN_OWNER_STREAM_HASH_STATE_BYTES,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_CHAIN_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_IMPLEMENTATION_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET,
+(B         DISTANN_MANIFEST_BUILD_OPTIONS_BYTES, DISTANN_MANIFEST_BUILD_OPTIONS_VERSION,
+         DISTANN_MANIFEST_BUILD_OPTIONS_VERSION_OFFSET, DISTANN_MANIFEST_CODEC_PARAMETERS_BYTES,
+         DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:480:
+         DISTANN_NODE_FLAGS_OFFSET, DISTANN_NODE_FORMAT_VERSION, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+         DISTANN_NODE_HEADER_BYTES, DISTANN_NODE_HEAP_TID_OFFSET,
+         DISTANN_NODE_NEIGHBOR_COUNT_OFFSET, DISTANN_NODE_SEARCH_CODE_OFFSET,
+-        DISTANN_NODE_TAG_OFFSET, DISTANN_NODE_VEC_ID_OFFSET, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B+        DISTANN_NODE_TAG_OFFSET, DISTANN_NODE_VEC_ID_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_OFFSET, DISTANN_OWNER_STREAM_HASH_STATE_BYTES,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_CHAIN_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_IMPLEMENTATION_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B         DISTANN_PLACEMENT_HASH_VERSION, DISTANN_READY_RECEIPT_BYTES, DISTANN_READY_RECEIPT_STATE,
+         DISTANN_READY_RECEIPT_VERSION, DISTANN_READY_RECEIPT_VERSION_OFFSET,
+         DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET, DISTANN_RETIRE_DECISION_EPOCH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/quant/int8_approx32/mod.rs:97:
+     use crate::quant::prod::ProdQuantizer;
+
+     fn assert_host_simd_isa(actual: crate::quant::isa::Isa) {
+-        let expected = crate::quant::isa::select_highest_isa(
+(B-            crate::quant::isa::HostIsaFeatures::detect(),
+(B-        );
+(B+        let expected =
+(B+            crate::quant::isa::select_highest_isa(crate::quant::isa::HostIsaFeatures::detect());
+(B         assert_eq!(
+             actual, expected,
+             "int8 differential test did not execute the host's preferred SIMD ISA"
+Diff in /Users/peter/dev/tqvector/src/quant/int8_approx32/mod.rs:136:
+
+         let block: &[&[u8]; BLOCK_WIDTH] = code_refs[..BLOCK_WIDTH].try_into().unwrap();
+         let mut block_scores = vec![0.0; BLOCK_WIDTH];
+-        let block_isa =
+(B-            score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+(B+        let block_isa = score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+(B         assert_host_simd_isa(block_isa);
+         for (score, code) in block_scores.iter().zip(code_refs[..BLOCK_WIDTH].iter()) {
+             let reference = score_int8_approx_scalar(&prepared, dimensions, code);
+Diff in /Users/peter/dev/tqvector/src/storage/page.rs:341:
+         assert_eq!(second.block_number, base, "same page while it fits");
+         assert_eq!(third.block_number, base + 1, "next page is base+1");
+         // Lookups resolve against the base.
+-        assert_eq!(chain.get_page(first.block_number).unwrap().raw_tuple(first).unwrap(), &[1; 32]);
+(B-        assert_eq!(chain.get_page(third.block_number).unwrap().raw_tuple(third).unwrap(), &[3; 32]);
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(first.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(first)
+(B+                .unwrap(),
+(B+            &[1; 32]
+(B+        );
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(third.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(third)
+(B+                .unwrap(),
+(B+            &[3; 32]
+(B+        );
+(B         // Below-base blocks are not in this chain.
+         assert!(chain.get_page(base - 1).is_none());
+         // pages() carry the base-relative block numbers for write_data_pages.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/tests/on_disk_fixtures.rs:9:
+     spire_decode_partition_object_v2_chain_segment_fixture,
+     spire_decode_routing_partition_object_fixture, spire_decode_top_graph_partition_object_fixture,
+     vamana_decode_overflow_tuple_fixture, DistannAbandonBindingAuditV1,
+-    DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildSpec, DistannCodecArtifact,
+(B-    DistannCancelPublishAuditV1, DistannEpochFingerprint, DistannEpochManifestV2,
+(B-    DistannGenerationDescriptor,
+(B-    DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape, DistannManifestBuildOptions,
+(B-    DistannManifestCodecParameters, DistannMetadataPage, DistannNodeTuple, DistannReadyReceipt,
+(B-    DistannRetireDecisionV1, DistannRowSchemaDescriptor, DistannSourceSnapshot,
+(B-    DistannSuccessorActivationV1, ItemPointer, IvfBlockRef, IvfCentroidTuple,
+(B-    IvfListDirectoryTuple, IvfMetadataPage, IvfPostingTuple, IvfPqCodebookTuple, IvfRerankMode,
+(B-    IvfRerankScoreMode, IvfStorageFormat, MetadataPage, SpireConsistencyMode, SpireEpochManifest,
+(B-    SpireEpochState, SpireLocalStoreConfig, SpireLocalStoreState, SpireManifestEntry,
+(B-    SpireObjectManifest, SpirePlacementDirectory, SpirePlacementEntry, SpirePlacementState,
+(B-    TqElementTuple, TqGroupedCodebookTuple, TqGroupedHotTuple, TqNeighborTuple, TqRerankTuple,
+(B-    TqTurboHotTuple, VamanaCodebookTuple, VamanaMetadataPage, VamanaNodeTuple,
+(B-    DISTANN_CONTROL_METADATA_BYTES, DISTANN_EPOCH_FINGERPRINT_BYTES, DISTANN_METADATA_BYTES,
+(B+    DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildSpec,
+(B+    DistannCancelPublishAuditV1, DistannCodecArtifact, DistannEpochFingerprint,
+(B+    DistannEpochManifestV2, DistannGenerationDescriptor, DistannHandoffBatch, DistannHandoffEntry,
+(B+    DistannHandoffShape, DistannManifestBuildOptions, DistannManifestCodecParameters,
+(B+    DistannMetadataPage, DistannNodeTuple, DistannReadyReceipt, DistannRetireDecisionV1,
+(B+    DistannRowSchemaDescriptor, DistannSourceSnapshot, DistannSuccessorActivationV1, ItemPointer,
+(B+    IvfBlockRef, IvfCentroidTuple, IvfListDirectoryTuple, IvfMetadataPage, IvfPostingTuple,
+(B+    IvfPqCodebookTuple, IvfRerankMode, IvfRerankScoreMode, IvfStorageFormat, MetadataPage,
+(B+    SpireConsistencyMode, SpireEpochManifest, SpireEpochState, SpireLocalStoreConfig,
+(B+    SpireLocalStoreState, SpireManifestEntry, SpireObjectManifest, SpirePlacementDirectory,
+(B+    SpirePlacementEntry, SpirePlacementState, TqElementTuple, TqGroupedCodebookTuple,
+(B+    TqGroupedHotTuple, TqNeighborTuple, TqRerankTuple, TqTurboHotTuple, VamanaCodebookTuple,
+(B+    VamanaMetadataPage, VamanaNodeTuple, DISTANN_CONTROL_METADATA_BYTES,
+(B+    DISTANN_EPOCH_FINGERPRINT_BYTES, DISTANN_METADATA_BYTES,
+(B     DISTANN_METADATA_FORMAT_VERSION_OFFSET, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.

--- a/reviews/task-36/003-review-findings-corrections/artifacts/int8-scalar-cap-negative-control.log
+++ b/reviews/task-36/003-review-findings-corrections/artifacts/int8-scalar-cap-negative-control.log
@@ -1,0 +1,42 @@
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.16s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 1 test
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ...
+thread 'quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference' (34391350) panicked at src/quant/int8_approx32/mod.rs:103:9:
+assertion `left == right` failed: int8 differential test did not execute the host's preferred SIMD ISA
+  left: Scalar
+ right: Neon
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+FAILED
+
+failures:
+
+failures:
+    quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2520 filtered out; finished in 0.04s
+
+error: test failed, to rerun pass `--lib`

--- a/reviews/task-36/003-review-findings-corrections/artifacts/make-simd-diff.log
+++ b/reviews/task-36/003-review-findings-corrections/artifacts/make-simd-diff.log
@@ -1,0 +1,455 @@
+task36 simd-diff: public bench hooks (Prod/FWHT/HNSW/DiskANN)
+cargo test --features bench --test simd_diff -- --test-threads=1 --nocapture
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 7m 04s
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-3eb2e7ac5b649314)
+
+running 10 tests
+test am_source_inner_product_simd_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_code_to_code_score_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_fwht_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_score_ip_from_parts_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test forced_neon_fwht_matches_scalar_reference_when_available ... ok
+test forced_neon_score_paths_match_scalar_reference_when_available ... ok
+test host_backend_inventory_is_visible ... task36_host arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false unavailable=x86_avx2_fma,x86_avx512
+ok
+test packed_mse_indices_roundtrip_across_widths ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test production_1536_4bit_score_path_matches_scalar_reference ... ok
+test three_bit_unpack_fixture_stays_bit_exact ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 22.25s
+
+task36 simd-diff: RaBitQ arithmetic SIMD inventory
+cargo test --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 5m 41s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 2 tests
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... task36_rabitq kernel=scalar_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=1536 status=exercised
+ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out; finished in 0.01s
+
+task36 simd-diff: rabitq32 bits=1/2/4 block and partial kernels
+cargo test --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.32s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 7 tests
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... task36_rabitq32 bits=2 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=2 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 2514 filtered out; finished in 0.05s
+
+task36 simd-diff: qjl32 block/octet/remainder kernels
+cargo test --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 10 tests
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_batch_with_blocks_and_tail_matches_pre_slice_scorer_bits ... task36_qjl32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2511 filtered out; finished in 0.24s
+
+task36 simd-diff: lut32 block/partial/tiled kernels
+cargo test --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 9 tests
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 2512 filtered out; finished in 0.02s
+
+task36 simd-diff: grouped-PQ block/partial kernels
+cargo test --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 8 tests
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2513 filtered out; finished in 0.00s
+
+task36 simd-diff: int8/SDOT block/partial kernels
+cargo test --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 5 tests
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... ok
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... ok
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... task36_int8_approx32 neon=true dotprod=true widths=1,7,8,9,16,17,31,32,33
+ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2516 filtered out; finished in 0.05s
+
+task36 simd-diff: tiled LUT lane and query-shape guards
+cargo test --lib --features bench quant::prod::tests::tiled_lut_query_prep_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 3 tests
+test quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch' (34360541) panicked at src/quant/prod.rs:1853:5:
+assertion `left == right` failed: prepared query LUT codebook length must match the centroid count
+  left: 8
+ right: 16
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane' (34360542) panicked at src/quant/prod.rs:418:9:
+explicit LUT query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch' (34360543) panicked at src/quant/prod.rs:411:9:
+assertion `left == right` failed: query length mismatch: got 1535, expected 1536
+  left: 1535
+ right: 1536
+ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2518 filtered out; finished in 0.07s
+
+task36 simd-diff: real hamming32 SIMD kernels
+cargo test --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 3 tests
+test quant::hamming32::tests::block32_is_integer_exact_with_scalar_reference ... ok
+test quant::hamming32::tests::partial_is_integer_exact_with_scalar_reference ... task36_hamming32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::hamming32::tests::scalar_reference_is_xor_popcount ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2518 filtered out; finished in 0.00s
+
+task36 simd-diff: DistANN codec composition, stride, and source IP
+cargo test --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 2 tests
+test am::ec_distann::insert::tests::simd_diff_exact_distance_is_shared_diskann_inner_product_negation ... task36_distann source_inner_product_backend=neon
+ok
+test am::ec_distann::quantizer::tests::simd_diff_distann_codec_batches_match_direct_scalar_scores_across_widths ... task36_distann format=grouped_pq dimensions=64 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=rabitq dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=turboquant dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out; finished in 0.06s

--- a/reviews/task-36/003-review-findings-corrections/artifacts/manifest.md
+++ b/reviews/task-36/003-review-findings-corrections/artifacts/manifest.md
@@ -1,0 +1,87 @@
+# Artifact manifest
+
+- Head SHA: `15e3831c13b65b488fea1c0f1ac1da8d46e321f1`
+- Task bucket: `reviews/task-36/`
+- Packet: `reviews/task-36/003-review-findings-corrections/`
+- Date: 2026-07-25
+- Host: Apple arm64, NEON + dot-product/SDOT detected
+- Scope: corrections prompted by feedback written against older head
+  `48fc8ee21`; review is requested against the current Task 36 branch.
+- Benchmark applicability: none. The production change restores rejected-input
+  preconditions and promotes a query-preparation shape check to a hard assert;
+  valid-lane scoring, index, rerank, posting, and storage behavior are
+  unchanged.
+
+## Commits under review
+
+- `07aa36712` — restore tiled-LUT query length/lane guards, harden the
+  centroid/codebook shape invariant, add three regression tests, and include
+  them in `make simd-diff`.
+- `6df8d4a30` — require int8 block and partial differential tests to report the
+  host-preferred ISA, preventing scalar-vs-scalar vacuity.
+- `15e3831c1` — replace stale automatic-PR-gate language with the repository's
+  actual manual-dispatch and packet-backed validation policy.
+
+## Artifacts
+
+### `make-simd-diff.log`
+
+- Command: `make simd-diff`
+- Status: PASS
+- Key results:
+  - public SIMD harness: 10 passed
+  - RaBitQ arithmetic: 2 passed
+  - `rabitq32`: 7 passed
+  - `qjl32`: 10 passed
+  - `lut32`: 9 passed
+  - grouped PQ: 8 passed
+  - int8/SDOT with host-ISA assertions: 5 passed
+  - tiled-LUT safety guards: 3 passed
+  - `hamming32`: 3 passed
+  - DistANN composition: 2 passed
+- Host inventory line:
+  `arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false`.
+
+### `quant-lib-tests.log`
+
+- Command:
+  `cargo test --lib --features bench quant:: -- --test-threads=1 --nocapture`
+- Status: PASS
+- Key result: 188 passed, 0 failed, 3 ignored.
+- This is the broader slice whose earlier run exposed
+  `tiled_lut_query_prep_rejects_qjl_active_lane`.
+
+### `int8-scalar-cap-negative-control.log`
+
+- Command:
+  `env ECAZ_ISA_CAP=scalar cargo test --lib --features bench
+  quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference
+  -- --test-threads=1 --nocapture`
+- Status: EXPECTED FAILURE
+- Key result: the assertion reports `left: Scalar`, `right: Neon`, proving an
+  environment cap can no longer turn this Apple-host differential into a
+  vacuous scalar-vs-scalar pass.
+
+### `cargo-fmt-check.log`
+
+- Command: `cargo fmt --all -- --check`
+- Status: FAIL on inherited repository-wide formatting drift.
+- See `quality-checks.md` for the bounded interpretation and the separate
+  clippy result.
+
+## Finding-by-finding disposition
+
+1. **Current block kernels absent from the lane:** already corrected by
+   `c373eb51f`; the current `make simd-diff` executes all six named families.
+   The green log above proves the current lane, not the older reviewed head.
+2. **Stale PR-visible claim:** corrected without changing the deliberate
+   manual-only CI policy. Task and hardening documentation now name packet-
+   backed local execution as the pre-merge evidence.
+3. **Tiled-LUT guard regression:** corrected in `07aa36712`; lane, length, and
+   codebook/centroid shape failures are hard assertions covered by tests.
+4. **Vacuous int8 dispatch tests:** corrected in `6df8d4a30`; every block and
+   partial dispatch result is checked against uncapped host feature selection.
+   The scalar-cap negative control fails at that assertion as intended.
+5. **SVE unvalidated:** already explicit in the current task and hardening
+   inventory. This Apple result lists SVE/SVE2 as unavailable; Graviton
+   execution remains a later hardware run and is not claimed here.

--- a/reviews/task-36/003-review-findings-corrections/artifacts/quality-checks.md
+++ b/reviews/task-36/003-review-findings-corrections/artifacts/quality-checks.md
@@ -1,0 +1,34 @@
+# Quality-check summary
+
+Head: `15e3831c13b65b488fea1c0f1ac1da8d46e321f1`
+
+## Whitespace
+
+Command: `git diff --check`
+
+Result: PASS before each correction commit and after the three correction
+commits.
+
+## Rustfmt
+
+Command: `cargo fmt --all -- --check`
+
+Result: FAIL on inherited repository-wide formatting drift. The complete
+output is in `cargo-fmt-check.log`. Making this global check green would
+rewrite many files and older regions outside Task 36.
+
+## Clippy
+
+Command: `cargo clippy --lib --features bench -- -D warnings`
+
+Result: FAIL on one pre-existing diagnostic outside Task 36:
+
+```text
+error: manual checked division
+  --> src/am/ec_ivf/quantizer.rs:695:34
+  = note: `-D clippy::manual-checked-ops` implied by `-D warnings`
+```
+
+No diagnostic referenced `Makefile`, `docs/hardening.md`,
+`plan/tasks/36-simd-scalar-differential.md`, `src/quant/prod.rs`, or
+`src/quant/int8_approx32/mod.rs`.

--- a/reviews/task-36/003-review-findings-corrections/artifacts/quant-lib-tests.log
+++ b/reviews/task-36/003-review-findings-corrections/artifacts/quant-lib-tests.log
@@ -1,0 +1,310 @@
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 191 tests
+test quant::codebook::tests::beta_pdf_integrates_to_one ... ok
+test quant::codebook::tests::beta_pdf_out_of_range ... ok
+test quant::codebook::tests::lloyd_max_b1_centroids_symmetric ... ok
+test quant::codebook::tests::log_gamma_known_values ... ok
+test quant::grouped_pq::tests::build_grouped_pq_lut_f32_uses_flat_codebooks_by_group ... ok
+test quant::grouped_pq::tests::encode_grouped_pq_packs_nibbles_from_shared_codebooks ... ok
+test quant::grouped_pq::tests::grouped_pq_nibble_reads_even_and_odd_groups ... ok
+test quant::grouped_pq::tests::grouped_pq_score_f32_sums_lut_rows_by_nibble ... ok
+test quant::grouped_pq::tests::nearest_centroid_l2_prefers_lowest_distance ... ok
+test quant::grouped_pq::tests::pack_grouped_pq_nibbles_packs_even_count ... ok
+test quant::grouped_pq::tests::pack_grouped_pq_nibbles_packs_odd_count ... ok
+test quant::grouped_pq::tests::pq_fastscan_quantizer_trait_score_matches_direct_helpers ... ok
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::hadamard::tests::fwht_preserves_norm_after_normalization ... ok
+test quant::hadamard::tests::fwht_runtime_path_matches_scalar_at_large_sizes ... ok
+test quant::hadamard::tests::fwht_runtime_path_matches_scalar_on_random_inputs ... ok
+test quant::hadamard::tests::miri_fwht_small ... ok
+test quant::hadamard::tests::miri_orthonormal_fwht_small ... ok
+test quant::hadamard::tests::orthonormal_fwht_runtime_path_matches_scalar_on_random_inputs ... ok
+test quant::hadamard::tests::tiled_fwht_matches_chunkwise_full_fwht ... ok
+test quant::hadamard::tests::tiled_orthonormal_fwht_preserves_norm_per_tile ... ok
+test quant::hamming32::tests::block32_is_integer_exact_with_scalar_reference ... ok
+test quant::hamming32::tests::partial_is_integer_exact_with_scalar_reference ... task36_hamming32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::hamming32::tests::scalar_reference_is_xor_popcount ... ok
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... ok
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... ok
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... task36_int8_approx32 neon=true dotprod=true widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::isa::tests::cap_encoding_roundtrips ... ok
+test quant::isa::tests::capped_selection_limits_but_never_fakes ... ok
+test quant::isa::tests::parse_isa_cap_accepts_known_values ... ok
+test quant::isa::tests::parse_isa_cap_rejects_unknown_values - should panic ...
+thread 'quant::isa::tests::parse_isa_cap_rejects_unknown_values' (34360783) panicked at src/quant/isa.rs:165:18:
+unsupported ECAZ_ISA_CAP value: fast
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+ok
+test quant::isa::tests::select_highest_isa_falls_back_to_neon_or_scalar ... ok
+test quant::isa::tests::select_highest_isa_prefers_neon_on_graviton4 ... ok
+test quant::isa::tests::select_highest_isa_prefers_x86_avx2_on_x86_features ... ok
+test quant::isa::tests::select_highest_isa_uses_sve_tiers_only_without_neon ... ok
+test quant::lut32::neon::tests::transpose_8x16_yields_byte_columns ... ok
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+test quant::lut32::tests::task124_profile_lut32_block32_and_query_prep ... ignored, Task 124 scorer microprofile; run explicitly with ECAZ_TQ_PROFILE_LOG
+test quant::lut32::tests::task132_profile_lut32_batch_tiled_widths ... ignored, Task 132 batch-tiled width microprofile; run explicitly with ECAZ_TQ_PROFILE_LOG
+test quant::mse::tests::branchless_matches_branching_over_random_inputs ... ok
+test quant::mse::tests::nearest_centroid_index_prefers_lower_index_on_tie ... ok
+test quant::mse::tests::quantize_to_indices_dispatches_unrolled_for_16_centroids ... ok
+test quant::mse::tests::unrolled_16_matches_generic_branchless ... ok
+test quant::prod::tests::binary_sign_no_qjl_4bit_keeps_identical_vector_ranked_first ... ok
+test quant::prod::tests::binary_sign_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::binary_sign_query_prep_rejects_qjl_active_lane' (34360803) panicked at src/quant/prod.rs:482:9:
+binary sign query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::cached_quantizer_reuses_instances ... ok
+test quant::prod::tests::cached_with_presence_reports_whether_entry_already_existed ... ok
+test quant::prod::tests::code_to_code_score_is_symmetric_and_ignores_qjl ... ok
+test quant::prod::tests::decode_eight_3bit_aligned_matches_packer ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_at_production_dims ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_on_random_inputs ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_with_tail_dims ... ok
+test quant::prod::tests::encode_decode_has_reasonable_fidelity ... ok
+test quant::prod::tests::encode_is_deterministic ... ok
+test quant::prod::tests::encode_payload_length_matches_spec ... ok
+test quant::prod::tests::explicit_lut_no_qjl_4bit_tracks_direct_scoring_with_int16_lut ... ok
+test quant::prod::tests::explicit_lut_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::explicit_lut_query_prep_rejects_qjl_active_lane' (34360896) panicked at src/quant/prod.rs:391:9:
+explicit LUT query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::int8_approx_no_qjl_4bit_keeps_identical_vector_ranked_first ... ok
+test quant::prod::tests::int8_approx_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::int8_approx_query_prep_rejects_qjl_active_lane' (34360902) panicked at src/quant/prod.rs:366:9:
+int8 approximate query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::miri_encode_decode_roundtrip ... ok
+test quant::prod::tests::miri_pack_unpack_mse ... ok
+test quant::prod::tests::miri_pack_unpack_qjl ... ok
+test quant::prod::tests::miri_quantizer_cache_concurrent_init_under_contention ... ok
+test quant::prod::tests::miri_score_ip_codes_lite ... ok
+test quant::prod::tests::miri_score_ip_encoded ... ok
+test quant::prod::tests::mse_pack_unpack_roundtrip_all_widths ... ok
+test quant::prod::tests::pack_mse_indices_fast_paths_match_generic ... ok
+test quant::prod::tests::prepared_query_score_matches_explicit_formula ... ok
+test quant::prod::tests::qjl_neon_production_path_matches_scalar_reference_tolerance ... ok
+test quant::prod::tests::qjl_pack_unpack_roundtrip ... ok
+test quant::prod::tests::qjl_pre_task104_neon_multi_accum_tolerance_diagnostic ... qjl_pre_task104_neon_multi_accum_tolerance_diagnostic dim=1024 bits=4 candidates=1000 max_ulp=13600 max_rel=9.433868108e-4 violations=298 worst_seed=924
+ok
+test quant::prod::tests::qjl_sign_lanes_exhaustive ... ok
+test quant::prod::tests::quantizer_1536_4bit_disables_unused_qjl_and_lut_state ... ok
+test quant::prod::tests::quantizer_1536_4bit_reallocates_qjl_budget_to_mse ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_binary_sign_query_prep ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_explicit_lut_query_prep ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_int8_approx_query_prep ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_tiled_lut_query_prep ... ok
+test quant::prod::tests::quantizer_1536_uses_tiled_working_dimension ... ok
+test quant::prod::tests::quantizer_32_4bit_keeps_qjl_and_lut_state_when_active ... ok
+test quant::prod::tests::quantizer_no_qjl_lut_min_bound_keeps_or_prunes_exact_score ... ok
+test quant::prod::tests::quantizer_trait_score_matches_inherent_score_ip_encoded ... ok
+test quant::prod::tests::raw_code_score_matches_encoded_lite_path ... ok
+test quant::prod::tests::score_from_parts_honors_supplied_gamma ... ok
+test quant::prod::tests::score_from_parts_matches_encoded_payload_path ... ok
+test quant::prod::tests::task124_profile_no_qjl_lut_query_prep ... ignored, Task 124 query-prep microprofile; run explicitly with ECAZ_TQ_QUERY_PREP_PROFILE_LOG
+test quant::prod::tests::tiled_lut_no_qjl_4bit_matches_direct_scoring ... ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch' (34360980) panicked at src/quant/prod.rs:1853:5:
+assertion `left == right` failed: prepared query LUT codebook length must match the centroid count
+  left: 8
+ right: 16
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane' (34360981) panicked at src/quant/prod.rs:418:9:
+explicit LUT query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch' (34360982) panicked at src/quant/prod.rs:411:9:
+assertion `left == right` failed: query length mismatch: got 1535, expected 1536
+  left: 1535
+ right: 1536
+ok
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_batch_with_blocks_and_tail_matches_pre_slice_scorer_bits ... task36_qjl32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... task36_rabitq32 bits=2 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=2 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+test quant::rabitq::tests::batch_max_prevalidated_matches_scalar_max ... ok
+test quant::rabitq::tests::bit_level_packers_round_trip_all_supported_widths ... ok
+test quant::rabitq::tests::bits1_batch_estimator_matches_scalar_order ... ok
+test quant::rabitq::tests::bits1_batch_estimator_rejects_wrong_width_and_stride ... ok
+test quant::rabitq::tests::bits1_byte_lut_matches_per_bit_decode ... ok
+test quant::rabitq::tests::bits1_byte_lut_scalar_sum_matches_per_bit_decode ... ok
+test quant::rabitq::tests::bits4_batch_estimator_matches_scalar_order ... ok
+test quant::rabitq::tests::bits8_batch_estimator_matches_scalar_order ... ok
+test quant::rabitq::tests::bits8_precompute_matches_lut_decode ... ok
+test quant::rabitq::tests::centered_api_rejects_qbit_bits ... ok
+test quant::rabitq::tests::centered_context_and_scorer_cover_raw_and_degenerate_paths ... ok
+test quant::rabitq::tests::centered_encode_pins_asymmetric_center_tail_and_zero_residual ... ok
+test quant::rabitq::tests::centered_estimator_bound_dominates_error_on_random_vectors ... ok
+test quant::rabitq::tests::centered_estimator_is_exact_on_sign_aligned_residual ... ok
+test quant::rabitq::tests::centered_scorer_floor_boundaries_cover_below_equal_and_above ... ok
+test quant::rabitq::tests::centered_scorer_matches_manual_unit_residual_ip ... ok
+test quant::rabitq::tests::centered_scorer_pins_nontrivial_bound_formula ... ok
+test quant::rabitq::tests::code_len_matches_dimension ... ok
+test quant::rabitq::tests::custom_rotation_plugs_into_seam ... ok
+test quant::rabitq::tests::dequantized_estimator_scores_reconstructed_payload_and_guards_tail_scalars ... ok
+test quant::rabitq::tests::encode_code_pins_qbit_payload_and_scalars ... ok
+test quant::rabitq::tests::encode_code_pins_zero_vector_tail_and_levels ... ok
+test quant::rabitq::tests::encode_then_score_same_vector_is_nonnegative ... ok
+test quant::rabitq::tests::estimate_ip_guards_and_bound_are_pinned ... ok
+test quant::rabitq::tests::estimate_ip_o_dot_floor_covers_below_equal_and_above ... ok
+test quant::rabitq::tests::estimator_bound_dominates_error_on_random_vectors ... ok
+test quant::rabitq::tests::estimator_recovers_self_ip_on_sign_aligned_vector ... ok
+test quant::rabitq::tests::hamming_similarity_identity_equals_dim ... ok
+test quant::rabitq::tests::least_squares_estimator_uses_o_dot_as_shrinkage ... ok
+test quant::rabitq::tests::neon_sum_query_dequant_matches_scalar_bits1 ... ok
+test quant::rabitq::tests::neon_sum_query_dequant_matches_scalar_bits4 ... ok
+test quant::rabitq::tests::neon_sum_query_dequant_matches_scalar_bits8 ... ok
+test quant::rabitq::tests::persisted_sidecar_helpers_preserve_supported_and_unsupported_lanes ... ok
+test quant::rabitq::tests::prepared_queries_only_keep_bits1_byte_lut_for_bits1 ... ok
+test quant::rabitq::tests::qbit_code_len_scales_with_bits ... ok
+test quant::rabitq::tests::qbit_encoder_reduces_error_vs_binary ... ok
+test quant::rabitq::tests::qbit_quantize_and_dequantize_pin_level_midpoints ... ok
+test quant::rabitq::tests::qbit_quantize_pins_non_roundtrip_scale_term ... ok
+test quant::rabitq::tests::qbit_rejects_unsupported_bits ... ok
+test quant::rabitq::tests::quantizer_and_prepared_estimator_accessors_are_stable ... ok
+test quant::rabitq::tests::query_scorer_matches_estimator_for_nontrivial_pair ... ok
+test quant::rabitq::tests::residual_beats_absolute_on_concentrated_lists ... ok
+test quant::rabitq::tests::residual_code_is_byte_identical_shape_to_absolute_code ... ok
+test quant::rabitq::tests::residual_estimate_recovers_exact_residual_term ... ok
+test quant::rabitq::tests::residual_scoring_matches_exact_within_tolerance ... ok
+test quant::rabitq::tests::seeded_srht_cache_keys_include_bits_seed_and_clip ... ok
+test quant::rabitq::tests::sign_sidecar_helpers_pack_exact_words ... ok
+test quant::rabitq::tests::sign_words_from_rotated_matches_manual_pack ... ok
+test quant::rabitq::tests::srht_seeded_rotation_is_deterministic_and_independent_of_prod ... ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... task36_rabitq kernel=scalar_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=1536 status=exercised
+ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+test quant::rabitq::tests::try_estimate_bound_carrying_cutoff_agrees_with_scalar ... ok
+test quant::rabitq::tests::try_estimate_scalar_cutoff_is_monotone_in_threshold ... ok
+test quant::rabitq::tests::try_estimate_scalar_cutoff_is_sound_under_non_identity_rotation ... ok
+test quant::rabitq::tests::try_estimate_scalar_cutoff_never_prunes_a_keepable_candidate ... ok
+test quant::rotation::tests::srht_padded_matches_pad_input_plus_srht ... ok
+test quant::rotation::tests::srht_preserves_norm ... ok
+test quant::rotation::tests::srht_runtime_path_matches_scalar_on_random_inputs ... ok
+test quant::rotation::tests::tiled_srht_roundtrip_1536 ... ok
+test quant::simd::tests::backend_name_matches_detected_backend ... ok
+test quant::simd::tests::detect_backend_honors_forced_scalar ... ok
+test quant::simd::tests::forced_backend_accepts_auto_empty_and_absent ... ok
+test quant::simd::tests::forced_backend_accepts_supported_backend_names ... ok
+test quant::simd::tests::forced_backend_rejects_unknown_name ...
+thread 'quant::simd::tests::forced_backend_rejects_unknown_name' (34361070) panicked at src/quant/simd.rs:207:18:
+unsupported ECAZ_SIMD value: bogus
+ok
+test quant::simd::tests::x86_backend_gate_requires_avx2_and_fma ... ok
+test quant::simd::tests::x86_feature_slots_model_task67_kernel_requirements ... ok
+test quant::tiled_lut32::tests::run_is_bit_equal_with_production_tiled_scorer ... ok
+
+test result: ok. 188 passed; 0 failed; 3 ignored; 0 measured; 2330 filtered out; finished in 5.64s

--- a/reviews/task-36/003-review-findings-corrections/request.md
+++ b/reviews/task-36/003-review-findings-corrections/request.md
@@ -1,0 +1,62 @@
+---
+task: 36
+agent: codex
+role: coder
+model: GPT-5
+date: 2026-07-25
+head: 15e3831c13b65b488fea1c0f1ac1da8d46e321f1
+---
+
+# Review request: Task 36 current-head corrections
+
+Please review the actual Task 36 current head
+`15e3831c13b65b488fea1c0f1ac1da8d46e321f1`.
+
+The feedback in packet 001 named reviewed head `48fc8ee21`, which predates the
+Task 36 implementation checkpoint `c373eb51f`. Consequently, its lane-
+inventory, tolerance, and SVE-accounting findings were already corrected on
+this branch. The feedback still exposed two valid regressions, both corrected
+here.
+
+## Corrections
+
+- Restored the tiled-LUT query length and no-QJL 4-bit lane guards.
+- Promoted the LUT codebook/centroid shape invariant from `debug_assert_eq!`
+  to release-enforced `assert_eq!`.
+- Added regression tests for all three failure modes and made them part of
+  `make simd-diff`.
+- Pinned every int8 block/partial differential dispatch to the uncapped
+  host-preferred ISA, so an environment cap cannot produce a vacuous
+  scalar-vs-scalar pass.
+- Removed the remaining stale “caught at PR time” language. The task and
+  hardening guide now accurately describe manual-dispatch CI and packet-backed
+  pre-merge evidence.
+
+No CI workflow was changed. Intel and Graviton execution remain explicit later
+hardware runs, not claims made by this Apple packet.
+
+## Evidence
+
+See [artifacts/manifest.md](artifacts/manifest.md) for the complete mapping of
+all five findings.
+
+- [make-simd-diff.log](artifacts/make-simd-diff.log): authoritative lane
+  passed, including the six current block-kernel families, int8 ISA pinning,
+  and three tiled-LUT safety tests.
+- [quant-lib-tests.log](artifacts/quant-lib-tests.log): reviewer discovery
+  slice passed, 188 passed / 0 failed / 3 ignored.
+- [int8-scalar-cap-negative-control.log](artifacts/int8-scalar-cap-negative-control.log):
+  forcing `ECAZ_ISA_CAP=scalar` fails with actual `Scalar` versus expected
+  `Neon`, proving the test cannot pass vacuously.
+- [quality-checks.md](artifacts/quality-checks.md): whitespace passed; global
+  format and clippy baseline failures are identified by exact unrelated scope.
+
+## Review focus
+
+1. Do the restored guards eliminate the release-mode silent wrong-score path?
+2. Does uncapped host selection make the int8 tests fail loudly under an ISA
+   cap or dispatch fallback?
+3. Does the current packet now distinguish current-head evidence from the
+   older head reviewed in packet 001?
+
+Task 36 remains review-requested; the coder is not closing the request.

--- a/reviews/task-36/004-current-head-review-flags/artifacts/2026-07-25-reviewer-counted-wrapper-controls.log
+++ b/reviews/task-36/004-current-head-review-flags/artifacts/2026-07-25-reviewer-counted-wrapper-controls.log
@@ -1,0 +1,6 @@
+# Reviewer negative controls for scripts/run-counted-cargo-test.sh
+# head: 8923245ee, Apple M5 aarch64
+
+A wrong expected count (99 vs 3): exit=1  counted cargo test: expected 99 passed tests, observed 3
+B filter matches nothing:        exit=1  counted cargo test: expected 3 passed tests, observed 0
+C cargo itself fails:            exit=1  For more information, try '--help'.

--- a/reviews/task-36/004-current-head-review-flags/artifacts/2026-07-25-reviewer-isa-cap-control.log
+++ b/reviews/task-36/004-current-head-review-flags/artifacts/2026-07-25-reviewer-isa-cap-control.log
@@ -1,0 +1,43 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 5 tests
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... FAILED
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... FAILED
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... FAILED
+
+failures:
+
+---- quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference stdout ----
+
+thread 'quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference' (34457025) panicked at src/quant/int8_approx32/mod.rs:103:9:
+assertion `left == right` failed: int8 differential test did not execute the host's preferred SIMD ISA
+  left: Scalar
+ right: Neon
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+---- quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values stdout ----
+
+thread 'quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values' (34457026) panicked at src/quant/int8_approx32/mod.rs:103:9:
+assertion `left == right` failed: int8 differential test did not execute the host's preferred SIMD ISA
+  left: Scalar
+ right: Neon
+
+---- quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference stdout ----
+
+thread 'quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference' (34457028) panicked at src/quant/int8_approx32/mod.rs:103:9:
+assertion `left == right` failed: int8 differential test did not execute the host's preferred SIMD ISA
+  left: Scalar
+ right: Neon
+
+
+failures:
+    quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference
+    quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values
+    quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference
+
+test result: FAILED. 2 passed; 3 failed; 0 ignored; 0 measured; 2516 filtered out; finished in 0.05s
+
+error: test failed, to rerun pass `--lib`

--- a/reviews/task-36/004-current-head-review-flags/artifacts/2026-07-25-reviewer-make-simd-diff-repro.log
+++ b/reviews/task-36/004-current-head-review-flags/artifacts/2026-07-25-reviewer-make-simd-diff-repro.log
@@ -1,0 +1,245 @@
+task36 simd-diff: public bench hooks (Prod/FWHT/HNSW/DiskANN)
+bash scripts/run-counted-cargo-test.sh 10 --features bench --test simd_diff -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 29.66s
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-066c79309fe4fb1b)
+
+running 10 tests
+test am_source_inner_product_simd_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_code_to_code_score_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_fwht_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_score_ip_from_parts_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test forced_neon_fwht_matches_scalar_reference_when_available ... ok
+test forced_neon_score_paths_match_scalar_reference_when_available ... ok
+test host_backend_inventory_is_visible ... task36_host arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false unavailable=x86_avx2_fma,x86_avx512
+ok
+test packed_mse_indices_roundtrip_across_widths ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test production_1536_4bit_score_path_matches_scalar_reference ... ok
+test three_bit_unpack_fixture_stays_bit_exact ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 20.78s
+
+counted cargo test: observed expected 10 passed tests
+task36 simd-diff: RaBitQ arithmetic SIMD inventory
+bash scripts/run-counted-cargo-test.sh 2 --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 30.74s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 2 tests
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... task36_rabitq kernel=scalar_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=1536 status=exercised
+ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out; finished in 0.01s
+
+counted cargo test: observed expected 2 passed tests
+task36 simd-diff: rabitq32 bits=1/2/4 block and partial kernels
+bash scripts/run-counted-cargo-test.sh 7 --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.24s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 7 tests
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... task36_rabitq32 bits=2 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=2 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 2514 filtered out; finished in 0.05s
+
+counted cargo test: observed expected 7 passed tests
+task36 simd-diff: qjl32 block/octet/remainder kernels
+bash scripts/run-counted-cargo-test.sh 10 --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 10 tests
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_batch_matches_pre_slice_scorer_by_execution_path ... task36_qjl32 observed_block_isa=neon scalar_tail=bit-exact widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2511 filtered out; finished in 0.25s
+
+counted cargo test: observed expected 10 passed tests
+task36 simd-diff: lut32 block/partial/tiled kernels
+bash scripts/run-counted-cargo-test.sh 9 --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.11s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 9 tests
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 2512 filtered out; finished in 0.03s
+
+counted cargo test: observed expected 9 passed tests
+task36 simd-diff: grouped-PQ block/partial kernels
+bash scripts/run-counted-cargo-test.sh 8 --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 8 tests
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2513 filtered out; finished in 0.00s
+
+counted cargo test: observed expected 8 passed tests
+task36 simd-diff: int8/SDOT block/partial kernels
+bash scripts/run-counted-cargo-test.sh 5 --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 5 tests
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... ok
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... ok
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... task36_int8_approx32 neon=true dotprod=true widths=1,7,8,9,16,17,31,32,33
+ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2516 filtered out; finished in 0.05s
+
+counted cargo test: observed expected 5 passed tests
+task36 simd-diff: tiled LUT lane and query-shape guards
+bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::prod::tests::tiled_lut_query_prep_ -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 3 tests
+test quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch - should panic ... 
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch' (34455289) panicked at src/quant/prod.rs:1853:5:
+assertion `left == right` failed: prepared query LUT codebook length must match the centroid count
+  left: 8
+ right: 16
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane - should panic ... 
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane' (34455290) panicked at src/quant/prod.rs:418:9:
+explicit LUT query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch - should panic ... 
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch' (34455291) panicked at src/quant/prod.rs:411:9:
+assertion `left == right` failed: query length mismatch: got 1535, expected 1536
+  left: 1535
+ right: 1536
+ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2518 filtered out; finished in 0.07s
+
+counted cargo test: observed expected 3 passed tests
+task36 simd-diff: real hamming32 SIMD kernels
+bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 3 tests
+test quant::hamming32::tests::block32_is_integer_exact_with_scalar_reference ... ok
+test quant::hamming32::tests::partial_is_integer_exact_with_scalar_reference ... task36_hamming32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::hamming32::tests::scalar_reference_is_xor_popcount ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2518 filtered out; finished in 0.00s
+
+counted cargo test: observed expected 3 passed tests
+task36 simd-diff: DistANN codec composition, stride, and source IP
+bash scripts/run-counted-cargo-test.sh 2 --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-0d594238e7d98c78)
+
+running 2 tests
+test am::ec_distann::insert::tests::simd_diff_exact_distance_is_shared_diskann_inner_product_negation ... task36_distann source_inner_product_backend=neon
+ok
+test am::ec_distann::quantizer::tests::simd_diff_distann_codec_batches_match_direct_scalar_scores_across_widths ... task36_distann format=grouped_pq dimensions=64 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=rabitq dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=turboquant dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out; finished in 0.06s
+
+counted cargo test: observed expected 2 passed tests
+EXIT=0

--- a/reviews/task-36/004-current-head-review-flags/artifacts/cargo-fmt-check.log
+++ b/reviews/task-36/004-current-head-review-flags/artifacts/cargo-fmt-check.log
@@ -1,0 +1,1828 @@
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/crates/ecaz-cli/src/commands/corpus/load.rs:2191:
+         stop.store(true, Ordering::SeqCst);
+         task.await
+             .map_err(|error| eyre!("build memory monitor task failed: {error}"))??;
+-        if let Some(after) = crate::commands::bench::latency::read_proc_status_memory(backend_pid)
+(B-            .await?
+(B+        if let Some(after) =
+(B+            crate::commands::bench::latency::read_proc_status_memory(backend_pid).await?
+(B         {
+             peak.lock().await.merge(after);
+         }
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/am/ec_diskann/scan.rs:1591:
+         // A chain graph exposes few admissible frontier entries per
+         // round, so the beam cannot widen flushes much here — but
+         // batching rounds must never *increase* the flush count.
+-        let flushes = |p: &FrontierProfile| {
+(B-            p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>()
+(B-        };
+(B+        let flushes =
+(B+            |p: &FrontierProfile| p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>();
+(B         assert!(
+             flushes(&profile) <= flushes(&sequential_profile),
+             "batched rounds must not exceed the sequential flush count"
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/am/ec_ivf/page.rs:3507:
+         "ec_ivf posting entry block sequence",
+         |buffer, block_number| {
+             let decode_started = std::time::Instant::now();
+-            let result =
+(B-                visit_all_ivf_posting_entries_from_buffer(buffer, block_number, payload_len, visitor);
+(B+            let result = visit_all_ivf_posting_entries_from_buffer(
+(B+                buffer,
+(B+                block_number,
+(B+                payload_len,
+(B+                visitor,
+(B+            );
+(B             decode_elapsed += decode_started.elapsed();
+             result
+         },
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/quant/int8_approx32/mod.rs:97:
+     use crate::quant::prod::ProdQuantizer;
+
+     fn assert_host_simd_isa(actual: crate::quant::isa::Isa) {
+-        let expected = crate::quant::isa::select_highest_isa(
+(B-            crate::quant::isa::HostIsaFeatures::detect(),
+(B-        );
+(B+        let expected =
+(B+            crate::quant::isa::select_highest_isa(crate::quant::isa::HostIsaFeatures::detect());
+(B         assert_eq!(
+             actual, expected,
+             "int8 differential test did not execute the host's preferred SIMD ISA"
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/quant/int8_approx32/mod.rs:136:
+
+         let block: &[&[u8]; BLOCK_WIDTH] = code_refs[..BLOCK_WIDTH].try_into().unwrap();
+         let mut block_scores = vec![0.0; BLOCK_WIDTH];
+-        let block_isa =
+(B-            score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+(B+        let block_isa = score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+(B         assert_host_simd_isa(block_isa);
+         for (score, code) in block_scores.iter().zip(code_refs[..BLOCK_WIDTH].iter()) {
+             let reference = score_int8_approx_scalar(&prepared, dimensions, code);
+Diff in /Users/peter/dev/tqvector/hardening/careful/src/../../../src/storage/page.rs:341:
+         assert_eq!(second.block_number, base, "same page while it fits");
+         assert_eq!(third.block_number, base + 1, "next page is base+1");
+         // Lookups resolve against the base.
+-        assert_eq!(chain.get_page(first.block_number).unwrap().raw_tuple(first).unwrap(), &[1; 32]);
+(B-        assert_eq!(chain.get_page(third.block_number).unwrap().raw_tuple(third).unwrap(), &[3; 32]);
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(first.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(first)
+(B+                .unwrap(),
+(B+            &[1; 32]
+(B+        );
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(third.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(third)
+(B+                .unwrap(),
+(B+            &[3; 32]
+(B+        );
+(B         // Below-base blocks are not in this chain.
+         assert!(chain.get_page(base - 1).is_none());
+         // pages() carry the base-relative block numbers for write_data_pages.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/src/am/ec_diskann/options.rs:194:
+ }
+
+ pub(super) fn current_beam_width() -> usize {
+-    usize::try_from(ECDISKANN_BEAM_WIDTH_GUC.get()).unwrap_or(1).max(1)
+(B+    usize::try_from(ECDISKANN_BEAM_WIDTH_GUC.get())
+(B+        .unwrap_or(1)
+(B+        .max(1)
+(B }
+
+ pub(super) fn scan_profile_notice_enabled() -> bool {
+Diff in /Users/peter/dev/tqvector/src/am/ec_diskann/scan.rs:1591:
+         // A chain graph exposes few admissible frontier entries per
+         // round, so the beam cannot widen flushes much here — but
+         // batching rounds must never *increase* the flush count.
+-        let flushes = |p: &FrontierProfile| {
+(B-            p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>()
+(B-        };
+(B+        let flushes =
+(B+            |p: &FrontierProfile| p.flush_width_zero + p.flush_width_buckets.iter().sum::<usize>();
+(B         assert!(
+             flushes(&profile) <= flushes(&sequential_profile),
+             "batched rounds must not exceed the sequential flush count"
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/build_gate.rs:358:
+         if rt_index <= 0 || rt_index > table_length {
+             continue;
+         }
+-        let rte = unsafe {
+(B-            pg_sys::list_nth(stmt.rtable, rt_index - 1).cast::<pg_sys::RangeTblEntry>()
+(B-        };
+(B+        let rte =
+(B+            unsafe { pg_sys::list_nth(stmt.rtable, rt_index - 1).cast::<pg_sys::RangeTblEntry>() };
+(B         let Some(rte) = (unsafe { rte.as_ref() }) else {
+             continue;
+         };
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/canonical_wire.rs:20:
+     code: &str,
+     field: &str,
+ ) -> Result<[u8; N], String> {
+-    bytes.try_into().map_err(|bytes: Vec<u8>| {
+(B-        format!(
+(B-            "{code}: {field} is {} bytes, expected {N}",
+(B-            bytes.len()
+(B-        )
+(B-    })
+(B+    bytes
+(B+        .try_into()
+(B+        .map_err(|bytes: Vec<u8>| format!("{code}: {field} is {} bytes, expected {N}", bytes.len()))
+(B }
+
+-pub(crate) fn fixed_digest(
+(B-    bytes: Vec<u8>,
+(B-    code: &str,
+(B-    field: &str,
+(B-) -> Result<[u8; 32], String> {
+(B+pub(crate) fn fixed_digest(bytes: Vec<u8>, code: &str, field: &str) -> Result<[u8; 32], String> {
+(B     fixed_bytes(bytes, code, field)
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/coordinator_retirement.rs:508:
+                             .value::<Vec<u8>>()
+                             .map_err(|_| "EC_EPOCH_STATE: retire digest decode failed".to_owned())?
+                             .ok_or_else(|| "EC_EPOCH_STATE: retire digest is NULL".to_owned())?,
+-                        state: RetireDecisionState::parse(&row["decision_state"]
+(B-                            .value::<String>()
+(B-                            .map_err(|_| "EC_EPOCH_STATE: retire state decode failed".to_owned())?
+(B-                            .ok_or_else(|| "EC_EPOCH_STATE: retire state is NULL".to_owned())?)?,
+(B+                        state: RetireDecisionState::parse(
+(B+                            &row["decision_state"]
+(B+                                .value::<String>()
+(B+                                .map_err(|_| {
+(B+                                    "EC_EPOCH_STATE: retire state decode failed".to_owned()
+(B+                                })?
+(B+                                .ok_or_else(|| "EC_EPOCH_STATE: retire state is NULL".to_owned())?,
+(B+                        )?,
+(B                         xmin: row["decision_xmin"]
+                             .value::<String>()
+                             .map_err(|_| {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/coordinator_retirement.rs:658:
+                         stored.build_id.into(),
+                     ],
+                 )
+-                .map_err(|error| {
+(B-                    format!("EC_EPOCH_STATE: head-sample reclaim failed: {error}")
+(B-                })?;
+(B+                .map_err(|error| format!("EC_EPOCH_STATE: head-sample reclaim failed: {error}"))?;
+(B             Ok::<(), String>(())
+         })?;
+         let updated = Spi::connect_mut(|client| {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/cost.rs:67:
+                 let constants = unsafe { current_planner_cost_constants() };
+                 // Per-query work is BW x H expansions (NFR-019); model the
+                 // search breadth as that product.
+-                let ef_search = i32::try_from(
+(B-                    options::current_beam_width() * options::current_hop_rounds(),
+(B-                )
+(B-                .unwrap_or(i32::MAX);
+(B+                let ef_search =
+(B+                    i32::try_from(options::current_beam_width() * options::current_hop_rounds())
+(B+                        .unwrap_or(i32::MAX);
+(B                 estimate_planner_cost(
+                     PlannerCostInputs {
+                         index_pages: index_pages_value,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/custom_scan.rs:1208:
+         .iter()
+         .take(previous_proven)
+         .position(|output| {
+-            output
+(B-                .as_ref()
+(B-                .and_then(materialized_remote_output_vec_id)
+(B-                == Some(vec_id)
+(B+            output.as_ref().and_then(materialized_remote_output_vec_id) == Some(vec_id)
+(B         })?;
+     previous_outputs.get_mut(position)?.take()
+ }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/custom_scan.rs:1773:
+ #[cfg(test)]
+ mod materialization_candidate_tests {
+     use super::{
+-        pending_materialization_window, take_materialized_remote_output_by_id,
+(B-        CustomScanOutputRow,
+(B+        pending_materialization_window, take_materialized_remote_output_by_id, CustomScanOutputRow,
+(B     };
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:85:
+     // are not already tombstoned (monotone: never re-flip).
+     let mut to_tombstone: Vec<ItemPointer> = Vec::new();
+     for (_vec_id, record_tid) in &directory {
+-        let raw = read_raw_tuple_bytes_from_relation(
+(B-            handle,
+(B-            *record_tid,
+(B-            "ec_distann tombstone scan",
+(B-        )?;
+(B+        let raw =
+(B+            read_raw_tuple_bytes_from_relation(handle, *record_tid, "ec_distann tombstone scan")?;
+(B         if raw.first().copied() != Some(DISTANN_NODE_TAG)
+             || raw.len() < DISTANN_NODE_HEAP_TID_OFFSET + 6
+         {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:180:
+     let handle = NonNull::new(index_relation).ok_or_else(|| {
+         DistannExpandError::Internal("ec_distann tombstone needs a valid index relation".to_owned())
+     })?;
+-    let metadata =
+(B-        read_metadata_from_index_handle(handle).map_err(DistannExpandError::Internal)?;
+(B+    let metadata = read_metadata_from_index_handle(handle).map_err(DistannExpandError::Internal)?;
+(B     super::require_legacy_local_storage(&metadata, "ec_distann tombstone")
+         .map_err(DistannExpandError::GenerationMissing)?;
+     if vec_ids.is_empty() {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:205:
+                 "ec_distann tombstone: vec_id {vec_id:#018x} is not in the directory"
+             ))
+         })?;
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, record_tid, "ec_distann tombstone by vec_id")
+(B-                .map_err(DistannExpandError::Internal)?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(
+(B+            handle,
+(B+            record_tid,
+(B+            "ec_distann tombstone by vec_id",
+(B+        )
+(B+        .map_err(DistannExpandError::Internal)?;
+(B         let flags = u16::from_le_bytes(
+             raw[DISTANN_NODE_FLAGS_OFFSET..DISTANN_NODE_FLAGS_OFFSET + 2]
+                 .try_into()
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/dml.rs:358:
+ /// Append one delta tuple on a freshly-extended page (one entry per page: a
+ /// dim-1536 entry is ~6 KB, near a page anyway, and the buffer is bounded).
+ /// WAL-logged. Returns the new tuple's TID.
+-fn append_delta_tuple(
+(B-    handle: RelationHandle,
+(B-    payload: Vec<u8>,
+(B-) -> Result<ItemPointer, String> {
+(B+fn append_delta_tuple(handle: RelationHandle, payload: Vec<u8>) -> Result<ItemPointer, String> {
+(B     let buffer = LockedBufferGuard::read_main_locked_handle(
+         handle,
+         P_NEW,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch.rs:214:
+             let mut id = base_identity();
+             mutate(&mut id);
+             let changed = compute_epoch_fingerprint(&id, DISTANN_EPOCH_FINGERPRINT_V1);
+-            assert_ne!(base, changed, "mutator {index} did not change the fingerprint");
+(B+            assert_ne!(
+(B+                base, changed,
+(B+                "mutator {index} did not change the fingerprint"
+(B+            );
+(B             assert!(!fingerprints_match(&base, &changed));
+         }
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch_manifest.rs:57:
+     Ok(result)
+ }
+
+-fn read_metadata(index_oid: pg_sys::Oid, caller: &'static str) -> Result<DistannMetadataPage, String> {
+(B+fn read_metadata(
+(B+    index_oid: pg_sys::Oid,
+(B+    caller: &'static str,
+(B+) -> Result<DistannMetadataPage, String> {
+(B     let guard = IndexRelationGuard::open(
+         index_oid,
+         pg_sys::AccessShareLock as pg_sys::LOCKMODE,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch_manifest.rs:175:
+         name!(in_flight_count, i64),
+     ),
+ > {
+-    let metadata =
+(B-        read_metadata(index_regclass, "ec_distann_epoch_status").unwrap_or_else(|e| pgrx::error!("{e}"));
+(B+    let metadata = read_metadata(index_regclass, "ec_distann_epoch_status")
+(B+        .unwrap_or_else(|e| pgrx::error!("{e}"));
+(B     TableIterator::new(std::iter::once((
+         epoch_state_name(metadata.epoch_state).to_owned(),
+         metadata.active_epoch as i64,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/epoch_manifest.rs:192:
+ fn ec_distann_debug_set_in_flight(index_regclass: pg_sys::Oid, count: i64) {
+     let count = u32::try_from(count)
+         .unwrap_or_else(|_| pgrx::error!("ec_distann_debug_set_in_flight: count out of range"));
+-    with_metadata_mut(index_regclass, "ec_distann_debug_set_in_flight", |metadata| {
+(B-        metadata.in_flight_count = count;
+(B-        Ok(())
+(B-    })
+(B+    with_metadata_mut(
+(B+        index_regclass,
+(B+        "ec_distann_debug_set_in_flight",
+(B+        |metadata| {
+(B+            metadata.in_flight_count = count;
+(B+            Ok(())
+(B+        },
+(B+    )
+(B     .unwrap_or_else(|e| pgrx::error!("{e}"));
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/expand.rs:58:
+                     tid.block_number, tid.offset_number
+                 ));
+             }
+-            DistannNodeTuple::decode_into(raw, self.graph_degree_r, self.code_len, &mut self.pooled_node)
+(B+            DistannNodeTuple::decode_into(
+(B+                raw,
+(B+                self.graph_degree_r,
+(B+                self.code_len,
+(B+                &mut self.pooled_node,
+(B+            )
+(B         })?;
+         match visit {
+             LockedPageTupleVisit::Present(()) => Ok(()),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/handoff_wire.rs:79:
+     pub(crate) fn from_descriptor(
+         descriptor: &super::generation_descriptor::DistannGenerationDescriptor,
+     ) -> Result<Self, String> {
+-        let binding = super::quantizer::DistannCodecBinding::from_artifact(
+(B-            &descriptor.codec_artifact,
+(B-        )?;
+(B+        let binding =
+(B+            super::quantizer::DistannCodecBinding::from_artifact(&descriptor.codec_artifact)?;
+(B         Self::new(
+             binding.code_len(usize::from(descriptor.dimensions))?,
+             usize::from(descriptor.graph_degree),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/head_cache.rs:132:
+         )
+     };
+     let head_seed = metadata.seed ^ DISTANN_HEAD_GRAPH_SEED_WRAP;
+-    let head_entry = crate::am::approximate_medoid(
+(B-        head_vectors.len(),
+(B-        head_vectors.len(),
+(B-        head_seed,
+(B-        head_dist,
+(B-    );
+(B+    let head_entry =
+(B+        crate::am::approximate_medoid(head_vectors.len(), head_vectors.len(), head_seed, head_dist);
+(B     let (head_graph, _stats) = crate::am::build_vamana_graph_with_stats(
+         head_vectors.len(),
+         head_entry,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/identity.rs:43:
+
+ /// vec_id for a heap TID (local mode; single-node posture only).
+ pub(crate) fn vec_id_from_local_heap_tid(heap_tid: ItemPointer) -> u64 {
+-    let packed =
+(B-        (u64::from(heap_tid.block_number) << 16) | u64::from(heap_tid.offset_number);
+(B+    let packed = (u64::from(heap_tid.block_number) << 16) | u64::from(heap_tid.offset_number);
+(B     fmix64(packed ^ DISTANN_VEC_ID_DOMAIN_LOCAL)
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:100:
+     let mut pairwise = vec![vec![0.0_f32; n]; n];
+     for left in 0..n {
+         for right in (left + 1)..n {
+-            let distance =
+(B-                exact_distance(&candidates[left].source_vector, &candidates[right].source_vector);
+(B+            let distance = exact_distance(
+(B+                &candidates[left].source_vector,
+(B+                &candidates[right].source_vector,
+(B+            );
+(B             pairwise[left][right] = distance;
+             pairwise[right][left] = distance;
+         }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:183:
+         return Err("ec_distann backlink planning max_degree must be > 0".to_owned());
+     }
+     // Already linked (idempotent — a re-inserted/duplicate edge is a no-op).
+-    if target.current_neighbors.iter().any(|n| n.vec_id == new_vec_id) {
+(B+    if target
+(B+        .current_neighbors
+(B+        .iter()
+(B+        .any(|n| n.vec_id == new_vec_id)
+(B+    {
+(B         return Ok(target.current_neighbors.iter().map(|n| n.vec_id).collect());
+     }
+     // Free slot: append, preserving existing edges.
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:306:
+     let new_code = binding.encode(new_source_vector);
+
+     // Directory first — the descent and the collision guard both need it.
+-    let directory =
+(B-        read_directory_from_relation(handle, metadata.directory_head, metadata.node_count as usize)?;
+(B+    let directory = read_directory_from_relation(
+(B+        handle,
+(B+        metadata.directory_head,
+(B+        metadata.node_count as usize,
+(B+    )?;
+(B     // 167-003-P2: reject a vec_id collision BEFORE appending. The directory is a
+     // strict-ascending vec_id set (the reader rejects duplicates); a duplicate
+     // insert (e.g. a retried fold) must error, never append a second record for
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:395:
+         })?;
+         let raw = read_raw_tuple_bytes_from_relation(handle, tid, "ec_distann insert forward")?;
+         let node = DistannNodeTuple::decode(&raw, graph_degree_r, code_len)?;
+-        forward.push(DistannInsertNeighbor { vec_id: fid, code: node.search_code });
+(B+        forward.push(DistannInsertNeighbor {
+(B+            vec_id: fid,
+(B+            code: node.search_code,
+(B+        });
+(B         forward_tids.push(tid);
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:527:
+             .map_err(|e| format!("ec_distann graph insert node add failed: {e:?}"))?
+     };
+     wal_txn.finish();
+-    Ok(ItemPointer { block_number, offset_number })
+(B+    Ok(ItemPointer {
+(B+        block_number,
+(B+        offset_number,
+(B+    })
+(B }
+
+ /// Amend a forward neighbor's adjacency to include `new_vec_id`, WAL-logged in
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:556:
+         pg_sys::BUFFER_LOCK_EXCLUSIVE as i32,
+     )
+     .ok_or_else(|| {
+-        format!("ec_distann backlink: could not open block {}", neighbor_tid.block_number)
+(B+        format!(
+(B+            "ec_distann backlink: could not open block {}",
+(B+            neighbor_tid.block_number
+(B+        )
+(B     })?;
+     let r = usize::from(graph_degree_r);
+     let vec_ids_off = distann_node_neighbor_vec_ids_offset(code_len);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:738:
+         let samples = vec![
+             (10_u64, vec![0.99, 0.01, 0.0]), // closest
+             (20, vec![0.0, 1.0, 0.0]),
+-            (30, vec![0.9, 0.1, 0.0]),   // 2nd closest
+(B-            (40, vec![-1.0, 0.0, 0.0]),  // farthest
+(B+            (30, vec![0.9, 0.1, 0.0]),  // 2nd closest
+(B+            (40, vec![-1.0, 0.0, 0.0]), // farthest
+(B         ];
+         let ranked = rank_insert_candidates(&new_vec, &samples, 2).unwrap();
+         assert_eq!(ranked.len(), 2, "limit respected");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:765:
+         let r: u16 = 4;
+         let code_len = 8;
+         let fwd = vec![
+-            DistannInsertNeighbor { vec_id: 111, code: vec![1_u8; code_len] },
+(B-            DistannInsertNeighbor { vec_id: 222, code: vec![2_u8; code_len] },
+(B+            DistannInsertNeighbor {
+(B+                vec_id: 111,
+(B+                code: vec![1_u8; code_len],
+(B+            },
+(B+            DistannInsertNeighbor {
+(B+                vec_id: 222,
+(B+                code: vec![2_u8; code_len],
+(B+            },
+(B         ];
+         let node = build_insert_node_tuple(
+             999,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:773:
+-            ItemPointer { block_number: 3, offset_number: 7 },
+(B+            ItemPointer {
+(B+                block_number: 3,
+(B+                offset_number: 7,
+(B+            },
+(B             vec![9_u8; code_len],
+             &fwd,
+             r,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:778:
+         )
+         .unwrap();
+         assert_eq!(node.vec_id, 999);
+-        assert_eq!(node.neighbor_count, 2, "count = real neighbors, not padding");
+(B+        assert_eq!(
+(B+            node.neighbor_count, 2,
+(B+            "count = real neighbors, not padding"
+(B+        );
+(B         assert_eq!(node.neighbor_vec_ids.len(), r as usize, "fixed R slots");
+         assert_eq!(node.neighbor_vec_ids[0], 111);
+-        assert_eq!(node.neighbor_vec_ids[2], 0, "slots past count are zero-padded");
+(B+        assert_eq!(
+(B+            node.neighbor_vec_ids[2], 0,
+(B+            "slots past count are zero-padded"
+(B+        );
+(B         assert!(!node.tombstoned);
+         // Round-trips through the on-disk encoding at fixed length.
+         let encoded = node.encode(r, code_len).unwrap();
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:788:
+         assert_eq!(encoded.len(), DistannNodeTuple::encoded_len(r, code_len));
+-        assert_eq!(DistannNodeTuple::decode(&encoded, r, code_len).unwrap(), node);
+(B+        assert_eq!(
+(B+            DistannNodeTuple::decode(&encoded, r, code_len).unwrap(),
+(B+            node
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:794:
+         let code_len = 8;
+         // Too many neighbors for R.
+         let many: Vec<_> = (0..5)
+-            .map(|i| DistannInsertNeighbor { vec_id: i, code: vec![0_u8; code_len] })
+(B+            .map(|i| DistannInsertNeighbor {
+(B+                vec_id: i,
+(B+                code: vec![0_u8; code_len],
+(B+            })
+(B             .collect();
+         assert!(
+-            build_insert_node_tuple(1, ItemPointer::INVALID, vec![0; code_len], &many, 4, code_len)
+(B-                .is_err(),
+(B+            build_insert_node_tuple(
+(B+                1,
+(B+                ItemPointer::INVALID,
+(B+                vec![0; code_len],
+(B+                &many,
+(B+                4,
+(B+                code_len
+(B+            )
+(B+            .is_err(),
+(B             "neighbors > R rejected"
+         );
+         // Wrong search_code length.
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:807:
+             "search_code len mismatch rejected"
+         );
+         // Wrong neighbor code length.
+-        let bad = vec![DistannInsertNeighbor { vec_id: 1, code: vec![0_u8; 4] }];
+(B+        let bad = vec![DistannInsertNeighbor {
+(B+            vec_id: 1,
+(B+            code: vec![0_u8; 4],
+(B+        }];
+(B         assert!(
+-            build_insert_node_tuple(1, ItemPointer::INVALID, vec![0; code_len], &bad, 4, code_len)
+(B-                .is_err(),
+(B+            build_insert_node_tuple(
+(B+                1,
+(B+                ItemPointer::INVALID,
+(B+                vec![0; code_len],
+(B+                &bad,
+(B+                4,
+(B+                code_len
+(B+            )
+(B+            .is_err(),
+(B             "neighbor code len mismatch rejected"
+         );
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:827:
+             ],
+         };
+         let kept = plan_insert_backlink(&target, 999, &[0.95, 0.05, 0.0], 1.2, 4).unwrap();
+-        assert_eq!(kept, vec![10, 20, 999], "free slot -> append, edges preserved");
+(B+        assert_eq!(
+(B+            kept,
+(B+            vec![10, 20, 999],
+(B+            "free slot -> append, edges preserved"
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:853:
+         let target = DistannBacklinkTarget {
+             vec_id: 100,
+             source_vector: vec![1.0, 0.0, 0.0],
+-            current_neighbors: vec![candidate(999, &[0.9, 0.1, 0.0]), candidate(10, &[0.8, 0.2, 0.0])],
+(B+            current_neighbors: vec![
+(B+                candidate(999, &[0.9, 0.1, 0.0]),
+(B+                candidate(10, &[0.8, 0.2, 0.0]),
+(B+            ],
+(B         };
+         let kept = plan_insert_backlink(&target, 999, &[0.9, 0.1, 0.0], 1.2, 4).unwrap();
+-        assert_eq!(kept, vec![999, 10], "already-linked -> unchanged (idempotent)");
+(B+        assert_eq!(
+(B+            kept,
+(B+            vec![999, 10],
+(B+            "already-linked -> unchanged (idempotent)"
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/insert.rs:863:
+     fn select_rejects_bad_input() {
+         let source = [1.0_f32, 0.0];
+-        assert!(select_insert_forward_neighbors(&[], &[], 1.2, 3).is_err(), "empty source");
+(B+        assert!(
+(B+            select_insert_forward_neighbors(&[], &[], 1.2, 3).is_err(),
+(B+            "empty source"
+(B+        );
+(B         assert!(
+             select_insert_forward_neighbors(&source, &[], 0.5, 3).is_err(),
+             "alpha < 1.0"
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:11:
+ //! materialization (Tasks 162–179).
+
+ mod ambuild;
+-mod build_gate;
+(B mod build_coordinator;
++mod build_gate;
+(B mod coordinator_abandonment;
+ #[cfg(any(test, feature = "pg_test"))]
++pub(crate) use self::ambuild::read_metadata_from_index;
+(B+#[cfg(any(test, feature = "pg_test"))]
+(B+pub(crate) use self::ambuild::test_physical_capture_dead_callback_does_not_access_datums;
+(B+pub(crate) use self::ambuild::{build_physical_graph_workspace, capture_physical_source_rows};
+(B+#[cfg(any(test, feature = "pg_test"))]
+(B pub(crate) use self::build_coordinator::build_session_lock_count_for_test;
+ #[cfg(any(test, feature = "pg_test"))]
+ pub(crate) use self::custom_scan::{
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:21:
+     exec_state_context_cleanups_for_test, reset_exec_state_context_cleanups_for_test,
+ };
+-#[cfg(any(test, feature = "pg_test"))]
+(B-pub(crate) use self::ambuild::read_metadata_from_index;
+(B-pub(crate) use self::ambuild::{
+(B-    build_physical_graph_workspace, capture_physical_source_rows,
+(B-};
+(B-#[cfg(any(test, feature = "pg_test"))]
+(B-pub(crate) use self::ambuild::{
+(B-    test_physical_capture_dead_callback_does_not_access_datums,
+(B-};
+(B mod canonical_wire;
+-mod cost;
+(B mod coordinator_retirement;
++mod cost;
+(B mod custom_scan;
+ mod dml;
+ mod epoch;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:51:
+ mod head_sample;
+ mod identity;
+ mod insert;
+-mod lifecycle_wire;
+(B mod lifecycle_guard;
+ mod lifecycle_state;
++mod lifecycle_wire;
+(B mod manifest_v2;
+ mod node_registry;
+ mod options;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:80:
+ pub(crate) mod scan;
+ mod shard_build;
+ mod source_spool;
+-mod traversal_replica;
+(B #[cfg(feature = "distann-head-attribution-benchmark")]
+ pub(crate) mod stage_counters;
++mod traversal_replica;
+(B pub mod tuple;
+
+ pub(crate) fn quote_ident(identifier: &str) -> String {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:90:
+ }
+
+ #[cfg(any(test, feature = "pg_test"))]
+-pub(crate) use self::generation_catalog::extension_relation_name as catalog_relation_name;
+(B-#[cfg(any(test, feature = "pg_test"))]
+(B pub(crate) use self::coordinator_retirement::ensure_fingerprint_not_retiring as ensure_fingerprint_not_retiring_for_test;
++#[cfg(any(test, feature = "pg_test"))]
+(B+pub(crate) use self::generation_catalog::extension_relation_name as catalog_relation_name;
+(B pub use self::generation_descriptor::{
+     roster_digest, DistannBuildOptions, DistannBuildSpec, DistannCodecArtifact,
+     DistannGenerationDescriptor, DistannHeadPolicy, DistannOwnerExpectation, DistannRosterEntry,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:107:
+     DISTANN_GENERATION_DESCRIPTOR_PLACEMENT_HASH_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET, DISTANN_GENERATION_DESCRIPTOR_VERSION,
+     DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET, DISTANN_GRAPH_RECORD_VERSION,
+-    DISTANN_HANDOFF_WIRE_VERSION,
+(B-    DISTANN_PHYSICAL_INDEX_FORMAT_VERSION, DISTANN_PLACEMENT_HASH_VERSION,
+(B+    DISTANN_HANDOFF_WIRE_VERSION, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B+    DISTANN_PLACEMENT_HASH_VERSION,
+(B };
++#[cfg(any(test, feature = "pg_test"))]
+(B+pub(crate) use self::handoff_router::{DistannHandoffRouteIdentity, DistannStageAck};
+(B+pub(crate) use self::handoff_wire::restore_owner_stream_hash_state;
+(B pub use self::handoff_wire::{
+     owner_stream_digest, DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape,
+     DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:122:
+     DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET,
+ };
+ #[cfg(any(test, feature = "pg_test"))]
+-pub(crate) use self::handoff_router::{DistannHandoffRouteIdentity, DistannStageAck};
+(B-pub(crate) use self::handoff_wire::restore_owner_stream_hash_state;
+(B-#[cfg(any(test, feature = "pg_test"))]
+(B pub(crate) use self::identity::vec_id_from_source_identity;
+ pub use self::lifecycle_wire::{
+     DistannAbandonBindingAuditV1, DistannAbandonedBinding, DistannAbandonedBindingSetV1,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:131:
+     DistannBuildCandidateV1, DistannCancelPublishAuditV1, DistannPublishedEpochIdentity,
+-    DistannRetireDecisionV1,
+(B-    DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+(B+    DistannRetireDecisionV1, DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+(B     DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET, DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES,
+     DISTANN_ABANDONED_BINDING_SET_VERSION, DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+     DISTANN_ABANDON_BINDING_AUDIT_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:140:
+     DISTANN_ABANDON_BINDING_AUDIT_VERSION, DISTANN_ABANDON_BINDING_AUDIT_VERSION_OFFSET,
+     DISTANN_BUILD_CANDIDATE_BUILD_SPEC_LENGTH_OFFSET, DISTANN_BUILD_CANDIDATE_FIXED_PREFIX_BYTES,
+     DISTANN_BUILD_CANDIDATE_REGISTRATION_DIGEST_OFFSET, DISTANN_BUILD_CANDIDATE_VERSION,
+-    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET,
+(B-    DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B+    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B     DISTANN_CANCEL_PUBLISH_AUDIT_COORDINATOR_UUID_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_EPOCH_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_FINGERPRINT_LENGTH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/mod.rs:148:
+     DISTANN_CANCEL_PUBLISH_AUDIT_FIXED_PREFIX_BYTES, DISTANN_CANCEL_PUBLISH_AUDIT_VERSION,
+-    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET,
+(B+    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET, DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET,
+(B     DISTANN_RETIRE_DECISION_EPOCH_OFFSET, DISTANN_RETIRE_DECISION_FINGERPRINT_LENGTH_OFFSET,
+     DISTANN_RETIRE_DECISION_FIXED_PREFIX_BYTES, DISTANN_RETIRE_DECISION_TARGET_BUILD_ID_OFFSET,
+     DISTANN_RETIRE_DECISION_VERSION, DISTANN_RETIRE_DECISION_VERSION_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:263:
+     }
+
+     pub fn decode(input: &[u8]) -> Result<Self, String> {
+-        if !matches!(input.len(), DISTANN_METADATA_BYTES | DISTANN_CONTROL_METADATA_BYTES) {
+(B+        if !matches!(
+(B+            input.len(),
+(B+            DISTANN_METADATA_BYTES | DISTANN_CONTROL_METADATA_BYTES
+(B+        ) {
+(B             return Err(format!(
+                 "distann metadata length mismatch: got {}, expected {DISTANN_METADATA_BYTES} or {DISTANN_CONTROL_METADATA_BYTES}",
+                 input.len()
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:332:
+             head_sample_head: ItemPointer::decode(&input[44..50])?,
+             delta_buffer_head: ItemPointer::decode(&input[50..56])?,
+             codec_subvector_count: u16::from_le_bytes(
+-                input[56..58].try_into().expect("codec_subvector_count bytes"),
+(B+                input[56..58]
+(B+                    .try_into()
+(B+                    .expect("codec_subvector_count bytes"),
+(B             ),
+             codec_subvector_dim: u16::from_le_bytes(
+                 input[58..60].try_into().expect("codec_subvector_dim bytes"),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:342:
+             content_digest: u64::from_le_bytes(
+                 input[72..80].try_into().expect("content_digest bytes"),
+             ),
+-            delta_count: u32::from_le_bytes(
+(B-                input[80..84].try_into().expect("delta_count bytes"),
+(B-            ),
+(B+            delta_count: u32::from_le_bytes(input[80..84].try_into().expect("delta_count bytes")),
+(B             epoch_state: input[DISTANN_METADATA_EPOCH_STATE_OFFSET],
+-            active_epoch: u64::from_le_bytes(
+(B-                input[85..93].try_into().expect("active_epoch bytes"),
+(B-            ),
+(B+            active_epoch: u64::from_le_bytes(input[85..93].try_into().expect("active_epoch bytes")),
+(B             in_flight_count: u32::from_le_bytes(
+                 input[93..97].try_into().expect("in_flight_count bytes"),
+             ),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:400:
+ #[cfg(test)]
+ mod tests {
+     use super::{
+-        DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES,
+(B-        DISTANN_METADATA_BYTES, DISTANN_METADATA_LOGICAL_INDEX_UUID_OFFSET,
+(B-        DISTANN_NEIGHBOR_CODEC_GROUPED_PQ, DISTANN_NEIGHBOR_CODEC_RABITQ,
+(B-        INDEX_FORMAT_V1_DISTANN, INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B+        DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES, DISTANN_METADATA_BYTES,
+(B+        DISTANN_METADATA_LOGICAL_INDEX_UUID_OFFSET, DISTANN_NEIGHBOR_CODEC_GROUPED_PQ,
+(B+        DISTANN_NEIGHBOR_CODEC_RABITQ, INDEX_FORMAT_V1_DISTANN, INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B     };
+     use crate::storage::page::ItemPointer;
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:465:
+         let mut encoded = sample().encode();
+         encoded[0] = 0xFF;
+         encoded[1] = 0xFF;
+-        let error =
+(B-            DistannMetadataPage::decode(&encoded).expect_err("unknown version must fail");
+(B+        let error = DistannMetadataPage::decode(&encoded).expect_err("unknown version must fail");
+(B         assert!(error.contains("format version"));
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/page.rs:494:
+             u16::from_le_bytes(encoded[0..2].try_into().unwrap()),
+             INDEX_FORMAT_V1_DISTANN
+         );
+-        assert_eq!(encoded, DistannMetadataPage::decode(&encoded).unwrap().encode());
+(B+        assert_eq!(
+(B+            encoded,
+(B+            DistannMetadataPage::decode(&encoded).unwrap().encode()
+(B+        );
+(B     }
+
+     #[test]
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:209:
+             usize::from(metadata.dimensions),
+             DISTANN_TURBOQUANT_BITS,
+         )),
+-        other => Err(format!("ec_distann unsupported neighbor codec kind {other}")),
+(B+        other => Err(format!(
+(B+            "ec_distann unsupported neighbor codec kind {other}"
+(B+        )),
+(B     }
+ }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:249:
+         match metadata.neighbor_codec_kind {
+             DISTANN_NEIGHBOR_CODEC_GROUPED_PQ => {
+                 let flat_codebooks = flat_codebooks.ok_or_else(|| {
+-                    "ec_distann grouped_pq query preparation requires the codebook chain"
+(B-                        .to_owned()
+(B+                    "ec_distann grouped_pq query preparation requires the codebook chain".to_owned()
+(B                 })?;
+                 let group_count = usize::from(metadata.codec_subvector_count);
+                 let group_size = usize::from(metadata.codec_subvector_dim);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:257:
+                 if group_count == 0 || group_size == 0 {
+                     return Err(
+-                        "ec_distann grouped_pq metadata is missing subvector parameters".to_owned()
+(B+                        "ec_distann grouped_pq metadata is missing subvector parameters".to_owned(),
+(B                     );
+                 }
+                 let rotated = crate::am::ec_diskann::scan_query::encode_query_srht(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:326:
+                 })
+             }
+             DistannCodecArtifact::RaBitQ { seed, bits, .. } => {
+-                let quantizer =
+(B-                    RaBitQQuantizer::cached_seeded_srht_bits(dimensions, *seed, *bits)?;
+(B+                let quantizer = RaBitQQuantizer::cached_seeded_srht_bits(dimensions, *seed, *bits)?;
+(B                 Ok(Self::RaBitQ {
+                     prepared: quantizer.prepare_estimator(raw_query),
+                 })
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/quantizer.rs:401:
+                     out_scores,
+                 )?;
+             }
+-            Self::RaBitQ { prepared } => {
+(B-                match prepared.bits1_block_prepared(code_len) {
+(B-                    Some(block_prepared) => {
+(B-                        let mut batch = CandidateBatch::with_capacity(count);
+(B-                        for slot in 0..count {
+(B-                            batch.push(
+(B-                                slot,
+(B-                                CandidatePayload::new(
+(B-                                    &codes[slot * code_len..(slot + 1) * code_len],
+(B-                                    CandidateMeta::RaBitQ,
+(B-                                ),
+(B-                            )?;
+(B-                        }
+(B-                        score_rabitq_bits1_batch_for(
+(B-                            CandidateBatchScoringSurface::Distann,
+(B-                            block_prepared,
+(B-                            &batch,
+(B-                            out_scores,
+(B+            Self::RaBitQ { prepared } => match prepared.bits1_block_prepared(code_len) {
+(B+                Some(block_prepared) => {
+(B+                    let mut batch = CandidateBatch::with_capacity(count);
+(B+                    for slot in 0..count {
+(B+                        batch.push(
+(B+                            slot,
+(B+                            CandidatePayload::new(
+(B+                                &codes[slot * code_len..(slot + 1) * code_len],
+(B+                                CandidateMeta::RaBitQ,
+(B+                            ),
+(B                         )?;
+                     }
+-                    None => {
+(B-                        for slot in 0..count {
+(B-                            out_scores[slot] = prepared.estimate_ip_scalar_only(
+(B-                                &codes[slot * code_len..(slot + 1) * code_len],
+(B-                            );
+(B-                        }
+(B+                    score_rabitq_bits1_batch_for(
+(B+                        CandidateBatchScoringSurface::Distann,
+(B+                        block_prepared,
+(B+                        &batch,
+(B+                        out_scores,
+(B+                    )?;
+(B+                }
+(B+                None => {
+(B+                    for slot in 0..count {
+(B+                        out_scores[slot] = prepared.estimate_ip_scalar_only(
+(B+                            &codes[slot * code_len..(slot + 1) * code_len],
+(B+                        );
+(B                     }
+                 }
+-            }
+(B+            },
+(B             Self::TurboQuant {
+                 quantizer,
+                 prepared,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:81:
+     let mut entries = Vec::with_capacity(expected_entries);
+     let mut cursor = head_tid;
+     while cursor != ItemPointer::INVALID {
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann directory chunk")?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann directory chunk")?;
+(B         let tuple = DistannDirectoryTuple::decode(&raw)?;
+         entries.extend_from_slice(&tuple.entries);
+         cursor = tuple.next_tid;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:115:
+     let mut samples = Vec::new();
+     let mut cursor = head_tid;
+     while cursor != ItemPointer::INVALID {
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann head sample")?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann head sample")?;
+(B         let tuple = DistannHeadSampleTuple::decode(&raw, dimensions)?;
+         cursor = tuple.next_tid;
+         samples.push(tuple);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:169:
+     let mut cursor = head_tid;
+     let mut group_index = 0_usize;
+     while cursor != ItemPointer::INVALID {
+-        let raw =
+(B-            read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann codebook tuple")?;
+(B+        let raw = read_raw_tuple_bytes_from_relation(handle, cursor, "ec_distann codebook tuple")?;
+(B         let tuple = crate::am::VamanaCodebookTuple::decode(&raw, centroid_count)?;
+         if usize::from(tuple.group_index) != group_index {
+             return Err(format!(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/reader.rs:201:
+     graph_degree_r: u16,
+     code_len: usize,
+ ) -> Result<DistannNodeTuple, String> {
+-    let page = chain
+(B-        .get_page(tid.block_number)
+(B-        .ok_or_else(|| format!("ec_distann node block {} not materialized", tid.block_number))?;
+(B+    let page = chain.get_page(tid.block_number).ok_or_else(|| {
+(B+        format!(
+(B+            "ec_distann node block {} not materialized",
+(B+            tid.block_number
+(B+        )
+(B+    })?;
+(B     let raw = page.raw_tuple(tid)?;
+     if raw.first().copied() != Some(DISTANN_NODE_TAG) {
+         return Err(format!(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/remote_endpoint.rs:30:
+ use crate::storage::slot_guard::TupleTableSlotGuard;
+
+ use super::ambuild::read_metadata_from_index_handle;
+-use super::quote_ident;
+(B use super::epoch::{
+     compute_epoch_fingerprint, fingerprint_from_bytes, fingerprints_match,
+     DISTANN_EPOCH_FINGERPRINT_V1,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/remote_endpoint.rs:40:
+ use super::head_cache::cached_index_entry;
+ use super::placement::owning_node;
+ use super::quantizer::{metadata_code_len, DistannPreparedQuery};
++use super::quote_ident;
+(B use super::reader::{
+     directory_lookup, read_directory_from_relation, read_raw_tuple_bytes_from_relation,
+ };
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/remote_endpoint.rs:765:
+     let entry = cached_index_entry(index_oid.into(), handle, &metadata)?;
+     let prepared_query =
+         DistannPreparedQuery::prepare(&metadata, entry.flat_codebooks.as_deref(), query)?;
+-    let owner_open_validate_ns = i64::try_from(open_validate_started.elapsed().as_nanos())
+(B-        .unwrap_or(i64::MAX);
+(B+    let owner_open_validate_ns =
+(B+        i64::try_from(open_validate_started.elapsed().as_nanos()).unwrap_or(i64::MAX);
+(B     let code_len = metadata_code_len(&metadata)?;
+
+     let heap_oid = index_heap_relation_oid_handle(handle);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/roster.rs:29:
+
+ use super::epoch::DistannEpochIdentity;
+ use super::page::DistannMetadataPage;
+-use super::placement::{
+(B-    DistannPlacementDirectory, DistannRosterNode, DISTANN_PLACEMENT_HASH_V1,
+(B-};
+(B+use super::placement::{DistannPlacementDirectory, DistannRosterNode, DISTANN_PLACEMENT_HASH_V1};
+(B
+-static ECDISTANN_ROSTER_GUC: GucSetting<Option<CString>> =
+(B-    GucSetting::<Option<CString>>::new(None);
+(B+static ECDISTANN_ROSTER_GUC: GucSetting<Option<CString>> = GucSetting::<Option<CString>>::new(None);
+(B static ECDISTANN_LOCAL_NODE_ID_GUC: GucSetting<i32> = GucSetting::<i32>::new(0);
+ /// PostgreSQL int GUCs are 32-bit; epoch numbers at research scale fit easily.
+ static ECDISTANN_EPOCH_GUC: GucSetting<i32> = GucSetting::<i32>::new(0);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/roster.rs:123:
+             continue;
+         }
+         let (id_str, conninfo) = entry.split_once('@').ok_or_else(|| {
+-            format!(
+(B-                "ec_distann.roster entry {index} ({entry:?}) must be `node_id@conninfo`"
+(B-            )
+(B+            format!("ec_distann.roster entry {index} ({entry:?}) must be `node_id@conninfo`")
+(B         })?;
+         let node_id: u32 = id_str.trim().parse().map_err(|_| {
+             format!("ec_distann.roster entry {index} has non-numeric node_id {id_str:?}")
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/roster.rs:189:
+             DistannRosterNode {
+                 node_id: entry.node_id,
+                 is_local,
+-                conninfo: if is_local { String::new() } else { entry.conninfo },
+(B+                conninfo: if is_local {
+(B+                    String::new()
+(B+                } else {
+(B+                    entry.conninfo
+(B+                },
+(B             }
+         })
+         .collect();
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/routine.rs:14:
+     ambuild, cost,
+     expand::LocalNodeExpander,
+     head_cache, options,
+-    quote_ident,
+(B     quantizer::{self, DistannPreparedQuery},
++    quote_ident,
+(B     scan::{
+         distann_orchestrated_search, DistannOrchestrationParams, DistannScanCounters,
+         DistannScanHit, DistannSeedCandidate,
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/row_schema.rs:49:
+     pub(crate) columns: Vec<ResolvedRowSchemaColumn>,
+ }
+
+-pub(crate) fn resolve_relation_schema(relation_oid: pg_sys::Oid) -> Result<ResolvedRowSchema, String> {
+(B+pub(crate) fn resolve_relation_schema(
+(B+    relation_oid: pg_sys::Oid,
+(B+) -> Result<ResolvedRowSchema, String> {
+(B     let rows = Spi::connect(|client| {
+         client
+             .select(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:338:
+ #[cfg(test)]
+ mod tests {
+     use super::{
+-        distann_orchestrated_search, run_scan_attempt_with_restart, DistannExpandedNode,
+(B-        DistannExpandError, DistannNodeExpander, DistannOrchestrationParams, DistannSeedCandidate,
+(B+        distann_orchestrated_search, run_scan_attempt_with_restart, DistannExpandError,
+(B+        DistannExpandedNode, DistannNodeExpander, DistannOrchestrationParams, DistannSeedCandidate,
+(B     };
+     use crate::storage::page::ItemPointer;
+     use std::cell::Cell;
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:379:
+         let calls = Cell::new(0);
+         let result = run_scan_attempt_with_restart(|| {
+             calls.set(calls.get() + 1);
+-            Err::<i32, _>(DistannExpandError::EpochMismatch(format!("mismatch {}", calls.get())))
+(B+            Err::<i32, _>(DistannExpandError::EpochMismatch(format!(
+(B+                "mismatch {}",
+(B+                calls.get()
+(B+            )))
+(B         });
+         assert!(matches!(result, Err(DistannExpandError::EpochMismatch(_))));
+         assert_eq!(calls.get(), 2, "capped at two attempts");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:420:
+             vec_ids
+                 .iter()
+                 .map(|vec_id| {
+-                    let (exact, tombstone, neighbors) = self
+(B-                        .nodes
+(B-                        .get(vec_id)
+(B-                        .ok_or_else(|| DistannExpandError::Internal(format!("unknown vec_id {vec_id}")))?;
+(B+                    let (exact, tombstone, neighbors) =
+(B+                        self.nodes.get(vec_id).ok_or_else(|| {
+(B+                            DistannExpandError::Internal(format!("unknown vec_id {vec_id}"))
+(B+                        })?;
+(B                     Ok(DistannExpandedNode {
+                         vec_id: *vec_id,
+                         exact_dist: (!tombstone).then_some(*exact),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:469:
+             vec_id: 1,
+             dist: -0.9,
+         }];
+-        let (hits, counters) =
+(B-            distann_orchestrated_search(&seeds, &mut expander, params(2, 8, 10))
+(B-                .expect("search should succeed");
+(B+        let (hits, counters) = distann_orchestrated_search(&seeds, &mut expander, params(2, 8, 10))
+(B+            .expect("search should succeed");
+(B         assert_eq!(counters.records_expanded, 2);
+         assert!(counters.records_expanded <= 2 * 8);
+         assert!(counters.beam_exhausted, "cycle exhausts the beam");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:493:
+             vec_id: 1,
+             dist: -0.5,
+         }];
+-        let (hits, counters) =
+(B-            distann_orchestrated_search(&seeds, &mut expander, params(4, 8, 10))
+(B-                .expect("search should succeed");
+(B+        let (hits, counters) = distann_orchestrated_search(&seeds, &mut expander, params(4, 8, 10))
+(B+            .expect("search should succeed");
+(B         assert_eq!(hits.len(), 1, "fewer-than-k is a complete result");
+         assert!(counters.beam_exhausted);
+         assert!(!counters.early_exit);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/scan.rs:537:
+             vec_id: 1,
+             dist: -0.9,
+         }];
+-        let (hits, counters) =
+(B-            distann_orchestrated_search(&seeds, &mut expander, params(1, 8, 1))
+(B-                .expect("search should succeed");
+(B+        let (hits, counters) = distann_orchestrated_search(&seeds, &mut expander, params(1, 8, 1))
+(B+            .expect("search should succeed");
+(B         assert!(counters.early_exit);
+         assert_eq!(counters.records_expanded, 1);
+         assert_eq!(hits[0].vec_id, 1);
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/shard_build.rs:348:
+                 "ec_distann duplicate or invalid shard spool index {shard_index}"
+             ));
+         }
+-        self.build_peak_completion_bytes = self
+(B-            .build_peak_completion_bytes
+(B-            .max(encoded.bytes.len());
+(B+        self.build_peak_completion_bytes =
+(B+            self.build_peak_completion_bytes.max(encoded.bytes.len());
+(B         let mut io = ShardSpoolIo::create()?;
+         io.write_all(&encoded.bytes);
+         let shard_bytes = u64::try_from(encoded.bytes.len())
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/shard_build.rs:840:
+                 // A send failure means the backend is already unwinding; no
+                 // PostgreSQL API or panic belongs on this worker thread.
+                 if sender.send((shard_index, result)).is_err() {
+-                    let _ = release_completion_bytes(
+(B-                        &retained_completion_bytes,
+(B-                        encoded_bytes,
+(B-                    );
+(B+                    let _ = release_completion_bytes(&retained_completion_bytes, encoded_bytes);
+(B                     return;
+                 }
+             });
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/shard_build.rs:1669:
+     }
+
+     fn raw_entry(node: u32, neighbors: &[u32]) -> Vec<u8> {
+-        let mut bytes = Vec::with_capacity(
+(B-            DISTANN_SHARD_SPILL_HEADER_BYTES + std::mem::size_of_val(neighbors),
+(B-        );
+(B+        let mut bytes =
+(B+            Vec::with_capacity(DISTANN_SHARD_SPILL_HEADER_BYTES + std::mem::size_of_val(neighbors));
+(B         bytes.extend_from_slice(&node.to_le_bytes());
+         bytes.extend_from_slice(&(neighbors.len() as u32).to_le_bytes());
+         for &neighbor in neighbors {
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:152:
+                 .iter()
+                 .any(|byte| *byte != 0)
+         {
+-            return Err(
+(B-                "distann physical node record has non-zero adjacency padding".to_owned(),
+(B-            );
+(B+            return Err("distann physical node record has non-zero adjacency padding".to_owned());
+(B         }
+         Ok(())
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:233:
+         expected_version: Option<u16>,
+     ) -> Result<Self, String> {
+         let mut out = Self::empty();
+-        Self::decode_into_version(
+(B-            input,
+(B-            graph_degree_r,
+(B-            code_len,
+(B-            expected_version,
+(B-            &mut out,
+(B-        )?;
+(B+        Self::decode_into_version(input, graph_degree_r, code_len, expected_version, &mut out)?;
+(B         Ok(out)
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:269:
+         }
+         if let Some(expected_version) = expected_version {
+             let format_version = u16::from_le_bytes(
+-                input[DISTANN_NODE_FORMAT_VERSION_OFFSET
+(B-                    ..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B+                input[DISTANN_NODE_FORMAT_VERSION_OFFSET..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B                     .try_into()
+                     .expect("graph record version bytes"),
+             );
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:387:
+                 input[0]
+             ));
+         }
+-        let entry_count =
+(B-            usize::from(u16::from_le_bytes(input[2..4].try_into().expect("count bytes")));
+(B+        let entry_count = usize::from(u16::from_le_bytes(
+(B+            input[2..4].try_into().expect("count bytes"),
+(B+        ));
+(B         let expected = Self::encoded_len(entry_count);
+         if input.len() != expected {
+             return Err(format!(
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:536:
+ #[cfg(test)]
+ mod tests {
+     use super::{
+-        DistannDeltaTuple, DistannNodeTuple, DISTANN_FLAG_TOMBSTONE,
+(B-        DISTANN_NODE_FORMAT_VERSION, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+(B-        DISTANN_NODE_HEADER_BYTES,
+(B+        DistannDeltaTuple, DistannNodeTuple, DISTANN_FLAG_TOMBSTONE, DISTANN_NODE_FORMAT_VERSION,
+(B+        DISTANN_NODE_FORMAT_VERSION_OFFSET, DISTANN_NODE_HEADER_BYTES,
+(B     };
+     use crate::storage::page::ItemPointer;
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:577:
+             search_code: (0..CODE_LEN as u8).collect(),
+             neighbor_vec_ids: vec![101, 202, 303, 0],
+             neighbor_codes: (0..R as usize * CODE_LEN)
+-                .map(|offset| if offset < 3 * CODE_LEN { offset as u8 } else { 0 })
+(B+                .map(|offset| {
+(B+                    if offset < 3 * CODE_LEN {
+(B+                        offset as u8
+(B+                    } else {
+(B+                        0
+(B+                    }
+(B+                })
+(B                 .collect(),
+         }
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:603:
+             .expect("physical encode should succeed");
+         assert_eq!(
+             u16::from_le_bytes(
+-                encoded[DISTANN_NODE_FORMAT_VERSION_OFFSET
+(B-                    ..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B+                encoded[DISTANN_NODE_FORMAT_VERSION_OFFSET..DISTANN_NODE_FORMAT_VERSION_OFFSET + 2]
+(B                     .try_into()
+                     .unwrap()
+             ),
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:697:
+                 offset_number: 2,
+             },
+             entries: vec![
+-                (10, ItemPointer { block_number: 1, offset_number: 1 }),
+(B-                (20, ItemPointer { block_number: 1, offset_number: 2 }),
+(B-                (30, ItemPointer { block_number: 2, offset_number: 1 }),
+(B+                (
+(B+                    10,
+(B+                    ItemPointer {
+(B+                        block_number: 1,
+(B+                        offset_number: 1,
+(B+                    },
+(B+                ),
+(B+                (
+(B+                    20,
+(B+                    ItemPointer {
+(B+                        block_number: 1,
+(B+                        offset_number: 2,
+(B+                    },
+(B+                ),
+(B+                (
+(B+                    30,
+(B+                    ItemPointer {
+(B+                        block_number: 2,
+(B+                        offset_number: 1,
+(B+                    },
+(B+                ),
+(B             ],
+         };
+         let encoded = tuple.encode().expect("encode");
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:706:
+-        assert_eq!(
+(B-            encoded.len(),
+(B-            super::DistannDirectoryTuple::encoded_len(3)
+(B-        );
+(B+        assert_eq!(encoded.len(), super::DistannDirectoryTuple::encoded_len(3));
+(B         let decoded = super::DistannDirectoryTuple::decode(&encoded).expect("decode");
+         assert_eq!(decoded, tuple);
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_distann/tuple.rs:719:
+             vector: vec![0.25, -0.5, 1.0, 0.0],
+         };
+         let encoded = tuple.encode();
+-        assert_eq!(
+(B-            encoded.len(),
+(B-            super::DistannHeadSampleTuple::encoded_len(4)
+(B-        );
+(B-        let decoded =
+(B-            super::DistannHeadSampleTuple::decode(&encoded, 4).expect("decode");
+(B+        assert_eq!(encoded.len(), super::DistannHeadSampleTuple::encoded_len(4));
+(B+        let decoded = super::DistannHeadSampleTuple::decode(&encoded, 4).expect("decode");
+(B         assert_eq!(decoded, tuple);
+         assert!(super::DistannHeadSampleTuple::decode(&encoded, 5).is_err());
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/page.rs:3507:
+         "ec_ivf posting entry block sequence",
+         |buffer, block_number| {
+             let decode_started = std::time::Instant::now();
+-            let result =
+(B-                visit_all_ivf_posting_entries_from_buffer(buffer, block_number, payload_len, visitor);
+(B+            let result = visit_all_ivf_posting_entries_from_buffer(
+(B+                buffer,
+(B+                block_number,
+(B+                payload_len,
+(B+                visitor,
+(B+            );
+(B             decode_elapsed += decode_started.elapsed();
+             result
+         },
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:449:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:663:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:883:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:1144:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/quantizer.rs:1249:
+             (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::RaBitQ(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuant(_))
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitLut(_))
+-            | (
+(B-                IvfQuantizerProfile::RaBitQ,
+(B-                IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_),
+(B-            )
+(B+            | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::TurboQuantNoQjl4BitInt8Approx(_))
+(B             | (IvfQuantizerProfile::TurboQuant, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::RaBitQ, IvfPreparedQuery::PqFastScan { .. })
+             | (IvfQuantizerProfile::PqFastScan { .. }, IvfPreparedQuery::TurboQuant(_))
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:1191:
+     capacity: usize,
+ ) -> *mut CandidateDedupPool {
+     if opaque.candidate_dedup.is_null() {
+-        opaque.candidate_dedup = Box::into_raw(Box::new(CandidateDedupPool::with_capacity(
+(B-            capacity,
+(B-        )));
+(B+        opaque.candidate_dedup =
+(B+            Box::into_raw(Box::new(CandidateDedupPool::with_capacity(capacity)));
+(B         return opaque.candidate_dedup;
+     }
+
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:1692:
+     // pure `pre_rerank_candidate_limit` / `ranked_collect_limit` helpers take it
+     // as a parameter so they never touch pgrx GUC FFI off-thread.
+     let effective_rerank_width =
+-        super::options::resolve_scan_rerank_width(index_options.rerank_width).effective_rerank_width;
+(B+        super::options::resolve_scan_rerank_width(index_options.rerank_width)
+(B+            .effective_rerank_width;
+(B     let mut running_top = bound_pruning_active
+         .then(|| pre_rerank_candidate_limit(index_options, effective_rerank_width))
+         .flatten()
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:1944:
+         // the rerank helper validates whether heap_f32 state is present
+         // before use.
+         let rerank_started = should_record_exact_rerank.then(Instant::now);
+-        unsafe { rerank_probe_candidates(scan, index_options, opaque, centroid_scores, candidates) };
+(B+        unsafe {
+(B+            rerank_probe_candidates(scan, index_options, opaque, centroid_scores, candidates)
+(B+        };
+(B         if let Some(rerank_started) = rerank_started {
+             record_stage_elapsed(
+                 opaque,
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:2511:
+         index_options.rerank.v1_effective(),
+         super::options::RerankMode::HeapF32
+     ) {
+-        Some(pre_rerank_candidate_limit(index_options, effective_rerank_width).unwrap_or(candidate_len))
+(B+        Some(
+(B+            pre_rerank_candidate_limit(index_options, effective_rerank_width)
+(B+                .unwrap_or(candidate_len),
+(B+        )
+(B     } else {
+         None
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5408:
+         let mut stream = Vec::new();
+         let mut state = 0x2545F4914F6CDD1D_u64;
+         for i in 0..10_000_u32 {
+-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+(B+            state = state
+(B+                .wrapping_mul(6364136223846793005)
+(B+                .wrapping_add(1442695040888963407);
+(B             let block = (state >> 33) as u32 % 512;
+             let offset = 1 + ((state >> 17) as u16 % 128);
+             let score = ((state >> 40) as f32) / 1e6 - 8.0;
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5446:
+             for (left, right) in from_pool.iter().zip(from_reference.iter()) {
+                 assert_eq!(left.heap_tid, right.heap_tid, "limit {limit:?}");
+                 assert_eq!(left.rerank_tid, right.rerank_tid, "limit {limit:?}");
+-                assert_eq!(left.score.to_bits(), right.score.to_bits(), "limit {limit:?}");
+(B+                assert_eq!(
+(B+                    left.score.to_bits(),
+(B+                    right.score.to_bits(),
+(B+                    "limit {limit:?}"
+(B+                );
+(B             }
+         }
+     }
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5495:
+         let mut stream = Vec::with_capacity(CANDIDATES);
+         let mut state = 0x9E3779B97F4A7C15_u64;
+         for i in 0..CANDIDATES as u64 {
+-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+(B+            state = state
+(B+                .wrapping_mul(6364136223846793005)
+(B+                .wrapping_add(1442695040888963407);
+(B             // Unique tids so the map holds the full candidate count.
+             let block = (i / 291) as u32;
+             let offset = 1 + (i % 291) as u16;
+Diff in /Users/peter/dev/tqvector/src/am/ec_ivf/scan.rs:5530:
+         let map_ref = &map;
+         let map_walk = time_ns(
+             "map walk only (values -> black_box)",
+-            Box::new(move || map_ref.values().map(|c| c.heap_tid.offset_number as usize).sum()),
+(B+            Box::new(move || {
+(B+                map_ref
+(B+                    .values()
+(B+                    .map(|c| c.heap_tid.offset_number as usize)
+(B+                    .sum()
+(B+            }),
+(B         );
+         let ranked_len = |ranked: RankedProbeCandidates| match ranked {
+             RankedProbeCandidates::Sorted(candidates) => candidates.len(),
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:38:
+ };
+ pub use self::ec_diskann::{vamana_decode_overflow_tuple_fixture, VamanaOverflowTupleFixture};
+ pub use self::ec_distann::page::{
+-    DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES,
+(B-    DISTANN_METADATA_ACTIVE_EPOCH_OFFSET, DISTANN_METADATA_ALPHA_OFFSET,
+(B-    DISTANN_METADATA_BUILD_LIST_SIZE_L_OFFSET, DISTANN_METADATA_BYTES,
+(B+    DistannMetadataPage, DISTANN_CONTROL_METADATA_BYTES, DISTANN_METADATA_ACTIVE_EPOCH_OFFSET,
+(B+    DISTANN_METADATA_ALPHA_OFFSET, DISTANN_METADATA_BUILD_LIST_SIZE_L_OFFSET,
+(B+    DISTANN_METADATA_BYTES, DISTANN_METADATA_CLOSURE_EPSILON_OFFSET,
+(B     DISTANN_METADATA_CODEC_SUBVECTOR_COUNT_OFFSET, DISTANN_METADATA_CODEC_SUBVECTOR_DIM_OFFSET,
+-    DISTANN_METADATA_CLOSURE_EPSILON_OFFSET, DISTANN_METADATA_CONTENT_DIGEST_OFFSET,
+(B-    DISTANN_METADATA_DELTA_BUFFER_HEAD_OFFSET, DISTANN_METADATA_DELTA_COUNT_OFFSET,
+(B+    DISTANN_METADATA_CONTENT_DIGEST_OFFSET, DISTANN_METADATA_DELTA_BUFFER_HEAD_OFFSET,
+(B+    DISTANN_METADATA_DELTA_COUNT_OFFSET, DISTANN_METADATA_DIMENSIONS_OFFSET,
+(B     DISTANN_METADATA_DIRECTORY_HEAD_OFFSET, DISTANN_METADATA_ENTRY_POINT_OFFSET,
+-    DISTANN_METADATA_DIMENSIONS_OFFSET,
+(B     DISTANN_METADATA_EPOCH_STATE_OFFSET, DISTANN_METADATA_FLAGS_OFFSET,
+     DISTANN_METADATA_FORMAT_VERSION_OFFSET, DISTANN_METADATA_GRAPH_DEGREE_R_OFFSET,
+     DISTANN_METADATA_GROUPED_CODEBOOK_HEAD_OFFSET, DISTANN_METADATA_HEAD_INDEX_CAP_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:52:
+     DISTANN_METADATA_HEAD_SAMPLE_HEAD_OFFSET, DISTANN_METADATA_IN_FLIGHT_COUNT_OFFSET,
+     DISTANN_METADATA_LOGICAL_INDEX_UUID_OFFSET, DISTANN_METADATA_NEIGHBOR_CODEC_KIND_OFFSET,
+-    DISTANN_METADATA_NODE_COUNT_OFFSET, DISTANN_METADATA_SEED_OFFSET,
+(B-    INDEX_FORMAT_V1_DISTANN, INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B+    DISTANN_METADATA_NODE_COUNT_OFFSET, DISTANN_METADATA_SEED_OFFSET, INDEX_FORMAT_V1_DISTANN,
+(B+    INDEX_FORMAT_V5_DISTANN_CONTROL,
+(B };
++pub(crate) use self::ec_distann::restore_owner_stream_hash_state;
+(B pub use self::ec_distann::tuple::{
+-    distann_node_neighbor_codes_offset, distann_node_neighbor_vec_ids_offset,
+(B-    DistannNodeTuple, DISTANN_NODE_FLAGS_OFFSET, DISTANN_NODE_FORMAT_VERSION,
+(B-    DISTANN_NODE_FORMAT_VERSION_OFFSET, DISTANN_NODE_HEADER_BYTES,
+(B-    DISTANN_NODE_HEAP_TID_OFFSET, DISTANN_NODE_NEIGHBOR_COUNT_OFFSET,
+(B+    distann_node_neighbor_codes_offset, distann_node_neighbor_vec_ids_offset, DistannNodeTuple,
+(B+    DISTANN_NODE_FLAGS_OFFSET, DISTANN_NODE_FORMAT_VERSION, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+(B+    DISTANN_NODE_HEADER_BYTES, DISTANN_NODE_HEAP_TID_OFFSET, DISTANN_NODE_NEIGHBOR_COUNT_OFFSET,
+(B     DISTANN_NODE_SEARCH_CODE_OFFSET, DISTANN_NODE_TAG_OFFSET, DISTANN_NODE_VEC_ID_OFFSET,
+ };
+ pub use self::ec_distann::{
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:65:
+     owner_stream_digest, DistannAbandonBindingAuditV1, DistannAbandonedBinding,
+     DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildOptions, DistannBuildSpec,
+-    DistannCancelPublishAuditV1,
+(B-    DistannCodecArtifact, DistannEpochFingerprint, DistannEpochManifestV2,
+(B-    DistannGenerationDescriptor, DistannHeadPolicy,
+(B-    DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape,
+(B-    DistannManifestBuildOptions, DistannManifestCodecParameters, DistannOwnerExpectation,
+(B-    DistannPublishedEpochIdentity, DistannReadyReceipt, DistannRetireDecisionV1,
+(B-    DistannRosterEntry, DistannRowSchemaAttribute,
+(B-    DistannRowSchemaDescriptor, DistannSourceSnapshot, DISTANN_BUILD_SPEC_VERSION,
+(B-    DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+(B-    DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET, DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES,
+(B-    DISTANN_ABANDONED_BINDING_SET_VERSION, DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+(B+    DistannCancelPublishAuditV1, DistannCodecArtifact, DistannEpochFingerprint,
+(B+    DistannEpochManifestV2, DistannGenerationDescriptor, DistannHandoffBatch, DistannHandoffEntry,
+(B+    DistannHandoffShape, DistannHeadPolicy, DistannManifestBuildOptions,
+(B+    DistannManifestCodecParameters, DistannOwnerExpectation, DistannPublishedEpochIdentity,
+(B+    DistannReadyReceipt, DistannRetireDecisionV1, DistannRosterEntry, DistannRowSchemaAttribute,
+(B+    DistannRowSchemaDescriptor, DistannSourceSnapshot, DistannSuccessorActivationV1,
+(B+    DISTANN_ABANDONED_BINDING_ENTRY_BYTES, DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET,
+(B+    DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES, DISTANN_ABANDONED_BINDING_SET_VERSION,
+(B+    DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+(B     DISTANN_ABANDON_BINDING_AUDIT_FIXED_PREFIX_BYTES,
+     DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_BUILD_ID_OFFSET,
+     DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_EPOCH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:82:
+     DISTANN_ABANDON_BINDING_AUDIT_VERSION, DISTANN_ABANDON_BINDING_AUDIT_VERSION_OFFSET,
+     DISTANN_BUILD_CANDIDATE_BUILD_SPEC_LENGTH_OFFSET, DISTANN_BUILD_CANDIDATE_FIXED_PREFIX_BYTES,
+     DISTANN_BUILD_CANDIDATE_REGISTRATION_DIGEST_OFFSET, DISTANN_BUILD_CANDIDATE_VERSION,
+-    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET,
+(B-    DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B+    DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_BUILD_SPEC_VERSION,
+(B+    DISTANN_BUILD_SPEC_VERSION_OFFSET, DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B     DISTANN_CANCEL_PUBLISH_AUDIT_COORDINATOR_UUID_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_EPOCH_OFFSET,
+     DISTANN_CANCEL_PUBLISH_AUDIT_FINGERPRINT_LENGTH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:90:
+     DISTANN_CANCEL_PUBLISH_AUDIT_FIXED_PREFIX_BYTES, DISTANN_CANCEL_PUBLISH_AUDIT_VERSION,
+-    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET,
+(B-    DISTANN_BUILD_SPEC_VERSION_OFFSET, DISTANN_CODEC_ARTIFACT_VERSION,
+(B+    DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET, DISTANN_CODEC_ARTIFACT_VERSION,
+(B     DISTANN_CODEC_ARTIFACT_VERSION_OFFSET, DISTANN_EPOCH_FINGERPRINT_BYTES,
+     DISTANN_EPOCH_MANIFEST_VERSION, DISTANN_EPOCH_MANIFEST_VERSION_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_COORDINATOR_UUID_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:101:
+     DISTANN_GENERATION_DESCRIPTOR_INDEX_FORMAT_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_PLACEMENT_HASH_OFFSET,
+     DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET, DISTANN_GENERATION_DESCRIPTOR_VERSION,
+-    DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET,
+(B-    DISTANN_GRAPH_RECORD_VERSION, DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES,
+(B-    DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_MAX_BYTES,
+(B-    DISTANN_HANDOFF_VERSION_OFFSET, DISTANN_HANDOFF_WIRE_VERSION,
+(B+    DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET, DISTANN_GRAPH_RECORD_VERSION,
+(B+    DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES,
+(B+    DISTANN_HANDOFF_MAX_BYTES, DISTANN_HANDOFF_VERSION_OFFSET, DISTANN_HANDOFF_WIRE_VERSION,
+(B+    DISTANN_MANIFEST_BUILD_OPTIONS_BYTES, DISTANN_MANIFEST_BUILD_OPTIONS_VERSION,
+(B+    DISTANN_MANIFEST_BUILD_OPTIONS_VERSION_OFFSET, DISTANN_MANIFEST_CODEC_PARAMETERS_BYTES,
+(B+    DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION, DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION_OFFSET,
+(B     DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_OFFSET, DISTANN_OWNER_STREAM_HASH_STATE_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:111:
+     DISTANN_OWNER_STREAM_HASH_STATE_CHAIN_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_IMPLEMENTATION_OFFSET,
+-    DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET,
+(B-    DISTANN_MANIFEST_BUILD_OPTIONS_BYTES, DISTANN_MANIFEST_BUILD_OPTIONS_VERSION,
+(B-    DISTANN_MANIFEST_BUILD_OPTIONS_VERSION_OFFSET, DISTANN_MANIFEST_CODEC_PARAMETERS_BYTES,
+(B-    DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION, DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION_OFFSET,
+(B-    DISTANN_PHYSICAL_INDEX_FORMAT_VERSION, DISTANN_PLACEMENT_HASH_VERSION,
+(B-    DISTANN_READY_RECEIPT_BYTES, DISTANN_READY_RECEIPT_STATE,
+(B+    DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B+    DISTANN_PLACEMENT_HASH_VERSION, DISTANN_READY_RECEIPT_BYTES, DISTANN_READY_RECEIPT_STATE,
+(B     DISTANN_READY_RECEIPT_VERSION, DISTANN_READY_RECEIPT_VERSION_OFFSET,
+     DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET, DISTANN_RETIRE_DECISION_EPOCH_OFFSET,
+     DISTANN_RETIRE_DECISION_FINGERPRINT_LENGTH_OFFSET, DISTANN_RETIRE_DECISION_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:122:
+     DISTANN_RETIRE_DECISION_TARGET_BUILD_ID_OFFSET, DISTANN_RETIRE_DECISION_VERSION,
+-    DISTANN_RETIRE_DECISION_VERSION_OFFSET,
+(B-    DISTANN_ROW_SCHEMA_VERSION, DISTANN_ROW_SCHEMA_VERSION_OFFSET,
+(B-    DISTANN_SOURCE_SNAPSHOT_VERSION, DISTANN_SOURCE_SNAPSHOT_VERSION_OFFSET,
+(B-    DISTANN_SUCCESSOR_ACTIVATION_COORDINATOR_UUID_OFFSET,
+(B+    DISTANN_RETIRE_DECISION_VERSION_OFFSET, DISTANN_ROW_SCHEMA_VERSION,
+(B+    DISTANN_ROW_SCHEMA_VERSION_OFFSET, DISTANN_SOURCE_SNAPSHOT_VERSION,
+(B+    DISTANN_SOURCE_SNAPSHOT_VERSION_OFFSET, DISTANN_SUCCESSOR_ACTIVATION_COORDINATOR_UUID_OFFSET,
+(B     DISTANN_SUCCESSOR_ACTIVATION_FIXED_PREFIX_BYTES,
+     DISTANN_SUCCESSOR_ACTIVATION_PREDECESSOR_PRESENT_OFFSET, DISTANN_SUCCESSOR_ACTIVATION_VERSION,
+     DISTANN_SUCCESSOR_ACTIVATION_VERSION_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/am/mod.rs:130:
+ };
+-pub(crate) use self::ec_distann::restore_owner_stream_hash_state;
+(B #[allow(unused_imports)]
+ pub(crate) use self::ec_hnsw::{
+     graph, index_admin_snapshot, index_cost_snapshot, page, planner_integration_snapshot,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:411:
+         owner_stream_digest, DistannAbandonBindingAuditV1, DistannAbandonedBinding,
+         DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildOptions,
+         DistannBuildSpec, DistannCancelPublishAuditV1, DistannCodecArtifact,
+-        DistannEpochFingerprint, DistannEpochManifestV2,
+(B-        DistannGenerationDescriptor, DistannHeadPolicy,
+(B-        DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape, DistannManifestBuildOptions,
+(B-        DistannManifestCodecParameters, DistannMetadataPage, DistannNodeTuple,
+(B-        DistannOwnerExpectation, DistannPublishedEpochIdentity, DistannReadyReceipt,
+(B-        DistannRetireDecisionV1, DistannRosterEntry,
+(B+        DistannEpochFingerprint, DistannEpochManifestV2, DistannGenerationDescriptor,
+(B+        DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape, DistannHeadPolicy,
+(B+        DistannManifestBuildOptions, DistannManifestCodecParameters, DistannMetadataPage,
+(B+        DistannNodeTuple, DistannOwnerExpectation, DistannPublishedEpochIdentity,
+(B+        DistannReadyReceipt, DistannRetireDecisionV1, DistannRosterEntry,
+(B         DistannRowSchemaAttribute, DistannRowSchemaDescriptor, DistannSourceSnapshot,
+         DistannSuccessorActivationV1, DISTANN_ABANDONED_BINDING_ENTRY_BYTES,
+         DISTANN_ABANDONED_BINDING_SET_COUNT_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:423:
+-        DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES,
+(B-        DISTANN_ABANDONED_BINDING_SET_VERSION,
+(B+        DISTANN_ABANDONED_BINDING_SET_FIXED_PREFIX_BYTES, DISTANN_ABANDONED_BINDING_SET_VERSION,
+(B         DISTANN_ABANDON_BINDING_AUDIT_COORDINATOR_UUID_OFFSET,
+         DISTANN_ABANDON_BINDING_AUDIT_FIXED_PREFIX_BYTES,
+         DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_BUILD_ID_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:428:
+         DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_EPOCH_OFFSET,
+         DISTANN_ABANDON_BINDING_AUDIT_SUCCESSOR_FINGERPRINT_LENGTH_OFFSET,
+         DISTANN_ABANDON_BINDING_AUDIT_VERSION, DISTANN_ABANDON_BINDING_AUDIT_VERSION_OFFSET,
+-        DISTANN_BUILD_SPEC_VERSION, DISTANN_BUILD_SPEC_VERSION_OFFSET,
+(B         DISTANN_BUILD_CANDIDATE_BUILD_SPEC_LENGTH_OFFSET,
+         DISTANN_BUILD_CANDIDATE_FIXED_PREFIX_BYTES,
+         DISTANN_BUILD_CANDIDATE_REGISTRATION_DIGEST_OFFSET, DISTANN_BUILD_CANDIDATE_VERSION,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:435:
+-        DISTANN_BUILD_CANDIDATE_VERSION_OFFSET,
+(B-        DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B+        DISTANN_BUILD_CANDIDATE_VERSION_OFFSET, DISTANN_BUILD_SPEC_VERSION,
+(B+        DISTANN_BUILD_SPEC_VERSION_OFFSET, DISTANN_CANCEL_PUBLISH_AUDIT_BUILD_ID_OFFSET,
+(B         DISTANN_CANCEL_PUBLISH_AUDIT_COORDINATOR_UUID_OFFSET,
+         DISTANN_CANCEL_PUBLISH_AUDIT_EPOCH_OFFSET,
+         DISTANN_CANCEL_PUBLISH_AUDIT_FINGERPRINT_LENGTH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:440:
+         DISTANN_CANCEL_PUBLISH_AUDIT_FIXED_PREFIX_BYTES, DISTANN_CANCEL_PUBLISH_AUDIT_VERSION,
+-        DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET,
+(B-        DISTANN_CODEC_ARTIFACT_VERSION, DISTANN_CODEC_ARTIFACT_VERSION_OFFSET,
+(B-        DISTANN_CONTROL_METADATA_BYTES, DISTANN_EPOCH_FINGERPRINT_BYTES,
+(B-        DISTANN_EPOCH_MANIFEST_VERSION, DISTANN_EPOCH_MANIFEST_VERSION_OFFSET,
+(B+        DISTANN_CANCEL_PUBLISH_AUDIT_VERSION_OFFSET, DISTANN_CODEC_ARTIFACT_VERSION,
+(B+        DISTANN_CODEC_ARTIFACT_VERSION_OFFSET, DISTANN_CONTROL_METADATA_BYTES,
+(B+        DISTANN_EPOCH_FINGERPRINT_BYTES, DISTANN_EPOCH_MANIFEST_VERSION,
+(B+        DISTANN_EPOCH_MANIFEST_VERSION_OFFSET,
+(B         DISTANN_GENERATION_DESCRIPTOR_COORDINATOR_UUID_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_DIMENSIONS_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_FIXED_PREFIX_BYTES,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:450:
+         DISTANN_GENERATION_DESCRIPTOR_HANDOFF_WIRE_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_INDEX_FORMAT_OFFSET,
+         DISTANN_GENERATION_DESCRIPTOR_PLACEMENT_HASH_OFFSET,
+-        DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET,
+(B-        DISTANN_GENERATION_DESCRIPTOR_VERSION, DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET,
+(B-        DISTANN_GRAPH_RECORD_VERSION,
+(B+        DISTANN_GENERATION_DESCRIPTOR_ROSTER_COUNT_OFFSET, DISTANN_GENERATION_DESCRIPTOR_VERSION,
+(B+        DISTANN_GENERATION_DESCRIPTOR_VERSION_OFFSET, DISTANN_GRAPH_RECORD_VERSION,
+(B         DISTANN_HANDOFF_BATCH_FIXED_PREFIX_BYTES, DISTANN_HANDOFF_ENTRY_FIXED_PREFIX_BYTES,
+         DISTANN_HANDOFF_MAX_BYTES, DISTANN_HANDOFF_VERSION_OFFSET, DISTANN_HANDOFF_WIRE_VERSION,
+-        DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_OFFSET, DISTANN_OWNER_STREAM_HASH_STATE_BYTES,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_CHAIN_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_IMPLEMENTATION_OFFSET,
+(B-        DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET,
+(B         DISTANN_MANIFEST_BUILD_OPTIONS_BYTES, DISTANN_MANIFEST_BUILD_OPTIONS_VERSION,
+         DISTANN_MANIFEST_BUILD_OPTIONS_VERSION_OFFSET, DISTANN_MANIFEST_CODEC_PARAMETERS_BYTES,
+         DISTANN_MANIFEST_CODEC_PARAMETERS_VERSION,
+Diff in /Users/peter/dev/tqvector/src/lib.rs:480:
+         DISTANN_NODE_FLAGS_OFFSET, DISTANN_NODE_FORMAT_VERSION, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+         DISTANN_NODE_HEADER_BYTES, DISTANN_NODE_HEAP_TID_OFFSET,
+         DISTANN_NODE_NEIGHBOR_COUNT_OFFSET, DISTANN_NODE_SEARCH_CODE_OFFSET,
+-        DISTANN_NODE_TAG_OFFSET, DISTANN_NODE_VEC_ID_OFFSET, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B+        DISTANN_NODE_TAG_OFFSET, DISTANN_NODE_VEC_ID_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_OFFSET, DISTANN_OWNER_STREAM_HASH_STATE_BYTES,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_CHAIN_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_IMPLEMENTATION_OFFSET,
+(B+        DISTANN_OWNER_STREAM_HASH_STATE_VERSION_OFFSET, DISTANN_PHYSICAL_INDEX_FORMAT_VERSION,
+(B         DISTANN_PLACEMENT_HASH_VERSION, DISTANN_READY_RECEIPT_BYTES, DISTANN_READY_RECEIPT_STATE,
+         DISTANN_READY_RECEIPT_VERSION, DISTANN_READY_RECEIPT_VERSION_OFFSET,
+         DISTANN_RETIRE_DECISION_COORDINATOR_UUID_OFFSET, DISTANN_RETIRE_DECISION_EPOCH_OFFSET,
+Diff in /Users/peter/dev/tqvector/src/quant/int8_approx32/mod.rs:97:
+     use crate::quant::prod::ProdQuantizer;
+
+     fn assert_host_simd_isa(actual: crate::quant::isa::Isa) {
+-        let expected = crate::quant::isa::select_highest_isa(
+(B-            crate::quant::isa::HostIsaFeatures::detect(),
+(B-        );
+(B+        let expected =
+(B+            crate::quant::isa::select_highest_isa(crate::quant::isa::HostIsaFeatures::detect());
+(B         assert_eq!(
+             actual, expected,
+             "int8 differential test did not execute the host's preferred SIMD ISA"
+Diff in /Users/peter/dev/tqvector/src/quant/int8_approx32/mod.rs:136:
+
+         let block: &[&[u8]; BLOCK_WIDTH] = code_refs[..BLOCK_WIDTH].try_into().unwrap();
+         let mut block_scores = vec![0.0; BLOCK_WIDTH];
+-        let block_isa =
+(B-            score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+(B+        let block_isa = score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+(B         assert_host_simd_isa(block_isa);
+         for (score, code) in block_scores.iter().zip(code_refs[..BLOCK_WIDTH].iter()) {
+             let reference = score_int8_approx_scalar(&prepared, dimensions, code);
+Diff in /Users/peter/dev/tqvector/src/storage/page.rs:341:
+         assert_eq!(second.block_number, base, "same page while it fits");
+         assert_eq!(third.block_number, base + 1, "next page is base+1");
+         // Lookups resolve against the base.
+-        assert_eq!(chain.get_page(first.block_number).unwrap().raw_tuple(first).unwrap(), &[1; 32]);
+(B-        assert_eq!(chain.get_page(third.block_number).unwrap().raw_tuple(third).unwrap(), &[3; 32]);
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(first.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(first)
+(B+                .unwrap(),
+(B+            &[1; 32]
+(B+        );
+(B+        assert_eq!(
+(B+            chain
+(B+                .get_page(third.block_number)
+(B+                .unwrap()
+(B+                .raw_tuple(third)
+(B+                .unwrap(),
+(B+            &[3; 32]
+(B+        );
+(B         // Below-base blocks are not in this chain.
+         assert!(chain.get_page(base - 1).is_none());
+         // pages() carry the base-relative block numbers for write_data_pages.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Diff in /Users/peter/dev/tqvector/tests/on_disk_fixtures.rs:9:
+     spire_decode_partition_object_v2_chain_segment_fixture,
+     spire_decode_routing_partition_object_fixture, spire_decode_top_graph_partition_object_fixture,
+     vamana_decode_overflow_tuple_fixture, DistannAbandonBindingAuditV1,
+-    DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildSpec, DistannCodecArtifact,
+(B-    DistannCancelPublishAuditV1, DistannEpochFingerprint, DistannEpochManifestV2,
+(B-    DistannGenerationDescriptor,
+(B-    DistannHandoffBatch, DistannHandoffEntry, DistannHandoffShape, DistannManifestBuildOptions,
+(B-    DistannManifestCodecParameters, DistannMetadataPage, DistannNodeTuple, DistannReadyReceipt,
+(B-    DistannRetireDecisionV1, DistannRowSchemaDescriptor, DistannSourceSnapshot,
+(B-    DistannSuccessorActivationV1, ItemPointer, IvfBlockRef, IvfCentroidTuple,
+(B-    IvfListDirectoryTuple, IvfMetadataPage, IvfPostingTuple, IvfPqCodebookTuple, IvfRerankMode,
+(B-    IvfRerankScoreMode, IvfStorageFormat, MetadataPage, SpireConsistencyMode, SpireEpochManifest,
+(B-    SpireEpochState, SpireLocalStoreConfig, SpireLocalStoreState, SpireManifestEntry,
+(B-    SpireObjectManifest, SpirePlacementDirectory, SpirePlacementEntry, SpirePlacementState,
+(B-    TqElementTuple, TqGroupedCodebookTuple, TqGroupedHotTuple, TqNeighborTuple, TqRerankTuple,
+(B-    TqTurboHotTuple, VamanaCodebookTuple, VamanaMetadataPage, VamanaNodeTuple,
+(B-    DISTANN_CONTROL_METADATA_BYTES, DISTANN_EPOCH_FINGERPRINT_BYTES, DISTANN_METADATA_BYTES,
+(B+    DistannAbandonedBindingSetV1, DistannBuildCandidateV1, DistannBuildSpec,
+(B+    DistannCancelPublishAuditV1, DistannCodecArtifact, DistannEpochFingerprint,
+(B+    DistannEpochManifestV2, DistannGenerationDescriptor, DistannHandoffBatch, DistannHandoffEntry,
+(B+    DistannHandoffShape, DistannManifestBuildOptions, DistannManifestCodecParameters,
+(B+    DistannMetadataPage, DistannNodeTuple, DistannReadyReceipt, DistannRetireDecisionV1,
+(B+    DistannRowSchemaDescriptor, DistannSourceSnapshot, DistannSuccessorActivationV1, ItemPointer,
+(B+    IvfBlockRef, IvfCentroidTuple, IvfListDirectoryTuple, IvfMetadataPage, IvfPostingTuple,
+(B+    IvfPqCodebookTuple, IvfRerankMode, IvfRerankScoreMode, IvfStorageFormat, MetadataPage,
+(B+    SpireConsistencyMode, SpireEpochManifest, SpireEpochState, SpireLocalStoreConfig,
+(B+    SpireLocalStoreState, SpireManifestEntry, SpireObjectManifest, SpirePlacementDirectory,
+(B+    SpirePlacementEntry, SpirePlacementState, TqElementTuple, TqGroupedCodebookTuple,
+(B+    TqGroupedHotTuple, TqNeighborTuple, TqRerankTuple, TqTurboHotTuple, VamanaCodebookTuple,
+(B+    VamanaMetadataPage, VamanaNodeTuple, DISTANN_CONTROL_METADATA_BYTES,
+(B+    DISTANN_EPOCH_FINGERPRINT_BYTES, DISTANN_METADATA_BYTES,
+(B     DISTANN_METADATA_FORMAT_VERSION_OFFSET, DISTANN_NODE_FORMAT_VERSION_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BLOCK_COUNT_OFFSET,
+     DISTANN_OWNER_STREAM_HASH_STATE_BUFFER_LENGTH_OFFSET,
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
+Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
+Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.

--- a/reviews/task-36/004-current-head-review-flags/artifacts/empty-filter-negative-control.log
+++ b/reviews/task-36/004-current-head-review-flags/artifacts/empty-filter-negative-control.log
@@ -1,0 +1,30 @@
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2521 filtered out; finished in 0.00s
+
+counted cargo test: expected 1 passed tests, observed 0

--- a/reviews/task-36/004-current-head-review-flags/artifacts/make-simd-diff.log
+++ b/reviews/task-36/004-current-head-review-flags/artifacts/make-simd-diff.log
@@ -1,0 +1,466 @@
+task36 simd-diff: public bench hooks (Prod/FWHT/HNSW/DiskANN)
+bash scripts/run-counted-cargo-test.sh 10 --features bench --test simd_diff -- --test-threads=1 --nocapture
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 24s
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-3eb2e7ac5b649314)
+
+running 10 tests
+test am_source_inner_product_simd_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_code_to_code_score_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_fwht_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_score_ip_from_parts_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test forced_neon_fwht_matches_scalar_reference_when_available ... ok
+test forced_neon_score_paths_match_scalar_reference_when_available ... ok
+test host_backend_inventory_is_visible ... task36_host arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false unavailable=x86_avx2_fma,x86_avx512
+ok
+test packed_mse_indices_roundtrip_across_widths ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test production_1536_4bit_score_path_matches_scalar_reference ... ok
+test three_bit_unpack_fixture_stays_bit_exact ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 32.86s
+
+counted cargo test: observed expected 10 passed tests
+task36 simd-diff: RaBitQ arithmetic SIMD inventory
+bash scripts/run-counted-cargo-test.sh 2 --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 35.76s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 2 tests
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... task36_rabitq kernel=scalar_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=1536 status=exercised
+ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out; finished in 0.00s
+
+counted cargo test: observed expected 2 passed tests
+task36 simd-diff: rabitq32 bits=1/2/4 block and partial kernels
+bash scripts/run-counted-cargo-test.sh 7 --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.34s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 7 tests
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... task36_rabitq32 bits=2 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=2 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 2514 filtered out; finished in 0.04s
+
+counted cargo test: observed expected 7 passed tests
+task36 simd-diff: qjl32 block/octet/remainder kernels
+bash scripts/run-counted-cargo-test.sh 10 --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 10 tests
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_batch_matches_pre_slice_scorer_by_execution_path ... task36_qjl32 observed_block_isa=neon scalar_tail=bit-exact widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2511 filtered out; finished in 0.24s
+
+counted cargo test: observed expected 10 passed tests
+task36 simd-diff: lut32 block/partial/tiled kernels
+bash scripts/run-counted-cargo-test.sh 9 --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 9 tests
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 2512 filtered out; finished in 0.03s
+
+counted cargo test: observed expected 9 passed tests
+task36 simd-diff: grouped-PQ block/partial kernels
+bash scripts/run-counted-cargo-test.sh 8 --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 8 tests
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2513 filtered out; finished in 0.00s
+
+counted cargo test: observed expected 8 passed tests
+task36 simd-diff: int8/SDOT block/partial kernels
+bash scripts/run-counted-cargo-test.sh 5 --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 5 tests
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... ok
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... ok
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... task36_int8_approx32 neon=true dotprod=true widths=1,7,8,9,16,17,31,32,33
+ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2516 filtered out; finished in 0.05s
+
+counted cargo test: observed expected 5 passed tests
+task36 simd-diff: tiled LUT lane and query-shape guards
+bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::prod::tests::tiled_lut_query_prep_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 3 tests
+test quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch' (34433530) panicked at src/quant/prod.rs:1853:5:
+assertion `left == right` failed: prepared query LUT codebook length must match the centroid count
+  left: 8
+ right: 16
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane' (34433531) panicked at src/quant/prod.rs:418:9:
+explicit LUT query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch' (34433532) panicked at src/quant/prod.rs:411:9:
+assertion `left == right` failed: query length mismatch: got 1535, expected 1536
+  left: 1535
+ right: 1536
+ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2518 filtered out; finished in 0.07s
+
+counted cargo test: observed expected 3 passed tests
+task36 simd-diff: real hamming32 SIMD kernels
+bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 3 tests
+test quant::hamming32::tests::block32_is_integer_exact_with_scalar_reference ... ok
+test quant::hamming32::tests::partial_is_integer_exact_with_scalar_reference ... task36_hamming32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::hamming32::tests::scalar_reference_is_xor_popcount ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2518 filtered out; finished in 0.00s
+
+counted cargo test: observed expected 3 passed tests
+task36 simd-diff: DistANN codec composition, stride, and source IP
+bash scripts/run-counted-cargo-test.sh 2 --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 2 tests
+test am::ec_distann::insert::tests::simd_diff_exact_distance_is_shared_diskann_inner_product_negation ... task36_distann source_inner_product_backend=neon
+ok
+test am::ec_distann::quantizer::tests::simd_diff_distann_codec_batches_match_direct_scalar_scores_across_widths ... task36_distann format=grouped_pq dimensions=64 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=rabitq dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=turboquant dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out; finished in 0.06s
+
+counted cargo test: observed expected 2 passed tests

--- a/reviews/task-36/004-current-head-review-flags/artifacts/manifest.md
+++ b/reviews/task-36/004-current-head-review-flags/artifacts/manifest.md
@@ -92,3 +92,36 @@ review.
 5. **Manual CI ran less than the local lane:** its SIMD matrix now runs
    `make simd-diff`. Triggers remain manual-only and no automatic CI claim is
    made.
+
+## Reviewer verification artifacts (2026-07-25, seq 02)
+
+Added by `feedback/2026-07-25-02-reviewer.md`. Verified at branch head
+`8923245ee` (packet head `a915b062b` plus the packet-004 request commit) in a
+clean worktree on Apple M5 (aarch64, NEON + dotprod, no SVE).
+
+### `2026-07-25-reviewer-make-simd-diff-repro.log`
+
+- Command: `make simd-diff`
+- Status: PASS (exit 0), independently reproducing `make-simd-diff.log`.
+- Key result: all ten counted stages report
+  `counted cargo test: observed expected N passed tests` with N =
+  10 / 2 / 7 / 10 / 9 / 8 / 5 / 3 / 3 / 2.
+
+### `2026-07-25-reviewer-counted-wrapper-controls.log`
+
+- Commands: three direct invocations of `scripts/run-counted-cargo-test.sh`.
+- Status: all three correctly fail.
+- Key result:
+  - wrong expected count (99 vs 3) → `exit=1`
+  - filter matching nothing → `exit=1, observed 0` (the packet-002 fail-open
+    hole)
+  - cargo itself failing → `exit=1`, cargo's own status propagated rather than
+    swallowed by the summary parsing.
+
+### `2026-07-25-reviewer-isa-cap-control.log`
+
+- Command: `ECAZ_ISA_CAP=scalar cargo test --lib --features bench quant::int8_approx32:: -- --test-threads=1`
+- Status: FAIL, as designed.
+- Key result: `int8 differential test did not execute the host's preferred SIMD
+  ISA` on every int8 differential test, confirming the pinning compares against
+  the uncapped host preference and cannot pass vacuously under a cap.

--- a/reviews/task-36/004-current-head-review-flags/artifacts/manifest.md
+++ b/reviews/task-36/004-current-head-review-flags/artifacts/manifest.md
@@ -1,0 +1,94 @@
+# Artifact manifest
+
+- Head SHA: `a915b062bac167532f961ee77dd184905db58d90`
+- Task bucket: `reviews/task-36/`
+- Packet: `reviews/task-36/004-current-head-review-flags/`
+- Date: 2026-07-25
+- Host: Apple arm64, NEON + dot-product/SDOT detected
+- Review source:
+  `reviews/task-36/002-current-quant-distann-simd-differential/feedback/2026-07-25-01-reviewer.md`
+- Hardware boundary: AVX2/AVX-512 and SVE/SVE2 changes are statically reviewed
+  only in this packet; their hardware runs remain separate later evidence.
+- Benchmark applicability: none. These changes affect test-lane enforcement,
+  assertions, documentation, and a manual workflow command; production
+  quantizer/index/scan/rerank/posting/storage behavior is unchanged.
+
+## Commits under review
+
+- `911e543ed` — run every filtered test stage through a counted wrapper that
+  rejects missing summaries and unexpected pass counts.
+- `e37df9309` + `a915b062b` — require every x86 public forced hook to return an
+  AVX2/FMA result rather than silently skip, plus its formatting-only follow-up.
+- `052a55553` — restrict QJL tolerance to observed SIMD block candidates,
+  retain bit equality for scalar tails, and print the block ISA returned by the
+  scorer.
+- `90999afa3` — make the manual CI SIMD matrix invoke the authoritative
+  `make simd-diff` lane and document its trigger/hardware boundary.
+
+The earlier `07aa36712` and `6df8d4a30` commits, documented in packet 003,
+address the tiled-LUT regression and int8 ISA pin called out again by this
+review.
+
+## Artifacts
+
+### `make-simd-diff.log`
+
+- Command: `make simd-diff`
+- Status: PASS
+- Every stage ends with
+  `counted cargo test: observed expected N passed tests`.
+- Counts: public 10; RaBitQ arithmetic 2; `rabitq32` 7; `qjl32` 10;
+  `lut32` 9; grouped PQ 8; int8/SDOT 5; tiled-LUT guards 3;
+  `hamming32` 3; DistANN 2.
+- QJL reports
+  `observed_block_isa=neon scalar_tail=bit-exact`.
+
+### `empty-filter-negative-control.log`
+
+- Command:
+  `bash scripts/run-counted-cargo-test.sh 1 --lib --features bench
+  quant::nonexistent_task36_filter -- --test-threads=1`
+- Status: EXPECTED FAILURE
+- Cargo itself reports 0 passed and exit 0; the wrapper rejects it with
+  `expected 1 passed tests, observed 0`.
+
+### `quant-lib-tests.log`
+
+- Command:
+  `cargo test --lib --features bench quant:: -- --test-threads=1 --nocapture`
+- Status: PASS
+- Result: 188 passed, 0 failed, 3 ignored.
+
+### `cargo-fmt-check.log`
+
+- Command: `cargo fmt --all -- --check`
+- Status: FAIL on the verified inherited repository-wide rustfmt drift.
+- No diff is reported for the changed Rust files
+  `tests/simd_diff.rs` or `src/quant/qjl32/mod.rs`.
+- `git diff --check` passes.
+
+### Workflow syntax
+
+- Command:
+  `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/ci.yml");
+  puts "ci.yml syntax ok"'`
+- Status: PASS (`ci.yml syntax ok`)
+
+## Flag disposition
+
+1. **Lossy name filters / missing prod stage:** the prod guard stage was added
+   in `07aa36712`; all ten stages now have explicit expected counts. The empty-
+   filter negative control proves fail-closed behavior.
+2. **x86 forced hooks could skip:** all four x86 areas now use `expect`/`assert`
+   for HNSW, DiskANN, Prod direct/code-to-code, and FWHT. Intel execution is
+   still owed and is not inferred from Apple compilation.
+3. **int8 lacked an ISA assertion:** fixed by `6df8d4a30`, with scalar-cap
+   negative evidence in packet 003.
+4. **QJL tolerance was overly broad/underexplained:** scalar-only widths and
+   the tail after a block are bit-exact. Only candidates actually scored by a
+   non-scalar 32-wide block receive 4 ULP/relative `1e-6`, because vector
+   reduction changes accumulation order. The test prints the returned block
+   ISA, not host capability.
+5. **Manual CI ran less than the local lane:** its SIMD matrix now runs
+   `make simd-diff`. Triggers remain manual-only and no automatic CI claim is
+   made.

--- a/reviews/task-36/004-current-head-review-flags/artifacts/quant-lib-tests.log
+++ b/reviews/task-36/004-current-head-review-flags/artifacts/quant-lib-tests.log
@@ -1,0 +1,310 @@
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 191 tests
+test quant::codebook::tests::beta_pdf_integrates_to_one ... ok
+test quant::codebook::tests::beta_pdf_out_of_range ... ok
+test quant::codebook::tests::lloyd_max_b1_centroids_symmetric ... ok
+test quant::codebook::tests::log_gamma_known_values ... ok
+test quant::grouped_pq::tests::build_grouped_pq_lut_f32_uses_flat_codebooks_by_group ... ok
+test quant::grouped_pq::tests::encode_grouped_pq_packs_nibbles_from_shared_codebooks ... ok
+test quant::grouped_pq::tests::grouped_pq_nibble_reads_even_and_odd_groups ... ok
+test quant::grouped_pq::tests::grouped_pq_score_f32_sums_lut_rows_by_nibble ... ok
+test quant::grouped_pq::tests::nearest_centroid_l2_prefers_lowest_distance ... ok
+test quant::grouped_pq::tests::pack_grouped_pq_nibbles_packs_even_count ... ok
+test quant::grouped_pq::tests::pack_grouped_pq_nibbles_packs_odd_count ... ok
+test quant::grouped_pq::tests::pq_fastscan_quantizer_trait_score_matches_direct_helpers ... ok
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::hadamard::tests::fwht_preserves_norm_after_normalization ... ok
+test quant::hadamard::tests::fwht_runtime_path_matches_scalar_at_large_sizes ... ok
+test quant::hadamard::tests::fwht_runtime_path_matches_scalar_on_random_inputs ... ok
+test quant::hadamard::tests::miri_fwht_small ... ok
+test quant::hadamard::tests::miri_orthonormal_fwht_small ... ok
+test quant::hadamard::tests::orthonormal_fwht_runtime_path_matches_scalar_on_random_inputs ... ok
+test quant::hadamard::tests::tiled_fwht_matches_chunkwise_full_fwht ... ok
+test quant::hadamard::tests::tiled_orthonormal_fwht_preserves_norm_per_tile ... ok
+test quant::hamming32::tests::block32_is_integer_exact_with_scalar_reference ... ok
+test quant::hamming32::tests::partial_is_integer_exact_with_scalar_reference ... task36_hamming32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::hamming32::tests::scalar_reference_is_xor_popcount ... ok
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... ok
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... ok
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... task36_int8_approx32 neon=true dotprod=true widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::isa::tests::cap_encoding_roundtrips ... ok
+test quant::isa::tests::capped_selection_limits_but_never_fakes ... ok
+test quant::isa::tests::parse_isa_cap_accepts_known_values ... ok
+test quant::isa::tests::parse_isa_cap_rejects_unknown_values - should panic ...
+thread 'quant::isa::tests::parse_isa_cap_rejects_unknown_values' (34433983) panicked at src/quant/isa.rs:165:18:
+unsupported ECAZ_ISA_CAP value: fast
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+ok
+test quant::isa::tests::select_highest_isa_falls_back_to_neon_or_scalar ... ok
+test quant::isa::tests::select_highest_isa_prefers_neon_on_graviton4 ... ok
+test quant::isa::tests::select_highest_isa_prefers_x86_avx2_on_x86_features ... ok
+test quant::isa::tests::select_highest_isa_uses_sve_tiers_only_without_neon ... ok
+test quant::lut32::neon::tests::transpose_8x16_yields_byte_columns ... ok
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+test quant::lut32::tests::task124_profile_lut32_block32_and_query_prep ... ignored, Task 124 scorer microprofile; run explicitly with ECAZ_TQ_PROFILE_LOG
+test quant::lut32::tests::task132_profile_lut32_batch_tiled_widths ... ignored, Task 132 batch-tiled width microprofile; run explicitly with ECAZ_TQ_PROFILE_LOG
+test quant::mse::tests::branchless_matches_branching_over_random_inputs ... ok
+test quant::mse::tests::nearest_centroid_index_prefers_lower_index_on_tie ... ok
+test quant::mse::tests::quantize_to_indices_dispatches_unrolled_for_16_centroids ... ok
+test quant::mse::tests::unrolled_16_matches_generic_branchless ... ok
+test quant::prod::tests::binary_sign_no_qjl_4bit_keeps_identical_vector_ranked_first ... ok
+test quant::prod::tests::binary_sign_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::binary_sign_query_prep_rejects_qjl_active_lane' (34434003) panicked at src/quant/prod.rs:482:9:
+binary sign query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::cached_quantizer_reuses_instances ... ok
+test quant::prod::tests::cached_with_presence_reports_whether_entry_already_existed ... ok
+test quant::prod::tests::code_to_code_score_is_symmetric_and_ignores_qjl ... ok
+test quant::prod::tests::decode_eight_3bit_aligned_matches_packer ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_at_production_dims ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_on_random_inputs ... ok
+test quant::prod::tests::dispatched_score_matches_scalar_with_tail_dims ... ok
+test quant::prod::tests::encode_decode_has_reasonable_fidelity ... ok
+test quant::prod::tests::encode_is_deterministic ... ok
+test quant::prod::tests::encode_payload_length_matches_spec ... ok
+test quant::prod::tests::explicit_lut_no_qjl_4bit_tracks_direct_scoring_with_int16_lut ... ok
+test quant::prod::tests::explicit_lut_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::explicit_lut_query_prep_rejects_qjl_active_lane' (34434071) panicked at src/quant/prod.rs:391:9:
+explicit LUT query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::int8_approx_no_qjl_4bit_keeps_identical_vector_ranked_first ... ok
+test quant::prod::tests::int8_approx_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::int8_approx_query_prep_rejects_qjl_active_lane' (34434079) panicked at src/quant/prod.rs:366:9:
+int8 approximate query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::miri_encode_decode_roundtrip ... ok
+test quant::prod::tests::miri_pack_unpack_mse ... ok
+test quant::prod::tests::miri_pack_unpack_qjl ... ok
+test quant::prod::tests::miri_quantizer_cache_concurrent_init_under_contention ... ok
+test quant::prod::tests::miri_score_ip_codes_lite ... ok
+test quant::prod::tests::miri_score_ip_encoded ... ok
+test quant::prod::tests::mse_pack_unpack_roundtrip_all_widths ... ok
+test quant::prod::tests::pack_mse_indices_fast_paths_match_generic ... ok
+test quant::prod::tests::prepared_query_score_matches_explicit_formula ... ok
+test quant::prod::tests::qjl_neon_production_path_matches_scalar_reference_tolerance ... ok
+test quant::prod::tests::qjl_pack_unpack_roundtrip ... ok
+test quant::prod::tests::qjl_pre_task104_neon_multi_accum_tolerance_diagnostic ... qjl_pre_task104_neon_multi_accum_tolerance_diagnostic dim=1024 bits=4 candidates=1000 max_ulp=13600 max_rel=9.433868108e-4 violations=298 worst_seed=924
+ok
+test quant::prod::tests::qjl_sign_lanes_exhaustive ... ok
+test quant::prod::tests::quantizer_1536_4bit_disables_unused_qjl_and_lut_state ... ok
+test quant::prod::tests::quantizer_1536_4bit_reallocates_qjl_budget_to_mse ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_binary_sign_query_prep ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_explicit_lut_query_prep ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_int8_approx_query_prep ... ok
+test quant::prod::tests::quantizer_1536_4bit_supports_tiled_lut_query_prep ... ok
+test quant::prod::tests::quantizer_1536_uses_tiled_working_dimension ... ok
+test quant::prod::tests::quantizer_32_4bit_keeps_qjl_and_lut_state_when_active ... ok
+test quant::prod::tests::quantizer_no_qjl_lut_min_bound_keeps_or_prunes_exact_score ... ok
+test quant::prod::tests::quantizer_trait_score_matches_inherent_score_ip_encoded ... ok
+test quant::prod::tests::raw_code_score_matches_encoded_lite_path ... ok
+test quant::prod::tests::score_from_parts_honors_supplied_gamma ... ok
+test quant::prod::tests::score_from_parts_matches_encoded_payload_path ... ok
+test quant::prod::tests::task124_profile_no_qjl_lut_query_prep ... ignored, Task 124 query-prep microprofile; run explicitly with ECAZ_TQ_QUERY_PREP_PROFILE_LOG
+test quant::prod::tests::tiled_lut_no_qjl_4bit_matches_direct_scoring ... ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch' (34434153) panicked at src/quant/prod.rs:1853:5:
+assertion `left == right` failed: prepared query LUT codebook length must match the centroid count
+  left: 8
+ right: 16
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane' (34434154) panicked at src/quant/prod.rs:418:9:
+explicit LUT query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch' (34434155) panicked at src/quant/prod.rs:411:9:
+assertion `left == right` failed: query length mismatch: got 1535, expected 1536
+  left: 1535
+ right: 1536
+ok
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_batch_matches_pre_slice_scorer_by_execution_path ... task36_qjl32 observed_block_isa=neon scalar_tail=bit-exact widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... task36_rabitq32 bits=2 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=2 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+test quant::rabitq::tests::batch_max_prevalidated_matches_scalar_max ... ok
+test quant::rabitq::tests::bit_level_packers_round_trip_all_supported_widths ... ok
+test quant::rabitq::tests::bits1_batch_estimator_matches_scalar_order ... ok
+test quant::rabitq::tests::bits1_batch_estimator_rejects_wrong_width_and_stride ... ok
+test quant::rabitq::tests::bits1_byte_lut_matches_per_bit_decode ... ok
+test quant::rabitq::tests::bits1_byte_lut_scalar_sum_matches_per_bit_decode ... ok
+test quant::rabitq::tests::bits4_batch_estimator_matches_scalar_order ... ok
+test quant::rabitq::tests::bits8_batch_estimator_matches_scalar_order ... ok
+test quant::rabitq::tests::bits8_precompute_matches_lut_decode ... ok
+test quant::rabitq::tests::centered_api_rejects_qbit_bits ... ok
+test quant::rabitq::tests::centered_context_and_scorer_cover_raw_and_degenerate_paths ... ok
+test quant::rabitq::tests::centered_encode_pins_asymmetric_center_tail_and_zero_residual ... ok
+test quant::rabitq::tests::centered_estimator_bound_dominates_error_on_random_vectors ... ok
+test quant::rabitq::tests::centered_estimator_is_exact_on_sign_aligned_residual ... ok
+test quant::rabitq::tests::centered_scorer_floor_boundaries_cover_below_equal_and_above ... ok
+test quant::rabitq::tests::centered_scorer_matches_manual_unit_residual_ip ... ok
+test quant::rabitq::tests::centered_scorer_pins_nontrivial_bound_formula ... ok
+test quant::rabitq::tests::code_len_matches_dimension ... ok
+test quant::rabitq::tests::custom_rotation_plugs_into_seam ... ok
+test quant::rabitq::tests::dequantized_estimator_scores_reconstructed_payload_and_guards_tail_scalars ... ok
+test quant::rabitq::tests::encode_code_pins_qbit_payload_and_scalars ... ok
+test quant::rabitq::tests::encode_code_pins_zero_vector_tail_and_levels ... ok
+test quant::rabitq::tests::encode_then_score_same_vector_is_nonnegative ... ok
+test quant::rabitq::tests::estimate_ip_guards_and_bound_are_pinned ... ok
+test quant::rabitq::tests::estimate_ip_o_dot_floor_covers_below_equal_and_above ... ok
+test quant::rabitq::tests::estimator_bound_dominates_error_on_random_vectors ... ok
+test quant::rabitq::tests::estimator_recovers_self_ip_on_sign_aligned_vector ... ok
+test quant::rabitq::tests::hamming_similarity_identity_equals_dim ... ok
+test quant::rabitq::tests::least_squares_estimator_uses_o_dot_as_shrinkage ... ok
+test quant::rabitq::tests::neon_sum_query_dequant_matches_scalar_bits1 ... ok
+test quant::rabitq::tests::neon_sum_query_dequant_matches_scalar_bits4 ... ok
+test quant::rabitq::tests::neon_sum_query_dequant_matches_scalar_bits8 ... ok
+test quant::rabitq::tests::persisted_sidecar_helpers_preserve_supported_and_unsupported_lanes ... ok
+test quant::rabitq::tests::prepared_queries_only_keep_bits1_byte_lut_for_bits1 ... ok
+test quant::rabitq::tests::qbit_code_len_scales_with_bits ... ok
+test quant::rabitq::tests::qbit_encoder_reduces_error_vs_binary ... ok
+test quant::rabitq::tests::qbit_quantize_and_dequantize_pin_level_midpoints ... ok
+test quant::rabitq::tests::qbit_quantize_pins_non_roundtrip_scale_term ... ok
+test quant::rabitq::tests::qbit_rejects_unsupported_bits ... ok
+test quant::rabitq::tests::quantizer_and_prepared_estimator_accessors_are_stable ... ok
+test quant::rabitq::tests::query_scorer_matches_estimator_for_nontrivial_pair ... ok
+test quant::rabitq::tests::residual_beats_absolute_on_concentrated_lists ... ok
+test quant::rabitq::tests::residual_code_is_byte_identical_shape_to_absolute_code ... ok
+test quant::rabitq::tests::residual_estimate_recovers_exact_residual_term ... ok
+test quant::rabitq::tests::residual_scoring_matches_exact_within_tolerance ... ok
+test quant::rabitq::tests::seeded_srht_cache_keys_include_bits_seed_and_clip ... ok
+test quant::rabitq::tests::sign_sidecar_helpers_pack_exact_words ... ok
+test quant::rabitq::tests::sign_words_from_rotated_matches_manual_pack ... ok
+test quant::rabitq::tests::srht_seeded_rotation_is_deterministic_and_independent_of_prod ... ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... task36_rabitq kernel=scalar_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=1536 status=exercised
+ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+test quant::rabitq::tests::try_estimate_bound_carrying_cutoff_agrees_with_scalar ... ok
+test quant::rabitq::tests::try_estimate_scalar_cutoff_is_monotone_in_threshold ... ok
+test quant::rabitq::tests::try_estimate_scalar_cutoff_is_sound_under_non_identity_rotation ... ok
+test quant::rabitq::tests::try_estimate_scalar_cutoff_never_prunes_a_keepable_candidate ... ok
+test quant::rotation::tests::srht_padded_matches_pad_input_plus_srht ... ok
+test quant::rotation::tests::srht_preserves_norm ... ok
+test quant::rotation::tests::srht_runtime_path_matches_scalar_on_random_inputs ... ok
+test quant::rotation::tests::tiled_srht_roundtrip_1536 ... ok
+test quant::simd::tests::backend_name_matches_detected_backend ... ok
+test quant::simd::tests::detect_backend_honors_forced_scalar ... ok
+test quant::simd::tests::forced_backend_accepts_auto_empty_and_absent ... ok
+test quant::simd::tests::forced_backend_accepts_supported_backend_names ... ok
+test quant::simd::tests::forced_backend_rejects_unknown_name ...
+thread 'quant::simd::tests::forced_backend_rejects_unknown_name' (34434239) panicked at src/quant/simd.rs:207:18:
+unsupported ECAZ_SIMD value: bogus
+ok
+test quant::simd::tests::x86_backend_gate_requires_avx2_and_fma ... ok
+test quant::simd::tests::x86_feature_slots_model_task67_kernel_requirements ... ok
+test quant::tiled_lut32::tests::run_is_bit_equal_with_production_tiled_scorer ... ok
+
+test result: ok. 188 passed; 0 failed; 3 ignored; 0 measured; 2330 filtered out; finished in 5.59s

--- a/reviews/task-36/004-current-head-review-flags/feedback/2026-07-25-02-reviewer.md
+++ b/reviews/task-36/004-current-head-review-flags/feedback/2026-07-25-02-reviewer.md
@@ -1,0 +1,214 @@
+---
+agent: claude
+role: reviewer
+model: claude-opus-5[1m]
+date: 2026-07-25
+seq: 02
+---
+
+# Review Feedback: Task 36 packets 003 + 004 — flag handling
+
+Reviewed head `a915b062b` (packet 004) with packet 003 (`15e3831c1`) folded in,
+verified at branch head `8923245ee` in a clean worktree on Apple M5
+(aarch64, NEON + dotprod, no SVE).
+
+## Verdict
+
+**APPROVE.** All five flags from packet 002 and the packet-001 regression are
+closed, and closed properly — every one was fixed at the mechanism level rather
+than papered over in prose. Two of the fixes are stronger than what I asked
+for. I re-ran the lane and all three negative controls myself rather than
+reading the coder's logs; everything reproduces.
+
+Two LOW follow-ups below. Neither blocks anything and neither needs to be in
+this packet.
+
+## Flag-by-flag disposition
+
+### Flag 1 — filters fail open → **CLOSED**
+
+`scripts/run-counted-cargo-test.sh` wraps every stage with a declared expected
+pass count, and all ten stages in the `simd-diff` target now go through it. I
+ran the three cases that matter:
+
+    artifacts/2026-07-25-reviewer-counted-wrapper-controls.log
+
+    A wrong expected count (99 vs 3): exit=1  expected 99 passed tests, observed 3
+    B filter matches nothing:        exit=1  expected 3 passed tests, observed 0
+    C cargo itself fails:            exit=1  (cargo's own status propagates)
+
+Case C is the one that is easy to get wrong when you add output parsing around
+a command, and the script gets it right: `set +e` around the pipeline with
+`PIPESTATUS[0]` captured before any parsing, and an early exit on non-zero.
+That answers review-focus question 1 — cargo failures are preserved, and both
+zero-match and wrong-count are rejected.
+
+The red test that prompted the flag is fixed and staged: the new
+`quant::prod::tests::tiled_lut_query_prep_` stage expects exactly 3 and passes.
+
+One scope note, not a complaint: I asked for a `quant::prod::tests::` stage and
+the packet added `quant::prod::tests::tiled_lut_query_prep_`, which is the
+three new guard tests only. The rest of the `prod` in-library suite — including
+`dispatched_score_matches_scalar_on_random_inputs`,
+`dispatched_score_matches_scalar_with_tail_dims`, and
+`qjl_neon_production_path_matches_scalar_reference_tolerance`, all genuinely
+differential — is still outside the lane. The public hooks in
+`tests/simd_diff.rs` cover the same entry points, so this is duplication-vs-gap
+judgement rather than a hole, and I am fine with where the line was drawn. Worth
+a sentence in `docs/hardening.md` saying `prod` is covered via the public-hook
+stage plus the guard stage, so the next person does not re-litigate it.
+
+### Packet-001 Finding 3 — tiled LUT guard → **CLOSED, and hardened beyond the ask**
+
+`prepare_ip_query_tiled_lut_no_qjl_4bit` gets back both the query-length assert
+and the no-QJL/4-bit lane guard, matching its non-tiled sibling. The
+`debug_assert_eq!` on codebook/centroid shape in `build_prepared_query_lut` was
+promoted to a release `assert_eq!`, which is what I suggested and which is the
+part that actually removes the silent-wrong-score path in release builds.
+
+Three regression tests, one per failure mode (lane, length, codebook shape),
+and the third calls `build_prepared_query_lut` directly so the invariant is
+pinned at the function that enforces it rather than only through a caller. That
+is the right place to put it.
+
+### Flag 2 — x86 "not a skip" → **CLOSED**
+
+All five x86 hooks now `.expect()` instead of `if let Some(..)`: HNSW and
+DiskANN source IP, Prod direct, Prod code-to-code, and FWHT. The aarch64 and
+x86 branches now enforce the same contract, so the sentence in
+`docs/hardening.md` describes the code again.
+
+I checked the count arithmetic for the CI x86 leg, since a hardcoded expected
+count that is arch-dependent would fail spuriously there: `tests/simd_diff.rs`
+has 12 `#[test]` attributes, of which two are `aarch64`-gated and two are
+`x86_64`-gated, giving 10 on either arch. The `10` in the Makefile is correct
+for both legs.
+
+### Flag 3 — int8 ISA pinning → **CLOSED, and stronger than asked**
+
+I asked for the discarded `Isa` to be asserted. The packet did that at all five
+call sites and then went further: `assert_host_simd_isa` compares against
+`select_highest_isa(HostIsaFeatures::detect())` — the *uncapped* host
+preference — so an `ECAZ_ISA_CAP` that downgrades dispatch makes the test fail
+loudly instead of quietly comparing scalar to scalar. Verified:
+
+    artifacts/2026-07-25-reviewer-isa-cap-control.log
+    $ ECAZ_ISA_CAP=scalar cargo test --lib --features bench quant::int8_approx32::
+    assertion `left == right` failed: int8 differential test did not execute
+      the host's preferred SIMD ISA
+
+That answers review-focus question 2. I also checked the consistency worry this
+raised for me — whether the other families would still pass vacuously under the
+same cap — and they would not: `hamming32::host_expected_simd_isa` and
+`rabitq32::multibit_block_isa` both compute from raw feature detection and
+ignore the cap too. All three families are cap-immune by the same reasoning.
+No action needed.
+
+### Flag 4 — QJL tolerance → **CLOSED, and better than the ask**
+
+I asked for the demotion to be justified or narrowed. The packet narrowed it,
+which is the better answer: candidates inside an observed non-scalar 32-wide
+block get 4 ULP, everything else — sub-block widths and the tail after a full
+block — is back to `to_bits()` equality. The observed block ISA is now threaded
+out of the batch function, so the printed line is an observation rather than
+`current_isa()` used as a proxy. `docs/hardening.md` records the split with the
+accumulation-order reason.
+
+That is review-focus question 2 answered for QJL: the boundary is now as narrow
+as the execution path permits, within the function under test. See follow-up 1
+for the caveat about *which* function that is.
+
+### Flag 5 — CI drift → **CLOSED**
+
+`ci.yml`'s SIMD job now runs `make simd-diff`, so the workflow cannot cover less
+than the local lane. Every stale "PR time" claim is gone from the task file and
+`docs/hardening.md`, replaced with an accurate description of manual-dispatch
+CI and packet-recorded pre-merge evidence — including the specific point that
+the aarch64 full-test workflow is unreachable because its `schedule` gate has no
+schedule trigger. That answers review-focus question 4.
+
+## Independently reproduced
+
+`make simd-diff` at `8923245ee`, exit 0, ten counted stages:
+
+    artifacts/2026-07-25-reviewer-make-simd-diff-repro.log
+
+    public bench hooks .......... 10   tiled LUT guards ............  3
+    RaBitQ arithmetic ...........  2   hamming32 ...................  3
+    rabitq32 ....................  7   DistANN composition .........  2
+    qjl32 ....................... 10
+    lut32 .......................  9
+    grouped-PQ ..................  8
+    int8/SDOT ...................  5
+
+## Follow-up 1 (LOW) — the QJL batch stage exercises a function no access method calls
+
+`qjl32::score_turboquant_qjl_batch` — the function
+`qjl32_batch_matches_pre_slice_scorer_by_execution_path` tests, and the one
+whose signature changed to return the observed ISA — has no non-test caller
+under `src/`. The production path is
+`candidate_batch::score_turboquant_qjl_batch_for` →
+`score_turboquant_qjl_batch_inner` → `score_width_cascade` with
+`score_turboquant_qjl_remainder` as the tail handler.
+
+The two differ in exactly the place the new tolerance split reasons about. The
+test wrapper's tail calls `score_turboquant_qjl_scalar` for everything below 32.
+Production's `score_turboquant_qjl_remainder` runs `score_turboquant_qjl_octet8`
+— SIMD — for tails of 8 or more, and only falls to scalar below an octet. So
+packet 004's statement that "QJL scalar candidates and tails remain bit-exact"
+is true of the wrapper but is not a claim about production: a 9-wide production
+tail executes an octet SIMD kernel, not the scalar reference.
+
+The math is still covered — `qjl32_octet8_matches_pre_slice_scorer_tolerance`
+pins the octet kernel separately, with the tolerance that path warrants — so
+this is not a correctness gap. It is a claim-scope issue plus a missing
+composition test. The DistANN work in packet 002 is the model here: it tests the
+binding rather than re-testing kernels, and that is what the QJL family is
+missing. Either add a cascade-level differential over the production entry
+point, or reword the doc line to say the bit-exactness applies to the batch
+wrapper's scalar remainder.
+
+While there: the shared-ISA `assert_eq!` added inside
+`score_turboquant_qjl_batch` is a panic path introduced for test observability.
+It is unreachable in practice, since `current_isa()` is a cached `OnceLock`, and
+the function has no production caller — but if that function ever acquires one,
+that assert ships with it.
+
+## Follow-up 2 (LOW) — counted wrapper checks only the last summary line
+
+`run-counted-cargo-test.sh` extracts pass counts with `sed` and takes
+`tail -n 1`. Every current stage passes `--lib` or `--test simd_diff`, so
+exactly one summary is ever printed and the behavior is correct today. If a
+stage is later broadened to a command that runs more than one test binary, only
+the final binary's count is checked and the others pass unexamined — the same
+fail-open shape the wrapper was written to remove, one level up. Cheap fix:
+fail when more than one summary line is present, or sum them and compare the
+total.
+
+## Review-focus answers
+
+1. **Does the counted wrapper preserve cargo failures while rejecting missing
+   or unexpected counts?** Yes — verified all three cases above, including the
+   cargo-failure case that the parsing could have swallowed.
+2. **Are the QJL boundaries as narrow as the execution path permits?** Within
+   the function under test, yes. Follow-up 1 is about that function not being
+   the production one.
+3. **Do the x86 assertions match the aarch64 contract?** Yes, all five hooks,
+   and the expected-count arithmetic holds on both arches.
+4. **Does the manual workflow execute the authoritative lane?** Yes. One
+   caveat worth recording in the task file: that job has never been dispatched
+   with the new step. `make simd-diff` now includes `--lib` stages, and the
+   library test binary's symbol resolution on the runners is covered only by
+   the job's `--unresolved-symbols=ignore-all` RUSTFLAGS, which has been
+   exercised for integration-test targets but not for `--lib`. It should work;
+   it is untested. Say "untested" rather than letting the next reader assume a
+   green manual run exists.
+
+## Status
+
+Task 36 stays open, correctly. What is owed is unchanged and unchallenged:
+Intel AVX2/AVX-512 and Graviton SVE/SVE2 execution on real hosts. SVE in
+particular is still proven on no host in this project. The Apple lane is now in
+good enough shape to be the template those runs copy.
+
+Nothing here blocks. The two follow-ups can ride along with the Intel packet.

--- a/reviews/task-36/004-current-head-review-flags/request.md
+++ b/reviews/task-36/004-current-head-review-flags/request.md
@@ -1,0 +1,57 @@
+---
+task: 36
+agent: codex
+role: coder
+model: GPT-5
+date: 2026-07-25
+head: a915b062bac167532f961ee77dd184905db58d90
+---
+
+# Review request: resolve packet 002 current-head flags
+
+Please review head `a915b062bac167532f961ee77dd184905db58d90`
+against all five flags in packet 002.
+
+## Corrections
+
+- Every filtered `make simd-diff` stage now declares its expected test count.
+  Cargo's zero-match success can no longer make the lane green.
+- The tiled-LUT prod safety stage from packet 003 is included in that counted
+  inventory.
+- All x86 public forced hooks now fail if AVX2/FMA execution is unavailable:
+  HNSW, DiskANN, Prod direct scoring, Prod code-to-code scoring, and FWHT.
+- QJL scalar candidates and tails remain bit-exact. The 4-ULP/relative
+  `1e-6` allowance applies only to candidates processed by an observed
+  non-scalar 32-wide block, whose vector reduction changes accumulation order.
+- QJL output now reports the ISA returned by the block scorer.
+- The manual CI SIMD matrix calls `make simd-diff`, preventing workflow/local
+  lane drift. CI triggers remain manual-only.
+
+Intel and Graviton hardware execution are still later host runs, as agreed;
+this packet makes no claim that Apple compilation proves those paths.
+
+## Evidence
+
+See [artifacts/manifest.md](artifacts/manifest.md) for the exact
+finding-by-finding mapping.
+
+- [make-simd-diff.log](artifacts/make-simd-diff.log): all ten counted stages
+  passed on NEON/SDOT.
+- [empty-filter-negative-control.log](artifacts/empty-filter-negative-control.log):
+  a zero-match Cargo success is converted into lane failure.
+- [quant-lib-tests.log](artifacts/quant-lib-tests.log): 188 passed, 0 failed,
+  3 ignored.
+- [cargo-fmt-check.log](artifacts/cargo-fmt-check.log): inherited global drift
+  remains; neither changed Rust file appears in the format diff.
+
+## Review focus
+
+1. Does the counted wrapper preserve Cargo failures while rejecting missing or
+   unexpected test counts?
+2. Are QJL exactness/tolerance boundaries now as narrow as the execution path
+   permits?
+3. Do the x86 assertions match the already-enforced aarch64 “not a skip”
+   contract?
+4. Does the manual workflow now execute exactly the authoritative local lane?
+
+Task 36 remains review-requested pending this response.

--- a/reviews/task-36/005-minor-review-followups/artifacts/clippy-lib.log
+++ b/reviews/task-36/005-minor-review-followups/artifacts/clippy-lib.log
@@ -1,0 +1,60 @@
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+error: manual checked division
+   --> src/am/ec_ivf/quantizer.rs:695:34
+    |
+695 |         let candidate_count = if payload_len == 0 {
+    |                                  ^^^^^^^^^^^^^^^^ check performed here
+...
+698 |             payloads.len() / payload_len
+    |             ---------------------------- division performed here
+    |
+    = help: consider using `checked_div`
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#manual_checked_ops
+    = note: `-D clippy::manual-checked-ops` implied by `-D warnings`
+    = help: to override `-D warnings` add `#[allow(clippy::manual_checked_ops)]`
+
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+error: could not compile `ecaz` (lib) due to 1 previous error

--- a/reviews/task-36/005-minor-review-followups/artifacts/make-simd-diff.log
+++ b/reviews/task-36/005-minor-review-followups/artifacts/make-simd-diff.log
@@ -1,0 +1,468 @@
+task36 simd-diff: public bench hooks (Prod/FWHT/HNSW/DiskANN)
+bash scripts/run-counted-cargo-test.sh 10 --features bench --test simd_diff -- --test-threads=1 --nocapture
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 54.85s
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-3eb2e7ac5b649314)
+
+running 10 tests
+test am_source_inner_product_simd_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_code_to_code_score_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_fwht_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test dispatched_score_ip_from_parts_matches_scalar_reference ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test forced_neon_fwht_matches_scalar_reference_when_available ... ok
+test forced_neon_score_paths_match_scalar_reference_when_available ... ok
+test host_backend_inventory_is_visible ... task36_host arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false unavailable=x86_avx2_fma,x86_avx512
+ok
+test packed_mse_indices_roundtrip_across_widths ... proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
+ok
+test production_1536_4bit_score_path_matches_scalar_reference ... ok
+test three_bit_unpack_fixture_stays_bit_exact ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 38.26s
+
+counted cargo test: observed expected 10 passed tests
+task36 simd-diff: RaBitQ arithmetic SIMD inventory
+bash scripts/run-counted-cargo-test.sh 2 --lib --features bench quant::rabitq::tests::task67_sum_query_dequant_for_test_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 27.28s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 2 tests
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available ... task36_rabitq kernel=scalar_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits1 bits=1 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits4 bits=4 dim=1536 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=7 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=8 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=9 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=31 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=32 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=33 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=96 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=384 status=exercised
+task36_rabitq kernel=scalar_bits8 bits=8 dim=1536 status=exercised
+task36_rabitq kernel=neon_bits8 bits=8 dim=1536 status=exercised
+ok
+test quant::rabitq::tests::task67_sum_query_dequant_for_test_scaffold_registers_expected_kernels ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2520 filtered out; finished in 0.00s
+
+counted cargo test: observed expected 2 passed tests
+task36 simd-diff: rabitq32 bits=1/2/4 block and partial kernels
+bash scripts/run-counted-cargo-test.sh 7 --lib --features bench quant::rabitq32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.13s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 7 tests
+test quant::rabitq32::tests::dispatched_block32_matches_anchor_within_tolerance ... ok
+test quant::rabitq32::tests::multibit_block_and_partial_match_scalar_estimate ... task36_rabitq32 bits=2 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=384 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=2 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+task36_rabitq32 bits=4 dimensions=1536 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::rabitq32::tests::partial_dispatch_matches_anchor_and_production_batch ... ok
+test quant::rabitq32::tests::production_dispatch_is_within_phase2_tolerance ... ok
+test quant::rabitq32::tests::scalar_block32_matches_forced_scalar_anchor_bits ... ok
+test quant::rabitq32::tests::scalar_tail_is_forced_scalar_anchor ... ok
+test quant::rabitq32::tests::simd_block32_is_bit_equal_with_production_batch ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 2515 filtered out; finished in 0.04s
+
+counted cargo test: observed expected 7 passed tests
+task36 simd-diff: qjl32 block/octet/remainder kernels
+bash scripts/run-counted-cargo-test.sh 10 --lib --features bench quant::qjl32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 10 tests
+test quant::qjl32::tests::qjl32_avx2_block32_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_batch_matches_pre_slice_scorer_by_execution_path ... task36_qjl32 observed_block_isa=neon scalar_tail=bit-exact widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::qjl32::tests::qjl32_block32_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_block32_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_neon_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+test quant::qjl32::tests::qjl32_octet8_matches_pre_slice_scorer_tolerance ... ok
+test quant::qjl32::tests::qjl32_rejects_no_qjl_1536_lane ... ok
+test quant::qjl32::tests::qjl32_scalar_matches_pre_slice_scorer_bits ... ok
+test quant::qjl32::tests::qjl32_scalar_reference_matches_production_dispatch_tolerance ... ok
+test quant::qjl32::tests::qjl32_sve_block32_matches_pre_slice_scorer_tolerance_when_available ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2512 filtered out; finished in 0.24s
+
+counted cargo test: observed expected 10 passed tests
+task36 simd-diff: lut32 block/partial/tiled kernels
+bash scripts/run-counted-cargo-test.sh 9 --lib --features bench quant::lut32::tests::lut32_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 9 tests
+test quant::lut32::tests::lut32_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_batch_under_block_width_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_batch_with_blocks_and_tail_matches_scalar_tail_bits ... ok
+test quant::lut32::tests::lut32_block32_matches_scalar_tail_bits_across_dims ... ok
+test quant::lut32::tests::lut32_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_partial_matches_scalar_tail_bits_across_widths ... ok
+test quant::lut32::tests::lut32_rejects_shape_mismatch ... ok
+test quant::lut32::tests::lut32_sve_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::lut32::tests::lut32_tiled_batch_matches_scalar_tail_bits_across_widths_and_dims ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 2513 filtered out; finished in 0.03s
+
+counted cargo test: observed expected 9 passed tests
+task36 simd-diff: grouped-PQ block/partial kernels
+bash scripts/run-counted-cargo-test.sh 8 --lib --features bench quant::grouped_pq_block::tests::grouped_pq_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 8 tests
+test quant::grouped_pq_block::tests::grouped_pq_avx2_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_rejects_shape_mismatch ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_under_block_width_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_batch_with_block_and_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_block32_matches_scalar_reference_bits_across_shapes ... ok
+test quant::grouped_pq_block::tests::grouped_pq_neon_backend_matches_scalar_reference_bits_when_available ... ok
+test quant::grouped_pq_block::tests::grouped_pq_scalar_tail_matches_scalar_reference_bits ... ok
+test quant::grouped_pq_block::tests::grouped_pq_sve_backend_matches_scalar_reference_bits_when_available ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2514 filtered out; finished in 0.00s
+
+counted cargo test: observed expected 8 passed tests
+task36 simd-diff: int8/SDOT block/partial kernels
+bash scripts/run-counted-cargo-test.sh 5 --lib --features bench quant::int8_approx32:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 5 tests
+test quant::int8_approx32::neon::neon_path_tests::legacy_and_dotprod_candidate_paths_match_scalar_bits ... ok
+test quant::int8_approx32::tests::block32_and_partial_are_bit_equal_with_scalar_reference ... ok
+test quant::int8_approx32::tests::block32_is_bit_equal_at_extreme_i8_values ... ok
+test quant::int8_approx32::tests::scalar_reference_matches_production_scorer_bits ... ok
+test quant::int8_approx32::tests::simd_dim_tails_are_bit_equal_with_scalar_reference ... task36_int8_approx32 neon=true dotprod=true widths=1,7,8,9,16,17,31,32,33
+ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2517 filtered out; finished in 0.05s
+
+counted cargo test: observed expected 5 passed tests
+task36 simd-diff: tiled LUT lane and query-shape guards
+bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::prod::tests::tiled_lut_query_prep_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 3 tests
+test quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_codebook_centroid_mismatch' (34525988) panicked at src/quant/prod.rs:1853:5:
+assertion `left == right` failed: prepared query LUT codebook length must match the centroid count
+  left: 8
+ right: 16
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_qjl_active_lane' (34525989) panicked at src/quant/prod.rs:418:9:
+explicit LUT query prep requires the no-QJL 4-bit lane
+ok
+test quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch - should panic ...
+thread 'quant::prod::tests::tiled_lut_query_prep_rejects_query_length_mismatch' (34525990) panicked at src/quant/prod.rs:411:9:
+assertion `left == right` failed: query length mismatch: got 1535, expected 1536
+  left: 1535
+ right: 1536
+ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out; finished in 0.07s
+
+counted cargo test: observed expected 3 passed tests
+task36 simd-diff: real hamming32 SIMD kernels
+bash scripts/run-counted-cargo-test.sh 3 --lib --features bench quant::hamming32::tests:: -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 3 tests
+test quant::hamming32::tests::block32_is_integer_exact_with_scalar_reference ... ok
+test quant::hamming32::tests::partial_is_integer_exact_with_scalar_reference ... task36_hamming32 isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test quant::hamming32::tests::scalar_reference_is_xor_popcount ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out; finished in 0.00s
+
+counted cargo test: observed expected 3 passed tests
+task36 simd-diff: production QJL cascade and DistANN composition/source IP
+bash scripts/run-counted-cargo-test.sh 3 --lib --features bench simd_diff_ -- --test-threads=1 --nocapture
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.08s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-65e29342b3f44057)
+
+running 3 tests
+test am::common::candidate_batch::tests::simd_diff_qjl_production_candidate_batch_cascade ... task36_qjl_candidate_batch production_cascade_isa=neon widths=1,7,8,9,16,17,31,32,33
+ok
+test am::ec_distann::insert::tests::simd_diff_exact_distance_is_shared_diskann_inner_product_negation ... task36_distann source_inner_product_backend=neon
+ok
+test am::ec_distann::quantizer::tests::simd_diff_distann_codec_batches_match_direct_scalar_scores_across_widths ... task36_distann format=grouped_pq dimensions=64 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=rabitq dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+task36_distann format=turboquant dimensions=1536 widths=[1, 7, 8, 9, 16, 17, 31, 32, 33] host_isa=neon
+ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out; finished in 0.09s
+
+counted cargo test: observed expected 3 passed tests

--- a/reviews/task-36/005-minor-review-followups/artifacts/manifest.md
+++ b/reviews/task-36/005-minor-review-followups/artifacts/manifest.md
@@ -1,0 +1,71 @@
+# Artifact manifest
+
+- Head SHA: `fbaa20a421eb3523caaccc92554df573f5771232`
+- Task bucket: `reviews/task-36/`
+- Packet: `reviews/task-36/005-minor-review-followups/`
+- Timestamp: `2026-07-25T19:59:54Z`
+- Host: Apple arm64, NEON + dot-product/SDOT detected
+- Review source:
+  `reviews/task-36/004-current-head-review-flags/feedback/2026-07-25-02-reviewer.md`
+- Hardware boundary: AVX2/AVX-512 and SVE/SVE2 were not executed. Their
+  hardware runs remain separate later evidence.
+- Benchmark applicability: none. The commit changes test-only differential
+  coverage, test-lane enforcement, and documentation; quantizer, index, scan,
+  rerank, posting, and storage behavior are unchanged.
+- Isolation/storage-format/rerank mode: not applicable to this test-only
+  packet; no corpus, index, table, or benchmark surface was used.
+
+## Commit under review
+
+- `fbaa20a42` — add a production-entry QJL cascade differential, remove the
+  test-helper ISA assertion, reject multiple Cargo summaries, and correct the
+  Task 36 coverage/CI documentation.
+
+## Artifacts
+
+### `make-simd-diff.log`
+
+- Head SHA: `fbaa20a421eb3523caaccc92554df573f5771232`
+- Command: `make simd-diff`
+- Timestamp: 2026-07-25
+- Status: PASS
+- Every one of the ten stages ends with
+  `counted cargo test: observed expected N passed tests`.
+- Counts: public 10; RaBitQ arithmetic 2; `rabitq32` 7; `qjl32` 10;
+  `lut32` 9; grouped PQ 8; int8/SDOT 5; tiled-LUT guards 3;
+  `hamming32` 3; production QJL plus DistANN composition/source IP 3.
+- Host line:
+  `arch=aarch64 backend=neon neon=true dotprod=true sve=false sve2=false`.
+- New composition result:
+  `production_cascade_isa=neon widths=1,7,8,9,16,17,31,32,33`.
+
+### `multiple-summary-negative-control.log`
+
+- Head SHA: `fbaa20a421eb3523caaccc92554df573f5771232`
+- Command:
+  `bash scripts/run-counted-cargo-test.sh 0 --lib --test simd_diff
+  --features bench task36_no_matching_test -- --test-threads=1`
+- Timestamp: 2026-07-25
+- Status: EXPECTED FAILURE from the counted wrapper.
+- Cargo emits two individually successful zero-test summaries, one for the
+  library and one for `tests/simd_diff.rs`.
+- Key result:
+  `expected exactly one test-result summary, observed 2`.
+
+### `clippy-lib.log`
+
+- Head SHA: `fbaa20a421eb3523caaccc92554df573f5771232`
+- Command:
+  `cargo clippy --lib --features bench --no-deps -- -D warnings`
+- Timestamp: 2026-07-25
+- Status: FAIL on an unrelated existing finding at
+  `src/am/ec_ivf/quantizer.rs:695`.
+- Key result: Clippy reports `manual checked division`; it reports no finding
+  in the six files changed by the Task 36 commit.
+
+## Additional local checks
+
+- `rustfmt --edition 2021 --check
+  src/am/common/candidate_batch/mod.rs src/quant/qjl32/mod.rs`: PASS
+- `bash -n scripts/run-counted-cargo-test.sh`: PASS
+- `git diff --check`: PASS before the code commit

--- a/reviews/task-36/005-minor-review-followups/artifacts/multiple-summary-negative-control.log
+++ b/reviews/task-36/005-minor-review-followups/artifacts/multiple-summary-negative-control.log
@@ -1,0 +1,37 @@
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: In file included from /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:19:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:537:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   537 | dlist_next_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:547:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:   547 | dlist_prev_node(dlist_head *head, dlist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/lib/ilist.h:1054:29: warning: unused parameter 'head' [-Wunused-parameter]
+warning: ecaz@0.1.1:  1054 | slist_next_node(slist_head *head, slist_node *node)
+warning: ecaz@0.1.1:       |                             ^
+warning: ecaz@0.1.1: In file included from csrc/pg18_pgstat_shim.c:10:
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:58: warning: unused parameter 'size' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                          ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:875:70: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   875 | pgstat_cmp_hash_key(const void *a, const void *b, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                                      ^
+warning: ecaz@0.1.1: /opt/homebrew/include/postgresql@18/server/utils/pgstat_internal.h:882:56: warning: unused parameter 'arg' [-Wunused-parameter]
+warning: ecaz@0.1.1:   882 | pgstat_hash_hash_key(const void *d, size_t size, void *arg)
+warning: ecaz@0.1.1:       |                                                        ^
+warning: ecaz@0.1.1: 6 warnings generated.
+   Compiling ecaz v0.1.1 (/Users/peter/dev/tqvector)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 26.97s
+     Running unittests src/lib.rs (target/debug/deps/ecaz-1314b13885bb6b83)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2522 filtered out; finished in 0.00s
+
+     Running tests/simd_diff.rs (target/debug/deps/simd_diff-3eb2e7ac5b649314)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.00s
+
+counted cargo test: expected exactly one test-result summary, observed 2

--- a/reviews/task-36/005-minor-review-followups/request.md
+++ b/reviews/task-36/005-minor-review-followups/request.md
@@ -1,0 +1,58 @@
+---
+task: 36
+agent: codex
+role: coder
+model: GPT-5
+date: 2026-07-25
+head: fbaa20a421eb3523caaccc92554df573f5771232
+---
+
+# Review request: close packet 004 minor follow-ups
+
+Please review head `fbaa20a421eb3523caaccc92554df573f5771232`
+against the two LOW follow-ups in packet 004.
+
+## Corrections
+
+- A new differential calls the production
+  `candidate_batch::score_turboquant_qjl_batch_for` entry point at widths
+  1/7/8/9/16/17/31/32/33. It checks the real block→octet→scalar cascade:
+  SIMD blocks and octets use the documented 4-ULP/relative `1e-6` tolerance,
+  while the sub-octet scalar remainder stays bit-exact.
+- The older test-only QJL batch helper no longer contains an ISA-consistency
+  assertion that could become a production panic path if the helper were
+  promoted later.
+- The counted Cargo wrapper now requires exactly one successful test-result
+  summary. A future filtered stage that accidentally selects multiple test
+  binaries fails closed instead of validating only the last summary.
+- The hardening guide now explains the public-hook plus focused-guard split for
+  `prod`, and accurately documents QJL octets as SIMD tolerance paths.
+- The task record explicitly says the manual CI matrix has not been dispatched
+  since counted `--lib` stages were added; CI-runner symbol resolution remains
+  untested.
+
+Intel and Graviton execution remain later host runs, as agreed. This packet
+makes only an Apple arm64 NEON/dotprod claim.
+
+## Evidence
+
+See [artifacts/manifest.md](artifacts/manifest.md) for commands and provenance.
+
+- [make-simd-diff.log](artifacts/make-simd-diff.log): all ten counted stages
+  pass; the final three-test stage reports the production QJL cascade on NEON.
+- [multiple-summary-negative-control.log](artifacts/multiple-summary-negative-control.log):
+  two successful Cargo summaries are rejected with an observed count of two.
+- [clippy-lib.log](artifacts/clippy-lib.log): the focused Clippy command reaches
+  one unrelated pre-existing IVF `manual_checked_ops` finding; no touched Task
+  36 file has a reported lint finding.
+
+## Review focus
+
+1. Does the new test exercise the production QJL block→octet→scalar composition
+   with the correct exactness boundary?
+2. Does the wrapper now reject both zero summaries and multiple summaries while
+   retaining the existing expected-pass-count check?
+3. Do the docs avoid claiming an undispatched CI run or hardware paths not
+   executed on this host?
+
+Task 36 remains review-requested pending an outside response.

--- a/scripts/run-counted-cargo-test.sh
+++ b/scripts/run-counted-cargo-test.sh
@@ -10,7 +10,8 @@ expected_count="$1"
 shift
 
 output_file="$(mktemp)"
-trap 'rm -f "$output_file"' EXIT
+summary_file="$(mktemp)"
+trap 'rm -f "$output_file" "$summary_file"' EXIT
 
 set +e
 cargo test "$@" 2>&1 | tee "$output_file"
@@ -21,14 +22,20 @@ if [[ "$cargo_status" -ne 0 ]]; then
   exit "$cargo_status"
 fi
 
-summary="$(
-  sed -n 's/^test result: ok\. \([0-9][0-9]*\) passed;.*/\1/p' "$output_file" |
-    tail -n 1
-)"
-if [[ -z "$summary" ]]; then
+sed -n 's/^test result: ok\. \([0-9][0-9]*\) passed;.*/\1/p' \
+  "$output_file" >"$summary_file"
+summary_count="$(wc -l <"$summary_file" | tr -d ' ')"
+if [[ "$summary_count" -eq 0 ]]; then
   echo "counted cargo test: missing successful test-result summary" >&2
   exit 1
 fi
+if [[ "$summary_count" -ne 1 ]]; then
+  echo \
+    "counted cargo test: expected exactly one test-result summary, observed ${summary_count}" \
+    >&2
+  exit 1
+fi
+IFS= read -r summary <"$summary_file"
 if [[ "$summary" -ne "$expected_count" ]]; then
   echo \
     "counted cargo test: expected ${expected_count} passed tests, observed ${summary}" \

--- a/scripts/run-counted-cargo-test.sh
+++ b/scripts/run-counted-cargo-test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <expected-passed-count> <cargo-test-args...>" >&2
+  exit 2
+fi
+
+expected_count="$1"
+shift
+
+output_file="$(mktemp)"
+trap 'rm -f "$output_file"' EXIT
+
+set +e
+cargo test "$@" 2>&1 | tee "$output_file"
+cargo_status="${PIPESTATUS[0]}"
+set -e
+
+if [[ "$cargo_status" -ne 0 ]]; then
+  exit "$cargo_status"
+fi
+
+summary="$(
+  sed -n 's/^test result: ok\. \([0-9][0-9]*\) passed;.*/\1/p' "$output_file" |
+    tail -n 1
+)"
+if [[ -z "$summary" ]]; then
+  echo "counted cargo test: missing successful test-result summary" >&2
+  exit 1
+fi
+if [[ "$summary" -ne "$expected_count" ]]; then
+  echo \
+    "counted cargo test: expected ${expected_count} passed tests, observed ${summary}" \
+    >&2
+  exit 1
+fi
+
+echo "counted cargo test: observed expected ${expected_count} passed tests"

--- a/src/am/common/candidate_batch/mod.rs
+++ b/src/am/common/candidate_batch/mod.rs
@@ -1062,6 +1062,73 @@ mod tests {
     }
 
     #[test]
+    fn simd_diff_qjl_production_candidate_batch_cascade() {
+        let dim = 1024;
+        let quantizer = crate::quant::prod::ProdQuantizer::new(dim, 4, 42);
+        let query = random_unit_vector(dim, 36_001);
+        let prepared = quantizer.prepare_ip_query(&query);
+        let encoded: Vec<(Vec<u8>, f32)> = (0..33)
+            .map(|seed| {
+                let encoded = quantizer.encode(&random_unit_vector(dim, 36_100 + seed as u64));
+                let mut code =
+                    Vec::with_capacity(encoded.mse_packed.len() + encoded.qjl_packed.len());
+                code.extend_from_slice(&encoded.mse_packed);
+                code.extend_from_slice(&encoded.qjl_packed);
+                (code, encoded.gamma)
+            })
+            .collect();
+
+        for width in [1_usize, 7, 8, 9, 16, 17, 31, 32, 33] {
+            let mut batch = CandidateBatch::with_capacity(width);
+            for (index, (code, gamma)) in encoded[..width].iter().enumerate() {
+                batch
+                    .push(
+                        index,
+                        CandidatePayload::new(code, CandidateMeta::Gamma(*gamma)),
+                    )
+                    .unwrap();
+            }
+            let mut scores = vec![0.0_f32; width];
+            super::score_turboquant_qjl_batch_for(
+                CandidateBatchScoringSurface::Ivf,
+                &quantizer,
+                &prepared,
+                &batch,
+                &mut scores,
+            )
+            .unwrap();
+
+            let isa = crate::quant::isa::current_isa();
+            let scalar_tail_start = if isa == Isa::Scalar {
+                0
+            } else {
+                width - (width % crate::quant::qjl32::OCTET_WIDTH)
+            };
+            for (index, ((code, gamma), score)) in
+                encoded[..width].iter().zip(scores.iter()).enumerate()
+            {
+                let scalar =
+                    quantizer.score_ip_from_parts_scalar_reference(&prepared, *gamma, code);
+                if index < scalar_tail_start {
+                    assert_qjl_close(*score, scalar, 4);
+                } else {
+                    assert_eq!(
+                        score.to_bits(),
+                        scalar.to_bits(),
+                        "width={width} index={index} ISA={} scalar tail changed",
+                        isa.label()
+                    );
+                }
+            }
+        }
+
+        eprintln!(
+            "task36_qjl_candidate_batch production_cascade_isa={} widths=1,7,8,9,16,17,31,32,33",
+            crate::quant::isa::current_isa().label()
+        );
+    }
+
+    #[test]
     fn turboquant_lut_batch_matches_scalar_tail() {
         let quantizer = crate::quant::prod::ProdQuantizer::new(1536, 4, 42);
         let query = random_unit_vector(1536, 31);
@@ -1974,6 +2041,24 @@ mod tests {
             *value /= norm;
         }
         values
+    }
+
+    fn assert_qjl_close(actual: f32, expected: f32, max_ulp: u32) {
+        fn ordered(bits: u32) -> i32 {
+            let signed = bits as i32;
+            if signed < 0 {
+                i32::MIN - signed
+            } else {
+                signed
+            }
+        }
+
+        let ulp = ordered(actual.to_bits()).abs_diff(ordered(expected.to_bits()));
+        let rel = ((actual - expected).abs() / expected.abs().max(1.0e-12)).abs();
+        assert!(
+            ulp <= max_ulp || rel <= 1.0e-6,
+            "actual={actual:?} expected={expected:?} ulp={ulp} rel={rel:?}"
+        );
     }
 
     fn task124_batch_width_profile_candidates() -> usize {

--- a/src/am/ec_distann/insert.rs
+++ b/src/am/ec_distann/insert.rs
@@ -687,6 +687,28 @@ mod tests {
     }
 
     #[test]
+    fn simd_diff_exact_distance_is_shared_diskann_inner_product_negation() {
+        for dimensions in [1usize, 7, 8, 9, 31, 32, 33, 384, 1536] {
+            let left = (0..dimensions)
+                .map(|index| ((index * 17 + 3) as f32 * 0.03125).sin())
+                .collect::<Vec<_>>();
+            let right = (0..dimensions)
+                .map(|index| ((index * 11 + 5) as f32 * 0.0625).cos())
+                .collect::<Vec<_>>();
+            let shared = crate::am::ec_diskann::source_inner_product(&left, &right);
+            assert_eq!(
+                exact_distance(&left, &right).to_bits(),
+                (-shared).to_bits(),
+                "dimensions={dimensions}"
+            );
+        }
+        eprintln!(
+            "task36_distann source_inner_product_backend={}",
+            crate::quant::simd_backend_name()
+        );
+    }
+
+    #[test]
     fn select_respects_degree_bound_and_returns_valid_vec_ids() {
         let source = [1.0_f32, 0.0, 0.0];
         let cands = vec![

--- a/src/am/ec_distann/quantizer.rs
+++ b/src/am/ec_distann/quantizer.rs
@@ -472,6 +472,7 @@ mod tests {
     use super::*;
 
     const ARTIFACT_TEST_DIMENSIONS: usize = 1536;
+    const SIMD_DIFF_WIDTHS: [usize; 9] = [1, 7, 8, 9, 16, 17, 31, 32, 33];
 
     fn corpus() -> Vec<Vec<f32>> {
         (0..32)
@@ -486,6 +487,142 @@ mod tests {
                 vector
             })
             .collect()
+    }
+
+    fn deterministic_vector(dimensions: usize, row: usize) -> Vec<f32> {
+        let mut vector = (0..dimensions)
+            .map(|dimension| {
+                let phase = (row * 37 + dimension * 13) as f32;
+                phase.sin() + 0.25 * (phase * 0.03125).cos()
+            })
+            .collect::<Vec<_>>();
+        let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
+        for value in &mut vector {
+            *value /= norm.max(f32::MIN_POSITIVE);
+        }
+        vector
+    }
+
+    fn grouped_pq_fixture() -> DistannCodecBinding {
+        let dimensions = 64;
+        let group_size = 8;
+        let group_count = dimensions / group_size;
+        let codebooks = (0..group_count)
+            .map(|group| {
+                (0..GROUPED_PQ_CENTROIDS * group_size)
+                    .map(|index| {
+                        let centroid = index / group_size;
+                        let lane = index % group_size;
+                        ((group * 101 + centroid * 17 + lane * 7) as f32 * 0.03125).sin()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        DistannCodecBinding::GroupedPq {
+            model: GroupedPq4Model {
+                codebooks,
+                group_count,
+                group_size,
+                transform_dim: dimensions,
+                signs: crate::quant::rotation::sign_vector(dimensions, 42),
+            },
+        }
+    }
+
+    fn assert_distann_score(format: NeighborCodeFormat, actual: f32, expected: f32) {
+        if format == NeighborCodeFormat::RaBitQ {
+            let tolerance = 1.0e-5_f32 * actual.abs().max(expected.abs()).max(1.0);
+            assert!(
+                (actual - expected).abs() <= tolerance,
+                "format={} actual={actual} expected={expected} tolerance={tolerance}",
+                format.as_str()
+            );
+        } else {
+            assert_eq!(
+                actual.to_bits(),
+                expected.to_bits(),
+                "format={}",
+                format.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn simd_diff_distann_codec_batches_match_direct_scalar_scores_across_widths() {
+        for format in [
+            NeighborCodeFormat::GroupedPq,
+            NeighborCodeFormat::RaBitQ,
+            NeighborCodeFormat::TurboQuant,
+        ] {
+            let (binding, dimensions) = match format {
+                NeighborCodeFormat::GroupedPq => (grouped_pq_fixture(), 64),
+                NeighborCodeFormat::RaBitQ | NeighborCodeFormat::TurboQuant => (
+                    DistannCodecBinding::prepare(format, &[], ARTIFACT_TEST_DIMENSIONS, 42)
+                        .unwrap(),
+                    ARTIFACT_TEST_DIMENSIONS,
+                ),
+            };
+            let artifact = binding.to_artifact(dimensions as u16, 42).unwrap();
+            let query = deterministic_vector(dimensions, 10_000);
+            let prepared = DistannPreparedQuery::prepare_artifact(&artifact, &query).unwrap();
+            let code_len = binding.code_len(dimensions).unwrap();
+            let codes = (0..SIMD_DIFF_WIDTHS[SIMD_DIFF_WIDTHS.len() - 1])
+                .map(|row| binding.encode(&deterministic_vector(dimensions, row + 1)))
+                .collect::<Vec<_>>();
+            assert!(
+                codes.iter().all(|code| code.len() == code_len),
+                "{} payload stride",
+                format.as_str()
+            );
+
+            let first_raw_ip = match &prepared {
+                DistannPreparedQuery::GroupedPq {
+                    query_lut,
+                    group_count,
+                } => grouped_pq_score_f32(query_lut, *group_count, &codes[0]),
+                DistannPreparedQuery::RaBitQ { prepared } => {
+                    prepared.estimate_ip_scalar_only(&codes[0])
+                }
+                DistannPreparedQuery::TurboQuant {
+                    quantizer,
+                    prepared,
+                } => quantizer.score_ip_from_parts_lut_no_qjl_4bit(prepared, &codes[0]),
+            };
+            assert_eq!(
+                prepared.score_dist(&codes[0]).to_bits(),
+                (-first_raw_ip).to_bits(),
+                "{} direct IP-to-distance negation",
+                format.as_str()
+            );
+
+            for width in SIMD_DIFF_WIDTHS {
+                let mut slab = codes[..width]
+                    .iter()
+                    .flat_map(|code| code.iter().copied())
+                    .collect::<Vec<_>>();
+                // A complete poison payload after the requested candidates
+                // proves the binding uses count × persisted stride and does
+                // not consume a neighboring record.
+                slab.extend(std::iter::repeat_n(0xA5, code_len));
+                let mut batch_scores = vec![f32::NAN; width];
+                prepared
+                    .score_dists_batch(&slab, code_len, width, &mut batch_scores)
+                    .unwrap();
+
+                for (slot, actual) in batch_scores.iter().copied().enumerate() {
+                    let expected = prepared.score_dist(&codes[slot]);
+                    assert_distann_score(format, actual, expected);
+                }
+            }
+
+            eprintln!(
+                "task36_distann format={} dimensions={} widths={:?} host_isa={}",
+                format.as_str(),
+                dimensions,
+                SIMD_DIFF_WIDTHS,
+                crate::quant::isa::current_isa().label()
+            );
+        }
     }
 
     #[test]

--- a/src/quant/hamming32/mod.rs
+++ b/src/quant/hamming32/mod.rs
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn partial_is_integer_exact_with_scalar_reference() {
-        for count in [1usize, 2, 7, 22, 31] {
+        for count in [1usize, 7, 8, 9, 16, 17, 31, 32, 33] {
             let word_count = 24;
             let query = words(word_count, 11);
             let candidates: Vec<Vec<u64>> = (0..count)
@@ -159,13 +159,35 @@ mod tests {
                 .collect();
             let candidate_refs: Vec<&[u64]> = candidates.iter().map(Vec::as_slice).collect();
             let mut distances = vec![0u32; count];
-
-            score_hamming_partial(&query, &candidate_refs, &mut distances);
+            let mut block_start = 0;
+            while block_start + BLOCK_WIDTH <= count {
+                let block: &[&[u64]; BLOCK_WIDTH] = candidate_refs
+                    [block_start..block_start + BLOCK_WIDTH]
+                    .try_into()
+                    .unwrap();
+                score_hamming_block32(
+                    &query,
+                    block,
+                    &mut distances[block_start..block_start + BLOCK_WIDTH],
+                );
+                block_start += BLOCK_WIDTH;
+            }
+            if block_start < count {
+                score_hamming_partial(
+                    &query,
+                    &candidate_refs[block_start..],
+                    &mut distances[block_start..],
+                );
+            }
 
             for (distance, candidate) in distances.iter().zip(candidate_refs.iter()) {
                 assert_eq!(*distance, hamming_distance_scalar(&query, candidate));
             }
         }
+        eprintln!(
+            "task36_hamming32 isa={} widths=1,7,8,9,16,17,31,32,33",
+            host_expected_simd_isa().label()
+        );
     }
 
     #[test]

--- a/src/quant/int8_approx32/mod.rs
+++ b/src/quant/int8_approx32/mod.rs
@@ -96,6 +96,16 @@ mod tests {
     };
     use crate::quant::prod::ProdQuantizer;
 
+    fn assert_host_simd_isa(actual: crate::quant::isa::Isa) {
+        let expected = crate::quant::isa::select_highest_isa(
+            crate::quant::isa::HostIsaFeatures::detect(),
+        );
+        assert_eq!(
+            actual, expected,
+            "int8 differential test did not execute the host's preferred SIMD ISA"
+        );
+    }
+
     fn vector(dimensions: usize, seed: u64) -> Vec<f32> {
         let mut state = seed ^ 0x9E37_79B9_7F4A_7C15;
         (0..dimensions)
@@ -126,19 +136,22 @@ mod tests {
 
         let block: &[&[u8]; BLOCK_WIDTH] = code_refs[..BLOCK_WIDTH].try_into().unwrap();
         let mut block_scores = vec![0.0; BLOCK_WIDTH];
-        score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+        let block_isa =
+            score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+        assert_host_simd_isa(block_isa);
         for (score, code) in block_scores.iter().zip(code_refs[..BLOCK_WIDTH].iter()) {
             let reference = score_int8_approx_scalar(&prepared, dimensions, code);
             assert_eq!(score.to_bits(), reference.to_bits());
         }
 
         let mut partial_scores = vec![0.0; 7];
-        score_int8_approx_partial(
+        let partial_isa = score_int8_approx_partial(
             &prepared,
             dimensions,
             &code_refs[BLOCK_WIDTH..],
             &mut partial_scores,
         );
+        assert_host_simd_isa(partial_isa);
         for (score, code) in partial_scores.iter().zip(code_refs[BLOCK_WIDTH..].iter()) {
             let reference = score_int8_approx_scalar(&prepared, dimensions, code);
             assert_eq!(score.to_bits(), reference.to_bits());
@@ -183,21 +196,23 @@ mod tests {
                         [block_start..block_start + BLOCK_WIDTH]
                         .try_into()
                         .unwrap();
-                    score_int8_approx_block32(
+                    let isa = score_int8_approx_block32(
                         &prepared,
                         dimensions,
                         block,
                         &mut scores[block_start..block_start + BLOCK_WIDTH],
                     );
+                    assert_host_simd_isa(isa);
                     block_start += BLOCK_WIDTH;
                 }
                 if block_start < width {
-                    score_int8_approx_partial(
+                    let isa = score_int8_approx_partial(
                         &prepared,
                         dimensions,
                         &code_refs[block_start..width],
                         &mut scores[block_start..],
                     );
+                    assert_host_simd_isa(isa);
                 }
                 for (score, code) in scores.iter().zip(code_refs[..width].iter()) {
                     let reference = score_int8_approx_scalar(&prepared, dimensions, code);
@@ -244,7 +259,8 @@ mod tests {
         let code_refs: Vec<&[u8]> = codes.iter().map(Vec::as_slice).collect();
         let block: &[&[u8]; BLOCK_WIDTH] = code_refs[..BLOCK_WIDTH].try_into().unwrap();
         let mut block_scores = vec![0.0; BLOCK_WIDTH];
-        score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+        let isa = score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
+        assert_host_simd_isa(isa);
         for (score, code) in block_scores.iter().zip(code_refs.iter()) {
             let reference = score_int8_approx_scalar(&prepared, dimensions, code);
             assert_eq!(score.to_bits(), reference.to_bits());

--- a/src/quant/int8_approx32/mod.rs
+++ b/src/quant/int8_approx32/mod.rs
@@ -162,7 +162,7 @@ mod tests {
                     .collect(),
                 score_scale: 0.25,
             };
-            let codes: Vec<Vec<u8>> = (0..BLOCK_WIDTH + 5)
+            let codes: Vec<Vec<u8>> = (0..BLOCK_WIDTH + 1)
                 .map(|lane| {
                     (0..dimensions.div_ceil(2))
                         .map(|byte| {
@@ -175,26 +175,42 @@ mod tests {
                 .collect();
             let code_refs: Vec<&[u8]> = codes.iter().map(Vec::as_slice).collect();
 
-            let block: &[&[u8]; BLOCK_WIDTH] = code_refs[..BLOCK_WIDTH].try_into().unwrap();
-            let mut block_scores = vec![0.0; BLOCK_WIDTH];
-            score_int8_approx_block32(&prepared, dimensions, block, &mut block_scores);
-            for (score, code) in block_scores.iter().zip(code_refs[..BLOCK_WIDTH].iter()) {
-                let reference = score_int8_approx_scalar(&prepared, dimensions, code);
-                assert_eq!(score.to_bits(), reference.to_bits());
-            }
-
-            let mut partial_scores = vec![0.0; 5];
-            score_int8_approx_partial(
-                &prepared,
-                dimensions,
-                &code_refs[BLOCK_WIDTH..],
-                &mut partial_scores,
-            );
-            for (score, code) in partial_scores.iter().zip(code_refs[BLOCK_WIDTH..].iter()) {
-                let reference = score_int8_approx_scalar(&prepared, dimensions, code);
-                assert_eq!(score.to_bits(), reference.to_bits());
+            for width in [1usize, 7, 8, 9, 16, 17, 31, 32, 33] {
+                let mut scores = vec![0.0; width];
+                let mut block_start = 0;
+                while block_start + BLOCK_WIDTH <= width {
+                    let block: &[&[u8]; BLOCK_WIDTH] = code_refs
+                        [block_start..block_start + BLOCK_WIDTH]
+                        .try_into()
+                        .unwrap();
+                    score_int8_approx_block32(
+                        &prepared,
+                        dimensions,
+                        block,
+                        &mut scores[block_start..block_start + BLOCK_WIDTH],
+                    );
+                    block_start += BLOCK_WIDTH;
+                }
+                if block_start < width {
+                    score_int8_approx_partial(
+                        &prepared,
+                        dimensions,
+                        &code_refs[block_start..width],
+                        &mut scores[block_start..],
+                    );
+                }
+                for (score, code) in scores.iter().zip(code_refs[..width].iter()) {
+                    let reference = score_int8_approx_scalar(&prepared, dimensions, code);
+                    assert_eq!(score.to_bits(), reference.to_bits());
+                }
             }
         }
+        #[cfg(target_arch = "aarch64")]
+        eprintln!(
+            "task36_int8_approx32 neon={} dotprod={} widths=1,7,8,9,16,17,31,32,33",
+            std::arch::is_aarch64_feature_detected!("neon"),
+            std::arch::is_aarch64_feature_detected!("dotprod")
+        );
     }
 
     /// Full-range i8 operands at the ±128 corner: 128 * 128 pair sums exceed

--- a/src/quant/prod.rs
+++ b/src/quant/prod.rs
@@ -408,6 +408,17 @@ impl ProdQuantizer {
         query: &[f32],
         tile_size: usize,
     ) -> PreparedTiledLutNoQjl4BitQuery {
+        assert_eq!(
+            query.len(),
+            self.original_dim,
+            "query length mismatch: got {}, expected {}",
+            query.len(),
+            self.original_dim
+        );
+        assert!(
+            self.bits == 4 && !qjl_enabled(self.original_dim, self.bits),
+            "explicit LUT query prep requires the no-QJL 4-bit lane"
+        );
         assert!(
             tile_size > 0,
             "tiled LUT query prep requires a positive tile size"
@@ -1839,7 +1850,11 @@ pub fn qjl_code_len(dim: usize) -> usize {
 }
 
 fn build_prepared_query_lut(rotated: &[f32], codebook: &[f32], num_centroids: usize) -> Vec<f32> {
-    debug_assert_eq!(codebook.len(), num_centroids);
+    assert_eq!(
+        codebook.len(),
+        num_centroids,
+        "prepared query LUT codebook length must match the centroid count"
+    );
     let mut lut = vec![0.0_f32; rotated.len() * num_centroids];
 
     if let [c0, c1, c2, c3, c4, c5, c6, c7] = codebook {
@@ -2593,6 +2608,20 @@ mod tests {
         let quantizer = ProdQuantizer::new(32, 4, 42);
         let query = random_unit_vector(32, 23);
         let _ = quantizer.prepare_ip_query_tiled_lut_no_qjl_4bit(&query, 16);
+    }
+
+    #[test]
+    #[should_panic(expected = "query length mismatch")]
+    fn tiled_lut_query_prep_rejects_query_length_mismatch() {
+        let quantizer = ProdQuantizer::new(1536, 4, 42);
+        let query = random_unit_vector(1535, 24);
+        let _ = quantizer.prepare_ip_query_tiled_lut_no_qjl_4bit(&query, 512);
+    }
+
+    #[test]
+    #[should_panic(expected = "prepared query LUT codebook length must match the centroid count")]
+    fn tiled_lut_query_prep_rejects_codebook_centroid_mismatch() {
+        let _ = build_prepared_query_lut(&[1.0, -1.0], &[0.0; 8], 16);
     }
 
     #[test]

--- a/src/quant/qjl32/mod.rs
+++ b/src/quant/qjl32/mod.rs
@@ -76,7 +76,7 @@ pub(crate) fn score_turboquant_qjl_batch(
     codes: &[&[u8]],
     gammas: &[f32],
     out_scores: &mut [f32],
-) -> Result<(), String> {
+) -> Result<Option<crate::quant::isa::Isa>, String> {
     if codes.len() != gammas.len() || codes.len() != out_scores.len() {
         return Err(format!(
             "qjl32 score output count {} does not match code count {} and gamma count {}",
@@ -91,8 +91,9 @@ pub(crate) fn score_turboquant_qjl_batch(
     }
 
     let mut block_start = 0usize;
+    let mut observed_block_isa = None;
     while block_start + BLOCK_WIDTH <= codes.len() {
-        let _ = score_turboquant_qjl_block32(
+        let isa = score_turboquant_qjl_block32(
             quantizer,
             prepared,
             codes[block_start..block_start + BLOCK_WIDTH]
@@ -103,6 +104,13 @@ pub(crate) fn score_turboquant_qjl_batch(
                 .expect("slice length is exactly one block"),
             &mut out_scores[block_start..block_start + BLOCK_WIDTH],
         );
+        if let Some(previous) = observed_block_isa {
+            assert_eq!(
+                previous, isa,
+                "QJL batch changed ISA between blocks in one dispatch"
+            );
+        }
+        observed_block_isa = Some(isa);
         block_start += BLOCK_WIDTH;
     }
 
@@ -113,7 +121,7 @@ pub(crate) fn score_turboquant_qjl_batch(
     {
         *out_score = score_turboquant_qjl_scalar(quantizer, prepared, code, *gamma);
     }
-    Ok(())
+    Ok(observed_block_isa)
 }
 
 pub(crate) fn score_turboquant_qjl_block32(
@@ -241,7 +249,7 @@ mod tests {
     }
 
     #[test]
-    fn qjl32_batch_with_blocks_and_tail_matches_pre_slice_scorer_bits() {
+    fn qjl32_batch_matches_pre_slice_scorer_by_execution_path() {
         let quantizer = crate::quant::prod::ProdQuantizer::new(1024, 4, 42);
         let query = random_unit_vector(1024, 91);
         let prepared = quantizer.prepare_ip_query(&query);
@@ -261,22 +269,45 @@ mod tests {
         let all_code_refs: Vec<&[u8]> = codes.iter().map(Vec::as_slice).collect();
         let all_gammas: Vec<f32> = encoded.iter().map(|encoded| encoded.gamma).collect();
 
+        let mut observed_block_isa = None;
         for width in [1usize, 7, 8, 9, 16, 17, 31, 32, 33] {
             let code_refs = &all_code_refs[..width];
             let gammas = &all_gammas[..width];
             let mut scores = vec![0.0; width];
-            score_turboquant_qjl_batch(&quantizer, &prepared, code_refs, gammas, &mut scores)
-                .unwrap();
+            let block_isa =
+                score_turboquant_qjl_batch(&quantizer, &prepared, code_refs, gammas, &mut scores)
+                    .unwrap();
+            if let Some(isa) = block_isa {
+                if let Some(previous) = observed_block_isa {
+                    assert_eq!(previous, isa);
+                }
+                observed_block_isa = Some(isa);
+            }
 
-            for ((code, gamma), score) in code_refs.iter().zip(gammas.iter()).zip(scores.iter()) {
+            let block_candidate_count = width / BLOCK_WIDTH * BLOCK_WIDTH;
+            for (index, ((code, gamma), score)) in code_refs
+                .iter()
+                .zip(gammas.iter())
+                .zip(scores.iter())
+                .enumerate()
+            {
                 let pre_slice =
                     quantizer.score_ip_from_parts_scalar_reference(&prepared, *gamma, code);
-                assert_close(*score, pre_slice, 4);
+                if index < block_candidate_count && block_isa != Some(Isa::Scalar) {
+                    // SIMD block reductions use a different accumulation order.
+                    assert_close(*score, pre_slice, 4);
+                } else {
+                    // Sub-block widths and the tail after a full block execute
+                    // the scalar reference path and must remain bit-exact.
+                    assert_eq!(score.to_bits(), pre_slice.to_bits());
+                }
             }
         }
         eprintln!(
-            "task36_qjl32 isa={} widths=1,7,8,9,16,17,31,32,33",
-            crate::quant::isa::current_isa().label()
+            "task36_qjl32 observed_block_isa={} scalar_tail=bit-exact widths=1,7,8,9,16,17,31,32,33",
+            observed_block_isa
+                .map(crate::quant::isa::Isa::label)
+                .unwrap_or("not-exercised")
         );
     }
 

--- a/src/quant/qjl32/mod.rs
+++ b/src/quant/qjl32/mod.rs
@@ -104,13 +104,9 @@ pub(crate) fn score_turboquant_qjl_batch(
                 .expect("slice length is exactly one block"),
             &mut out_scores[block_start..block_start + BLOCK_WIDTH],
         );
-        if let Some(previous) = observed_block_isa {
-            assert_eq!(
-                previous, isa,
-                "QJL batch changed ISA between blocks in one dispatch"
-            );
+        if observed_block_isa.is_none() {
+            observed_block_isa = Some(isa);
         }
-        observed_block_isa = Some(isa);
         block_start += BLOCK_WIDTH;
     }
 

--- a/src/quant/qjl32/mod.rs
+++ b/src/quant/qjl32/mod.rs
@@ -245,7 +245,7 @@ mod tests {
         let quantizer = crate::quant::prod::ProdQuantizer::new(1024, 4, 42);
         let query = random_unit_vector(1024, 91);
         let prepared = quantizer.prepare_ip_query(&query);
-        let encoded: Vec<_> = (0..BLOCK_WIDTH + 7)
+        let encoded: Vec<_> = (0..BLOCK_WIDTH + 1)
             .map(|seed| quantizer.encode(&random_unit_vector(1024, seed as u64 + 300)))
             .collect();
         let codes: Vec<Vec<u8>> = encoded
@@ -258,17 +258,26 @@ mod tests {
                 code
             })
             .collect();
-        let code_refs: Vec<&[u8]> = codes.iter().map(Vec::as_slice).collect();
-        let gammas: Vec<f32> = encoded.iter().map(|encoded| encoded.gamma).collect();
-        let mut scores = vec![0.0; code_refs.len()];
+        let all_code_refs: Vec<&[u8]> = codes.iter().map(Vec::as_slice).collect();
+        let all_gammas: Vec<f32> = encoded.iter().map(|encoded| encoded.gamma).collect();
 
-        score_turboquant_qjl_batch(&quantizer, &prepared, &code_refs, &gammas, &mut scores)
-            .unwrap();
+        for width in [1usize, 7, 8, 9, 16, 17, 31, 32, 33] {
+            let code_refs = &all_code_refs[..width];
+            let gammas = &all_gammas[..width];
+            let mut scores = vec![0.0; width];
+            score_turboquant_qjl_batch(&quantizer, &prepared, code_refs, gammas, &mut scores)
+                .unwrap();
 
-        for ((code, gamma), score) in code_refs.iter().zip(gammas.iter()).zip(scores.iter()) {
-            let pre_slice = quantizer.score_ip_from_parts_scalar_reference(&prepared, *gamma, code);
-            assert_eq!(score.to_bits(), pre_slice.to_bits());
+            for ((code, gamma), score) in code_refs.iter().zip(gammas.iter()).zip(scores.iter()) {
+                let pre_slice =
+                    quantizer.score_ip_from_parts_scalar_reference(&prepared, *gamma, code);
+                assert_close(*score, pre_slice, 4);
+            }
         }
+        eprintln!(
+            "task36_qjl32 isa={} widths=1,7,8,9,16,17,31,32,33",
+            crate::quant::isa::current_isa().label()
+        );
     }
 
     #[test]

--- a/src/quant/rabitq.rs
+++ b/src/quant/rabitq.rs
@@ -4807,6 +4807,27 @@ pub(crate) mod bench_api {
             required_features: &[],
             invoke: scalar_sum_query_dequant_for_test,
         },
+        #[cfg(target_arch = "aarch64")]
+        SumQueryDequantKernelForTest {
+            name: "neon_bits1",
+            bits: 1,
+            required_features: &["neon"],
+            invoke: sum_query_dequant_neon_bits1_for_test,
+        },
+        #[cfg(target_arch = "aarch64")]
+        SumQueryDequantKernelForTest {
+            name: "neon_bits4",
+            bits: 4,
+            required_features: &["neon"],
+            invoke: sum_query_dequant_neon_bits4_for_test,
+        },
+        #[cfg(target_arch = "aarch64")]
+        SumQueryDequantKernelForTest {
+            name: "neon_bits8",
+            bits: 8,
+            required_features: &["neon"],
+            invoke: sum_query_dequant_neon_bits8_for_test,
+        },
         #[cfg(target_arch = "x86_64")]
         SumQueryDequantKernelForTest {
             name: "avx512_bits1",
@@ -4873,6 +4894,52 @@ pub(crate) mod bench_api {
             fixture.lut,
             fixture.code,
         ))
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[target_feature(enable = "neon")]
+    unsafe fn sum_query_dequant_neon_bits1_for_test(
+        fixture: &SumQueryDequantFixtureForTest<'_>,
+    ) -> Option<f32> {
+        Some(unsafe {
+            sum_query_dequant_neon_bits1(
+                fixture.query_rotated,
+                fixture.dimensions,
+                fixture.bits1_byte_lut?,
+                fixture.lut,
+                fixture.code,
+            )
+        })
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[target_feature(enable = "neon")]
+    unsafe fn sum_query_dequant_neon_bits4_for_test(
+        fixture: &SumQueryDequantFixtureForTest<'_>,
+    ) -> Option<f32> {
+        Some(unsafe {
+            sum_query_dequant_neon_bits4(
+                fixture.query_rotated,
+                fixture.dimensions,
+                fixture.lut,
+                fixture.code,
+            )
+        })
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[target_feature(enable = "neon")]
+    unsafe fn sum_query_dequant_neon_bits8_for_test(
+        fixture: &SumQueryDequantFixtureForTest<'_>,
+    ) -> Option<f32> {
+        Some(unsafe {
+            sum_query_dequant_neon_bits8(
+                fixture.bits8_query_scale,
+                fixture.bits8_query_offset,
+                fixture.dimensions,
+                fixture.code,
+            )
+        })
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -5074,6 +5141,8 @@ mod tests {
     fn task67_kernel_features_available(features: &[&str]) -> bool {
         features.iter().all(|feature| match *feature {
             "" => true,
+            #[cfg(target_arch = "aarch64")]
+            "neon" => std::arch::is_aarch64_feature_detected!("neon"),
             #[cfg(target_arch = "x86_64")]
             "avx2" => std::arch::is_x86_feature_detected!("avx2"),
             #[cfg(target_arch = "x86_64")]
@@ -5097,6 +5166,13 @@ mod tests {
         assert!(names.contains(&"scalar_bits4"));
         assert!(names.contains(&"scalar_bits8"));
 
+        #[cfg(target_arch = "aarch64")]
+        {
+            assert!(names.contains(&"neon_bits1"));
+            assert!(names.contains(&"neon_bits4"));
+            assert!(names.contains(&"neon_bits8"));
+        }
+
         #[cfg(target_arch = "x86_64")]
         {
             assert!(names.contains(&"avx512_bits1"));
@@ -5114,7 +5190,7 @@ mod tests {
     #[test]
     fn task67_sum_query_dequant_for_test_scaffold_matches_scalar_when_available() {
         for &bits in &[1_usize, 4, 8] {
-            for &dim in &[33_usize, 96] {
+            for &dim in &[7_usize, 8, 9, 31, 32, 33, 96, 384, 1536] {
                 let packed_bytes = (dim * bits).div_ceil(8);
                 let mut code = vec![0_u8; packed_bytes + RABITQ_SCALAR_LEN];
                 for i in 0..dim {
@@ -5150,19 +5226,27 @@ mod tests {
                     .filter(|kernel| kernel.bits == bits)
                 {
                     if !task67_kernel_features_available(kernel.required_features) {
+                        eprintln!(
+                            "task36_rabitq kernel={} bits={} dim={} status=unavailable features={:?}",
+                            kernel.name, bits, dim, kernel.required_features
+                        );
                         continue;
                     }
                     // SAFETY: the feature check above covers the kernel's
                     // declared target features; fixture buffers are sized for
                     // `dim` and the selected bit width.
-                    let Some(actual) = (unsafe { (kernel.invoke)(&fixture) }) else {
-                        continue;
-                    };
+                    let actual = (unsafe { (kernel.invoke)(&fixture) }).unwrap_or_else(|| {
+                        panic!("available kernel {} declined fixture", kernel.name)
+                    });
                     let tol = 1e-4_f32 * scalar.abs().max(1.0);
                     assert!(
                         (scalar - actual).abs() <= tol,
                         "kernel={} bits={bits} dim={dim}: scalar={scalar} actual={actual}",
                         kernel.name
+                    );
+                    eprintln!(
+                        "task36_rabitq kernel={} bits={} dim={} status=exercised",
+                        kernel.name, bits, dim
                     );
                 }
             }

--- a/src/quant/rabitq32/mod.rs
+++ b/src/quant/rabitq32/mod.rs
@@ -572,53 +572,63 @@ mod tests {
         // estimate (`estimate_ip_scalar_only`) under the ADR-076 family
         // envelope, so recall is preserved when IVF routes these widths
         // through the unified driver.
-        for bits in [2_u8, 4] {
-            let dim = 96;
-            let quantizer = RaBitQQuantizer::cached_seeded_srht_bits(dim, 42, bits).unwrap();
-            let query = vector(dim, 7);
-            let prepared = quantizer.prepare_estimator(&query);
-            let code_len = quantizer.code_len();
-            let block_prepared = prepared
-                .bitsn_block_prepared(code_len)
-                .expect("bits=2/4 block prepared should exist");
+        for dim in [384usize, 1536] {
+            for bits in [2_u8, 4] {
+                let quantizer = RaBitQQuantizer::cached_seeded_srht_bits(dim, 42, bits).unwrap();
+                let query = vector(dim, 7);
+                let prepared = quantizer.prepare_estimator(&query);
+                let code_len = quantizer.code_len();
+                let block_prepared = prepared
+                    .bitsn_block_prepared(code_len)
+                    .expect("bits=2/4 block prepared should exist");
+                let codes: Vec<Vec<u8>> = (0..BLOCK_WIDTH + 1)
+                    .map(|seed| {
+                        quantizer
+                            .encode_code(&vector(dim, seed as u64 + 100))
+                            .into_vec()
+                    })
+                    .collect();
+                let code_refs: Vec<&[u8]> = codes.iter().map(Vec::as_slice).collect();
 
-            // 39 candidates = one 32-wide block + a 7-wide partial tail.
-            let codes: Vec<Vec<u8>> = (0..39)
-                .map(|seed| {
-                    quantizer
-                        .encode_code(&vector(dim, seed as u64 + 100))
-                        .into_vec()
-                })
-                .collect();
-            let code_refs: Vec<&[u8]> = codes.iter().map(Vec::as_slice).collect();
+                for width in [1usize, 7, 8, 9, 16, 17, 31, 32, 33] {
+                    let mut scores = vec![0.0_f32; width];
+                    let mut block_start = 0;
+                    while block_start + BLOCK_WIDTH <= width {
+                        let block: [&[u8]; BLOCK_WIDTH] = code_refs
+                            [block_start..block_start + BLOCK_WIDTH]
+                            .try_into()
+                            .expect("block slice has exact width");
+                        let block_isa = super::score_rabitq_bitsn_block32(
+                            block_prepared,
+                            block,
+                            &mut scores[block_start..block_start + BLOCK_WIDTH],
+                        );
+                        assert_eq!(block_isa, multibit_block_isa(), "dim={dim} bits={bits}");
+                        block_start += BLOCK_WIDTH;
+                    }
+                    if block_start < width {
+                        let tail_isa = super::score_rabitq_bitsn_partial(
+                            block_prepared,
+                            &code_refs[block_start..width],
+                            &mut scores[block_start..],
+                        );
+                        assert_eq!(tail_isa, multibit_block_isa(), "dim={dim} bits={bits}");
+                    }
 
-            let mut scores = vec![0.0_f32; codes.len()];
-            let block: [&[u8]; BLOCK_WIDTH] = code_refs[..BLOCK_WIDTH]
-                .try_into()
-                .expect("first 32 codes form one block");
-            let block_isa = super::score_rabitq_bitsn_block32(
-                block_prepared,
-                block,
-                &mut scores[..BLOCK_WIDTH],
-            );
-            super::score_rabitq_bitsn_partial(
-                block_prepared,
-                &code_refs[BLOCK_WIDTH..],
-                &mut scores[BLOCK_WIDTH..],
-            );
-
-            // The block must engage the host SIMD backend, not silently fall to
-            // scalar (NEON on aarch64; AVX2 multi-bit is a follow-up, so x86
-            // grades as scalar for now).
-            let expected_isa = multibit_block_isa();
-            assert_eq!(block_isa, expected_isa, "bits={bits}");
-
-            for (score, code) in scores.iter().zip(code_refs.iter()) {
-                let expected = prepared.estimate_ip_scalar_only(code);
-                let bound = 1e-5_f32 * score.abs().max(expected.abs()).max(1.0);
-                assert!(
-                    (score - expected).abs() <= bound,
-                    "bits={bits} kernel={score} expected={expected}"
+                    for (score, code) in scores.iter().zip(code_refs[..width].iter()) {
+                        let expected = prepared.estimate_ip_scalar_only(code);
+                        let bound = 1e-5_f32 * score.abs().max(expected.abs()).max(1.0);
+                        assert!(
+                            (score - expected).abs() <= bound,
+                            "dim={dim} bits={bits} width={width} kernel={score} expected={expected}"
+                        );
+                    }
+                }
+                eprintln!(
+                    "task36_rabitq32 bits={} dimensions={} isa={} widths=1,7,8,9,16,17,31,32,33",
+                    bits,
+                    dim,
+                    multibit_block_isa().label()
                 );
             }
         }

--- a/tests/simd_diff.rs
+++ b/tests/simd_diff.rs
@@ -164,8 +164,16 @@ proptest! {
 
         let hnsw_scalar = ecaz::bench_api::hnsw_source_inner_product_scalar_reference(&left, &right);
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        if let Some(hnsw_avx2) = ecaz::bench_api::hnsw_source_inner_product_avx2_fma_for_test(&left, &right) {
-            assert_close("hnsw forced avx2 source inner product", hnsw_avx2, hnsw_scalar, 1.0e-4);
+        {
+            let hnsw_avx2 =
+                ecaz::bench_api::hnsw_source_inner_product_avx2_fma_for_test(&left, &right)
+                    .expect("x86 Task 36 lane requires HNSW AVX2+FMA execution");
+            assert_close(
+                "hnsw forced avx2 source inner product",
+                hnsw_avx2,
+                hnsw_scalar,
+                1.0e-4,
+            );
         }
         #[cfg(target_arch = "aarch64")]
         {
@@ -182,8 +190,16 @@ proptest! {
 
         let diskann_scalar = ecaz::bench_api::diskann_source_inner_product_scalar_reference(&left, &right);
         #[cfg(target_arch = "x86_64")]
-        if let Some(diskann_avx2) = ecaz::bench_api::diskann_source_inner_product_avx2_fma_for_test(&left, &right) {
-            assert_close("diskann forced avx2 source inner product", diskann_avx2, diskann_scalar, 1.0e-4);
+        {
+            let diskann_avx2 =
+                ecaz::bench_api::diskann_source_inner_product_avx2_fma_for_test(&left, &right)
+                    .expect("x86 Task 36 lane requires DiskANN AVX2+FMA execution");
+            assert_close(
+                "diskann forced avx2 source inner product",
+                diskann_avx2,
+                diskann_scalar,
+                1.0e-4,
+            );
         }
         #[cfg(target_arch = "aarch64")]
         {
@@ -228,19 +244,19 @@ fn forced_avx2_fma_score_paths_match_scalar_reference_when_available() {
     let prepared = quantizer.prepare_ip_query(&query);
     let codes = code_bytes(&candidate);
 
-    if let Some(avx2) =
-        quantizer.score_ip_from_parts_avx2_fma_for_test(&prepared, candidate.gamma, &codes)
-    {
-        let scalar =
-            quantizer.score_ip_from_parts_scalar_reference(&prepared, candidate.gamma, &codes);
-        assert_close("forced avx2 score_ip_from_parts", avx2, scalar, 1.0e-5);
-    }
+    let avx2 = quantizer
+        .score_ip_from_parts_avx2_fma_for_test(&prepared, candidate.gamma, &codes)
+        .expect("x86 Task 36 lane requires Prod AVX2+FMA execution");
+    let scalar =
+        quantizer.score_ip_from_parts_scalar_reference(&prepared, candidate.gamma, &codes);
+    assert_close("forced avx2 score_ip_from_parts", avx2, scalar, 1.0e-5);
 
     let other = code_bytes(&quantizer.encode(&random_unit_vector(384, 0xC44)));
-    if let Some(avx2) = quantizer.score_ip_codes_lite_avx2_fma_for_test(&codes, &other) {
-        let scalar = quantizer.score_ip_codes_lite_scalar_reference(&codes, &other);
-        assert_close("forced avx2 score_ip_codes_lite", avx2, scalar, 1.0e-5);
-    }
+    let avx2 = quantizer
+        .score_ip_codes_lite_avx2_fma_for_test(&codes, &other)
+        .expect("x86 Task 36 lane requires Prod code-to-code AVX2+FMA execution");
+    let scalar = quantizer.score_ip_codes_lite_scalar_reference(&codes, &other);
+    assert_close("forced avx2 score_ip_codes_lite", avx2, scalar, 1.0e-5);
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -275,16 +291,18 @@ fn forced_avx2_fwht_matches_scalar_reference_when_available() {
         .collect::<Vec<_>>();
     let mut scalar = avx2.clone();
 
-    if ecaz::bench_api::fwht_in_place_avx2_for_test(&mut avx2) {
-        fwht_in_place_scalar_reference(&mut scalar);
-        for (index, (actual, expected)) in avx2.iter().zip(scalar.iter()).enumerate() {
-            assert_close(
-                &format!("forced avx2 fwht lane {index}"),
-                *actual,
-                *expected,
-                1.0e-5,
-            );
-        }
+    assert!(
+        ecaz::bench_api::fwht_in_place_avx2_for_test(&mut avx2),
+        "x86 Task 36 lane requires FWHT AVX2 execution"
+    );
+    fwht_in_place_scalar_reference(&mut scalar);
+    for (index, (actual, expected)) in avx2.iter().zip(scalar.iter()).enumerate() {
+        assert_close(
+            &format!("forced avx2 fwht lane {index}"),
+            *actual,
+            *expected,
+            1.0e-5,
+        );
     }
 }
 

--- a/tests/simd_diff.rs
+++ b/tests/simd_diff.rs
@@ -44,6 +44,43 @@ fn assert_close(label: &str, dispatched: f32, scalar: f32, rel_tol: f32) {
     );
 }
 
+#[test]
+fn host_backend_inventory_is_visible() {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let neon = std::arch::is_aarch64_feature_detected!("neon");
+        let dotprod = std::arch::is_aarch64_feature_detected!("dotprod");
+        let sve = std::arch::is_aarch64_feature_detected!("sve");
+        let sve2 = std::arch::is_aarch64_feature_detected!("sve2");
+        eprintln!(
+            "task36_host arch=aarch64 backend={} neon={} dotprod={} sve={} sve2={} unavailable=x86_avx2_fma,x86_avx512",
+            ecaz::bench_api::simd_backend(),
+            neon,
+            dotprod,
+            sve,
+            sve2
+        );
+        assert!(neon, "aarch64 Task 36 lane requires host-reachable NEON");
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        let avx2 = std::arch::is_x86_feature_detected!("avx2");
+        let fma = std::arch::is_x86_feature_detected!("fma");
+        let avx512f = std::arch::is_x86_feature_detected!("avx512f");
+        eprintln!(
+            "task36_host arch=x86 backend={} avx2={} fma={} avx512f={} unavailable=arm_neon,arm_sve,arm_sve2",
+            ecaz::bench_api::simd_backend(),
+            avx2,
+            fma,
+            avx512f
+        );
+        assert!(
+            avx2 && fma,
+            "x86 Task 36 lane requires host-reachable AVX2+FMA"
+        );
+    }
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(24))]
 
@@ -131,8 +168,16 @@ proptest! {
             assert_close("hnsw forced avx2 source inner product", hnsw_avx2, hnsw_scalar, 1.0e-4);
         }
         #[cfg(target_arch = "aarch64")]
-        if let Some(hnsw_neon) = ecaz::bench_api::hnsw_source_inner_product_neon_for_test(&left, &right) {
-            assert_close("hnsw forced neon source inner product", hnsw_neon, hnsw_scalar, 1.0e-4);
+        {
+            let hnsw_neon =
+                ecaz::bench_api::hnsw_source_inner_product_neon_for_test(&left, &right)
+                    .expect("aarch64 Task 36 lane requires HNSW NEON execution");
+            assert_close(
+                "hnsw forced neon source inner product",
+                hnsw_neon,
+                hnsw_scalar,
+                1.0e-4,
+            );
         }
 
         let diskann_scalar = ecaz::bench_api::diskann_source_inner_product_scalar_reference(&left, &right);
@@ -141,8 +186,16 @@ proptest! {
             assert_close("diskann forced avx2 source inner product", diskann_avx2, diskann_scalar, 1.0e-4);
         }
         #[cfg(target_arch = "aarch64")]
-        if let Some(diskann_neon) = ecaz::bench_api::diskann_source_inner_product_neon_for_test(&left, &right) {
-            assert_close("diskann forced neon source inner product", diskann_neon, diskann_scalar, 1.0e-4);
+        {
+            let diskann_neon =
+                ecaz::bench_api::diskann_source_inner_product_neon_for_test(&left, &right)
+                    .expect("aarch64 Task 36 lane requires DiskANN NEON execution");
+            assert_close(
+                "diskann forced neon source inner product",
+                diskann_neon,
+                diskann_scalar,
+                1.0e-4,
+            );
         }
     }
 }
@@ -199,19 +252,18 @@ fn forced_neon_score_paths_match_scalar_reference_when_available() {
     let prepared = quantizer.prepare_ip_query(&query);
     let codes = code_bytes(&candidate);
 
-    if let Some(neon) =
-        quantizer.score_ip_from_parts_neon_for_test(&prepared, candidate.gamma, &codes)
-    {
-        let scalar =
-            quantizer.score_ip_from_parts_scalar_reference(&prepared, candidate.gamma, &codes);
-        assert_close("forced neon score_ip_from_parts", neon, scalar, 1.0e-5);
-    }
+    let neon = quantizer
+        .score_ip_from_parts_neon_for_test(&prepared, candidate.gamma, &codes)
+        .expect("aarch64 Task 36 lane requires Prod NEON execution");
+    let scalar = quantizer.score_ip_from_parts_scalar_reference(&prepared, candidate.gamma, &codes);
+    assert_close("forced neon score_ip_from_parts", neon, scalar, 1.0e-5);
 
     let other = code_bytes(&quantizer.encode(&random_unit_vector(384, 0xC44)));
-    if let Some(neon) = quantizer.score_ip_codes_lite_neon_for_test(&codes, &other) {
-        let scalar = quantizer.score_ip_codes_lite_scalar_reference(&codes, &other);
-        assert_close("forced neon score_ip_codes_lite", neon, scalar, 1.0e-5);
-    }
+    let neon = quantizer
+        .score_ip_codes_lite_neon_for_test(&codes, &other)
+        .expect("aarch64 Task 36 lane requires Prod code-to-code NEON execution");
+    let scalar = quantizer.score_ip_codes_lite_scalar_reference(&codes, &other);
+    assert_close("forced neon score_ip_codes_lite", neon, scalar, 1.0e-5);
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -245,16 +297,18 @@ fn forced_neon_fwht_matches_scalar_reference_when_available() {
         .collect::<Vec<_>>();
     let mut scalar = neon.clone();
 
-    if ecaz::bench_api::fwht_in_place_neon_for_test(&mut neon) {
-        fwht_in_place_scalar_reference(&mut scalar);
-        for (index, (actual, expected)) in neon.iter().zip(scalar.iter()).enumerate() {
-            assert_close(
-                &format!("forced neon fwht lane {index}"),
-                *actual,
-                *expected,
-                1.0e-5,
-            );
-        }
+    assert!(
+        ecaz::bench_api::fwht_in_place_neon_for_test(&mut neon),
+        "aarch64 Task 36 lane requires FWHT NEON execution"
+    );
+    fwht_in_place_scalar_reference(&mut scalar);
+    for (index, (actual, expected)) in neon.iter().zip(scalar.iter()).enumerate() {
+        assert_close(
+            &format!("forced neon fwht lane {index}"),
+            *actual,
+            *expected,
+            1.0e-5,
+        );
     }
 }
 

--- a/tests/simd_diff.rs
+++ b/tests/simd_diff.rs
@@ -247,8 +247,7 @@ fn forced_avx2_fma_score_paths_match_scalar_reference_when_available() {
     let avx2 = quantizer
         .score_ip_from_parts_avx2_fma_for_test(&prepared, candidate.gamma, &codes)
         .expect("x86 Task 36 lane requires Prod AVX2+FMA execution");
-    let scalar =
-        quantizer.score_ip_from_parts_scalar_reference(&prepared, candidate.gamma, &codes);
+    let scalar = quantizer.score_ip_from_parts_scalar_reference(&prepared, candidate.gamma, &codes);
     assert_close("forced avx2 score_ip_from_parts", avx2, scalar, 1.0e-5);
 
     let other = code_bytes(&quantizer.encode(&random_unit_vector(384, 0xC44)));


### PR DESCRIPTION
## What changed

- expands `make simd-diff` to cover the current quantizer/block-kernel inventory and DistANN composition
- makes every filtered stage fail closed on missing, unexpected, or multiple Cargo test summaries
- pins host-reachable SIMD execution instead of allowing scalar-vs-scalar vacuous passes
- restores tiled-LUT query preparation invariants and regression coverage
- adds production QJL block→octet→scalar cascade differential coverage with path-appropriate exactness/tolerances
- aligns the manual CI job with the authoritative local lane and corrects stale CI/hardware claims
- includes task-scoped review requests, reviewer feedback, and packet-local validation evidence

## Why

Task 36's original differential harness had drifted behind newer SIMD kernel families, and name-filtered Cargo stages could silently pass after losing their tests. Review also found a tiled-LUT guard regression, incomplete ISA assertions, overly broad QJL tolerance wording, and a CI/local-lane mismatch. This branch resolves those findings at the mechanism level.

## Validation

- `make simd-diff` — PASS, all ten counted stages on Apple arm64 NEON + dotprod
- production QJL cascade widths `1/7/8/9/16/17/31/32/33` — PASS
- empty/wrong/multiple-summary negative controls — rejected as designed
- Task 36 packet 004 outside review — APPROVE; all five current-head flags independently reproduced as closed
- focused formatting, shell syntax, and `git diff --check` — PASS
- focused Clippy reaches one unrelated existing `manual_checked_ops` finding in `src/am/ec_ivf/quantizer.rs:695`; no changed Task 36 file is reported

## Scope boundary

This merges the reviewed current Apple/NEON inventory. Intel AVX2/AVX-512 and Graviton SVE/SVE2 execution remain explicitly deferred hardware evidence and are not claimed by this PR.