### PR TITLE
spec: convert obligation-shaped acceptance criteria to assertion form

### DIFF
--- a/spec/functional/common/FR-001-tqvector-data-type-registration.md
+++ b/spec/functional/common/FR-001-tqvector-data-type-registration.md
@@ -71,13 +71,13 @@ For a 1536-dim, 4-bit datum (QJL active, `mse_bits = 3`) the packed wire size is
 | FR-001-AC-3 | Pack/unpack of `(dim, bits, seed, gamma, code_bytes)` round-trips losslessly for all valid parameter combinations | Test |
 
 ### FR-001-AC-1: Type exists after CREATE EXTENSION
-After `CREATE EXTENSION ecaz`, the type `tqvector` SHALL be visible in `pg_type`.
+After `CREATE EXTENSION ecaz`, the type `tqvector` is visible in `pg_type`.
 
 ### FR-001-AC-2: Varlena storage
-Values stored in `tqvector` columns SHALL be TOASTable. A 1536-dim, 4-bit datum SHALL occupy `2 + 4 + 576 + 192 = 774` bytes total: 6-byte datum prefix (`dim` + `gamma`), 768-byte `code_bytes` section (`mse_packed` + `qjl_packed`).
+Values stored in `tqvector` columns are TOASTable. A 1536-dim, 4-bit datum occupies `2 + 4 + 576 + 192 = 774` bytes total: 6-byte datum prefix (`dim` + `gamma`), 768-byte `code_bytes` section (`mse_packed` + `qjl_packed`).
 
 ### FR-001-AC-3: Binary layout correctness
-Pack/unpack of `(dim, bits, seed, gamma, code_bytes)` SHALL round-trip losslessly for all valid parameter combinations.
+Pack/unpack of `(dim, bits, seed, gamma, code_bytes)` round-trips losslessly for all valid parameter combinations.
 
 ## Dependencies
 

--- a/spec/functional/common/FR-002-text-io.md
+++ b/spec/functional/common/FR-002-text-io.md
@@ -64,13 +64,13 @@ The text I/O surface is registered as two `LANGUAGE c` SQL functions in `sql/boo
 | FR-002-AC-3 | Hex length not matching `code_len(dim, bits)` raises ERROR with "code length mismatch" | Test |
 
 ### FR-002-AC-1: Text round-trip
-`tqvector_out(tqvector_in(text))` SHALL produce the canonical form of any valid input text.
+`tqvector_out(tqvector_in(text))` produces the canonical form of any valid input text.
 
 ### FR-002-AC-2: Error on invalid hex
-Input `'[dim=4,bits=4]:ZZZZ'::tqvector` SHALL raise ERROR with a message containing "hex".
+Input `'[dim=4,bits=4]:ZZZZ'::tqvector` raises ERROR with a message containing "hex".
 
 ### FR-002-AC-3: Error on dimension mismatch
-Input with hex length not matching `code_len(dim, bits)` SHALL raise ERROR with "code length mismatch".
+Input with hex length not matching `code_len(dim, bits)` raises ERROR with "code length mismatch".
 
 ## Dependencies
 

--- a/spec/functional/common/FR-003-binary-protocol.md
+++ b/spec/functional/common/FR-003-binary-protocol.md
@@ -40,10 +40,10 @@ The binary protocol surface is registered as two `LANGUAGE c` SQL functions in `
 | FR-003-AC-2 | Binary payloads shorter than `MIN_BINARY_BYTES` (6 bytes) raise ERROR | Test |
 
 ### FR-003-AC-1: Binary round-trip
-`tqvector_recv(tqvector_send(val))` SHALL produce a value identical to `val` for all valid tqvector values.
+`tqvector_recv(tqvector_send(val))` produces a value identical to `val` for all valid tqvector values.
 
 ### FR-003-AC-2: Reject truncated binary
-A binary payload shorter than `MIN_BINARY_BYTES` (6 bytes) SHALL raise ERROR. This threshold covers the 2-byte `dim` descriptor plus the required 4-byte `gamma` field; the trailing `code_bytes` length is validated separately against `code_len(dim, bits)`.
+A binary payload shorter than `MIN_BINARY_BYTES` (6 bytes) raises ERROR. This threshold covers the 2-byte `dim` descriptor plus the required 4-byte `gamma` field; the trailing `code_bytes` length is validated separately against `code_len(dim, bits)`.
 
 ## Dependencies
 

--- a/spec/functional/common/FR-006-sql-operators.md
+++ b/spec/functional/common/FR-006-sql-operators.md
@@ -74,10 +74,10 @@ The operator surface registered in `sql/bootstrap.sql` for the `tqvector` type. 
 | FR-006-AC-3 | `a <#> b` equals `b <#> a` for the `(tqvector, tqvector)` overload | Test |
 
 ### FR-006-AC-1: Operator usable in ORDER BY
-`SELECT * FROM t ORDER BY col <#> $query LIMIT 10` SHALL parse and execute when `$query` is `float4[]`.
+`SELECT * FROM t ORDER BY col <#> $query LIMIT 10` parses and executes when `$query` is `float4[]`.
 
 ### FR-006-AC-2: Index scan chosen
-EXPLAIN of the above query on an indexed table SHALL show an Index Scan using `ec_hnsw`.
+EXPLAIN of the above query on an indexed table shows an Index Scan using `ec_hnsw`.
 
 Current staged behavior:
 - ADR-011 is retired and the live cost model can now select `ec_hnsw` naturally.
@@ -88,7 +88,7 @@ Current staged behavior:
   descriptive-only.
 
 ### FR-006-AC-3: Operator commutativity
-`a <#> b` SHALL equal `b <#> a` for the `(tqvector, tqvector)` overload.
+`a <#> b` equals `b <#> a` for the `(tqvector, tqvector)` overload.
 
 ## Dependencies
 

--- a/spec/functional/common/FR-011-wal-safety.md
+++ b/spec/functional/common/FR-011-wal-safety.md
@@ -63,10 +63,10 @@ flowchart TD
 | FR-011-AC-2 | Code audit confirms no index page is modified without GenericXLog wrapping | Inspection |
 
 ### FR-011-AC-1: Crash recovery
-After building an index, simulating a crash (kill -9), and restarting PostgreSQL, the index SHALL pass `REINDEX` without errors.
+After building an index, simulating a crash (kill -9), and restarting PostgreSQL, the index passes `REINDEX` without errors.
 
 ### FR-011-AC-2: No direct page writes
-A code audit SHALL confirm that no index page is modified without GenericXLog wrapping.
+A code audit confirms that no index page is modified without GenericXLog wrapping.
 
 ## Dependencies
 

--- a/spec/functional/common/FR-012-sql-bootstrap.md
+++ b/spec/functional/common/FR-012-sql-bootstrap.md
@@ -70,13 +70,13 @@ The extension control file (`ecaz.control`) declares the following settings, all
 | FR-012-AC-3 | `cargo pgrx test pg17` and `cargo pgrx test pg18` both pass | Test |
 
 ### FR-012-AC-1: Clean install
-`CREATE EXTENSION ecaz` on a fresh database SHALL succeed without errors.
+`CREATE EXTENSION ecaz` on a fresh database succeeds without errors.
 
 ### FR-012-AC-2: Clean uninstall
-`DROP EXTENSION ecaz CASCADE` SHALL remove all objects without orphans in pg_type, pg_operator, or pg_am.
+`DROP EXTENSION ecaz CASCADE` removes all objects without orphans in pg_type, pg_operator, or pg_am.
 
 ### FR-012-AC-3: Multi-version support
-`cargo pgrx test pg17` and `cargo pgrx test pg18` SHALL both pass.
+`cargo pgrx test pg17` and `cargo pgrx test pg18` both pass.
 
 ## Dependencies
 

--- a/spec/functional/common/FR-019-async-io-read-stream.md
+++ b/spec/functional/common/FR-019-async-io-read-stream.md
@@ -275,19 +275,19 @@ flowchart TD
 | FR-019-AC-5 | On PG18, `count_element_tuples()` uses a sequential ReadStream instead of per-page `ReadBufferExtended` | Inspection |
 
 ### FR-019-AC-1: PG18 scan uses ReadStream
-On PG18, `amgettuple` SHALL NOT call `ReadBufferExtended` directly during the bootstrap or linear scan phases. All page reads SHALL go through `read_stream_next_buffer()`.
+On PG18, `amgettuple` does not call `ReadBufferExtended` directly during the bootstrap or linear scan phases. All page reads go through `read_stream_next_buffer()`.
 
 ### FR-019-AC-2: PG17 fallback unchanged
-On PG17, scan behavior SHALL be identical to the pre-FR-019 implementation. No `read_stream` calls SHALL be present in the compiled binary.
+On PG17, scan behavior is identical to the pre-FR-019 implementation. No `read_stream` calls are present in the compiled binary.
 
 ### FR-019-AC-3: Cold-cache improvement measurable
-On PG18 with `io_method=worker` and `effective_io_concurrency=16`, cold-cache HNSW top-10 query latency SHALL be measurably lower than with `effective_io_concurrency=0` on the same dataset.
+On PG18 with `io_method=worker` and `effective_io_concurrency=16`, cold-cache HNSW top-10 query latency is measurably lower than with `effective_io_concurrency=0` on the same dataset.
 
 ### FR-019-AC-4: No buffer pin leaks
-After `amendscan`, zero buffers from the graph or linear stream SHALL remain pinned. `read_stream_end()` SHALL be called for both streams.
+After `amendscan`, zero buffers from the graph or linear stream remain pinned. `read_stream_end()` is called for both streams.
 
 ### FR-019-AC-5: Vacuum uses streaming reads
-On PG18, `count_element_tuples()` SHALL use a sequential `ReadStream` instead of per-page `ReadBufferExtended`.
+On PG18, `count_element_tuples()` uses a sequential `ReadStream` instead of per-page `ReadBufferExtended`.
 
 ## References
 

--- a/spec/functional/common/FR-020-cost-estimation.md
+++ b/spec/functional/common/FR-020-cost-estimation.md
@@ -169,19 +169,19 @@ flowchart TD
 | FR-020-AC-5 | ADR-011 remains marked superseded and the former blanket prohibitive-cost override is not used for non-empty valid indexes | Inspection |
 
 ### FR-020-AC-1: Planner selects index
-On a 10K-row table with a ec_hnsw index, `EXPLAIN SELECT ... ORDER BY col <#> $q LIMIT 10` SHALL show "Index Scan using ec_hnsw".
+On a 10K-row table with a ec_hnsw index, `EXPLAIN SELECT ... ORDER BY col <#> $q LIMIT 10` shows "Index Scan using ec_hnsw".
 
 ### FR-020-AC-2: Planner prefers seqscan for small tables
 On a 50-row table with a ec_hnsw index, the planner MAY prefer sequential scan (cost model correctly identifies the crossover).
 
 ### FR-020-AC-3: Cost model uses metadata
-The cost model SHALL read `m`, `ef_search`, `dimensions`, and `max_level` from the index metadata page — not use hardcoded defaults.
+The cost model reads `m`, `ef_search`, `dimensions`, and `max_level` from the index metadata page — it does not use hardcoded defaults.
 
 ### FR-020-AC-4: amgettreeheight reports max_level
-On PG18, `amgettreeheight` SHALL return the `max_level` value from the metadata page.
+On PG18, `amgettreeheight` returns the `max_level` value from the metadata page.
 
 ### FR-020-AC-5: ADR-011 superseded
-ADR-011 SHALL remain marked as superseded, and the former blanket prohibitive-cost override SHALL NOT be used for non-empty valid indexes.
+ADR-011 remains marked as superseded, and the former blanket prohibitive-cost override is not used for non-empty valid indexes.
 
 ## References
 

--- a/spec/functional/common/FR-021-parallel-build.md
+++ b/spec/functional/common/FR-021-parallel-build.md
@@ -274,28 +274,28 @@ flowchart TD
 | FR-021-AC-6 | All page writes during the leader's graph serialization phase use GenericXLog | Inspection |
 
 ### FR-021-AC-1: Parallel workers used
-With `max_parallel_maintenance_workers = 4` on a 100K-row table, `CREATE INDEX USING ec_hnsw` SHALL launch parallel workers.
+With `max_parallel_maintenance_workers = 4` on a 100K-row table, `CREATE INDEX USING ec_hnsw` launches parallel workers.
 
 ### FR-021-AC-2: Correctness
-The index produced by parallel build SHALL contain the same indexed heap tuple
+The index produced by parallel build contains the same indexed heap tuple
 set as a serial build on the same data. Concurrent graph assembly is not
-required to be byte-identical to serial topology; it SHALL meet the documented
+required to be byte-identical to serial topology; it meets the documented
 recall gates for the same fixture.
 
 ### FR-021-AC-3: Speedup
-Parallel build with 4 workers SHALL materially improve graph-phase and
+Parallel build with 4 workers materially improves graph-phase and
 wall-clock build time on representative 50k+ fixtures. Packet 666 records the
 first accepted real-50k source-scored result: about `9.20x` wall-clock speedup
 and `10.77x` graph-phase speedup against serial.
 
 ### FR-021-AC-4: Concurrent build
-`CREATE INDEX CONCURRENTLY ... USING ec_hnsw ...` SHALL work correctly with parallel workers.
+`CREATE INDEX CONCURRENTLY ... USING ec_hnsw ...` works correctly with parallel workers.
 
 ### FR-021-AC-5: Small table fallback
-On a 100-row table, the build SHALL fall back to serial execution without launching workers.
+On a 100-row table, the build falls back to serial execution without launching workers.
 
 ### FR-021-AC-6: GenericXLog safety
-All page writes during the leader's graph serialization phase SHALL use GenericXLog, identical to the serial build path.
+All page writes during the leader's graph serialization phase use GenericXLog, identical to the serial build path.
 
 ## References
 

--- a/spec/functional/common/FR-022-vacuum-implementation.md
+++ b/spec/functional/common/FR-022-vacuum-implementation.md
@@ -224,22 +224,22 @@ flowchart TD
 | FR-022-AC-6 | After amvacuumcleanup, `pg_class.reltuples` reflects the live (non-deleted) element count | Test |
 
 ### FR-022-AC-1: Dead rows removed
-After `DELETE FROM t WHERE id = $x; VACUUM t;`, a search query SHALL NOT return the deleted row.
+After `DELETE FROM t WHERE id = $x; VACUUM t;`, a search query does not return the deleted row.
 
 ### FR-022-AC-2: Heap TID removal
-After vacuuming, element tuples SHALL NOT contain heap TIDs that the vacuum callback reported as dead.
+After vacuuming, element tuples do not contain heap TIDs that the vacuum callback reported as dead.
 
 ### FR-022-AC-3: Graph connectivity
-After vacuuming 10% of rows from a 10K-row index (m=8), recall@10 SHALL be ≥ 80% of pre-vacuum recall, measured using NFR-003 methodology.
+After vacuuming 10% of rows from a 10K-row index (m=8), recall@10 is ≥ 80% of pre-vacuum recall, measured using NFR-003 methodology.
 
 ### FR-022-AC-4: Concurrent safety
-Running VACUUM concurrently with INSERT and SELECT for 60 seconds SHALL NOT produce errors, panics, or corrupted results.
+Running VACUUM concurrently with INSERT and SELECT for 60 seconds produces no errors, panics, or corrupted results.
 
 ### FR-022-AC-5: GenericXLog
-Every page write in ambulkdelete SHALL be wrapped in GenericXLog.
+Every page write in ambulkdelete is wrapped in GenericXLog.
 
 ### FR-022-AC-6: Statistics reported
-After `amvacuumcleanup`, `pg_class.reltuples` SHALL reflect the count of live (non-deleted) elements.
+After `amvacuumcleanup`, `pg_class.reltuples` reflects the count of live (non-deleted) elements.
 
 ## References
 

--- a/spec/functional/common/FR-023-strategy-translation.md
+++ b/spec/functional/common/FR-023-strategy-translation.md
@@ -96,16 +96,16 @@ The strategy-translation surface is captured by `StrategyTranslationSnapshot` (`
 | FR-023-AC-4 | Invalid inputs return `COMPARE_INVALID` and `InvalidStrategy` respectively | Test |
 
 ### FR-023-AC-1: Strategy translation registered
-On PG18, the `IndexAmRoutine` returned by `ec_hnsw_handler` SHALL have non-null `amtranslatestrategy` and `amtranslatecmptype` callbacks.
+On PG18, the `IndexAmRoutine` returned by `ec_hnsw_handler` has non-null `amtranslatestrategy` and `amtranslatecmptype` callbacks.
 
 ### FR-023-AC-2: COMPARE_LT mapping
-`amtranslatestrategy(1, opfamily)` SHALL return `COMPARE_LT`.
+`amtranslatestrategy(1, opfamily)` returns `COMPARE_LT`.
 
 ### FR-023-AC-3: Reverse mapping
-`amtranslatecmptype(COMPARE_LT, opfamily)` SHALL return strategy number 1.
+`amtranslatecmptype(COMPARE_LT, opfamily)` returns strategy number 1.
 
 ### FR-023-AC-4: Invalid inputs
-`amtranslatestrategy(99, opfamily)` SHALL return `COMPARE_INVALID`. `amtranslatecmptype(COMPARE_EQ, opfamily)` SHALL return `InvalidStrategy`.
+`amtranslatestrategy(99, opfamily)` returns `COMPARE_INVALID`. `amtranslatecmptype(COMPARE_EQ, opfamily)` returns `InvalidStrategy`.
 
 ## References
 

--- a/spec/functional/common/FR-024-custom-explain.md
+++ b/spec/functional/common/FR-024-custom-explain.md
@@ -171,21 +171,21 @@ flowchart TD
 | FR-024-AC-5 | The per-node hook chains to any previously installed `explain_per_node_hook` | Inspection |
 
 ### FR-024-AC-1: Option recognized
-`EXPLAIN (ecaz) SELECT ...` SHALL parse without error when the extension is loaded.
+`EXPLAIN (ecaz) SELECT ...` parses without error when the extension is loaded.
 
 ### FR-024-AC-2: Stats emitted
 `EXPLAIN (FORMAT JSON, ecaz) SELECT ... ORDER BY col <#> $q LIMIT 10` on a table with an
-`ec_hnsw` index SHALL include a `"Ecaz Stats"` group with all defined counters. Text output
-SHALL still expose the same counter properties even though the group label is not guaranteed there.
+`ec_hnsw` index includes a `"Ecaz Stats"` group with all defined counters. Text output
+still exposes the same counter properties even though the group label is not guaranteed there.
 
 ### FR-024-AC-3: No output when disabled
-`EXPLAIN SELECT ... ORDER BY col <#> $q LIMIT 10` (without `ecaz` option) SHALL NOT include any Ecaz-specific output.
+`EXPLAIN SELECT ... ORDER BY col <#> $q LIMIT 10` (without `ecaz` option) includes no Ecaz-specific output.
 
 ### FR-024-AC-4: ANALYZE shows actuals
-`EXPLAIN (ecaz, ANALYZE) SELECT ...` SHALL show non-zero counter values reflecting actual scan execution.
+`EXPLAIN (ecaz, ANALYZE) SELECT ...` shows non-zero counter values reflecting actual scan execution.
 
 ### FR-024-AC-5: Hook chains
-If another extension has installed an `explain_per_node_hook`, Ecaz's hook SHALL chain to the previous hook after its own processing.
+If another extension has installed an `explain_per_node_hook`, Ecaz's hook chains to the previous hook after its own processing.
 
 ## References
 

--- a/spec/functional/common/FR-025-custom-statistics.md
+++ b/spec/functional/common/FR-025-custom-statistics.md
@@ -131,21 +131,21 @@ The cumulative counters are held in `TqStatsCounters` (`src/am/common/stats.rs`)
 | FR-025-AC-5 | On PG17, `ecaz_stats()` raises an appropriate error or does not exist | Test |
 
 ### FR-025-AC-1: Stats function exists
-On PG18, `SELECT * FROM ecaz_stats()` SHALL return a row with all defined counters.
+On PG18, `SELECT * FROM ecaz_stats()` returns a row with all defined counters.
 
 ### FR-025-AC-2: Counters increment
-After running 10 HNSW scan queries, `total_scans_started` SHALL be ≥ 10 and `total_distance_calcs` SHALL be > 0.
+After running 10 HNSW scan queries, `total_scans_started` is ≥ 10 and `total_distance_calcs` is > 0.
 
 ### FR-025-AC-3: Reset blocker documented
 Until PostgreSQL exposes a reset surface for custom pgstat kinds in this environment, Ecaz
-SHALL document the limitation rather than claim that `pg_stat_reset_shared(text)` can reset the
+documents the limitation rather than claiming that `pg_stat_reset_shared(text)` can reset the
 custom kind directly.
 
 ### FR-025-AC-4: Persistence within session
-Counters SHALL accumulate across queries within a session. They SHALL NOT reset between queries.
+Counters accumulate across queries within a session. They do not reset between queries.
 
 ### FR-025-AC-5: PG17 graceful absence
-On PG17, calling `ecaz_stats()` SHALL raise an appropriate error or the function SHALL not exist.
+On PG17, calling `ecaz_stats()` raises an appropriate error or the function does not exist.
 
 ## References
 

--- a/spec/functional/common/FR-026-pg18-module-identity.md
+++ b/spec/functional/common/FR-026-pg18-module-identity.md
@@ -64,10 +64,10 @@ The module identity declared via `pgrx::pg_module_magic!` in `src/lib.rs` is fix
 
 ### FR-026-AC-1: Module visible
 On PG18, `SELECT module_name, version FROM pg_get_loaded_modules() WHERE module_name = 'ecaz'`
-SHALL return one row with the correct version.
+returns one row with the correct version.
 
 ### FR-026-AC-2: Version matches Cargo.toml
-The reported version SHALL match the `version` field in `Cargo.toml`.
+The reported version matches the `version` field in `Cargo.toml`.
 
 ## References
 

--- a/spec/functional/common/FR-027-pgrx-pg18-upgrade.md
+++ b/spec/functional/common/FR-027-pgrx-pg18-upgrade.md
@@ -113,16 +113,16 @@ The Cargo feature flags in `[features]` of `Cargo.toml` select the PostgreSQL ta
 | FR-027-AC-4 | On PG18, `CREATE EXTENSION ecaz` invokes `_PG_init`, registering the EXPLAIN option and non-preload-blocked diagnostics setup | Test |
 
 ### FR-027-AC-1: PG18 builds
-`cargo pgrx build --features pg18 --release` SHALL succeed.
+`cargo pgrx build --features pg18 --release` succeeds.
 
 ### FR-027-AC-2: PG17 builds
-`cargo pgrx build --features pg17 --release` SHALL succeed with no PG18-specific code compiled.
+`cargo pgrx build --features pg17 --release` succeeds with no PG18-specific code compiled.
 
 ### FR-027-AC-3: Tests pass on both
-`cargo pgrx test pg17` and `cargo pgrx test pg18` SHALL both pass.
+`cargo pgrx test pg17` and `cargo pgrx test pg18` both pass.
 
 ### FR-027-AC-4: _PG_init called
-On PG18, `CREATE EXTENSION ecaz` SHALL invoke `_PG_init`, registering the EXPLAIN option and any PG18 diagnostics setup that is not still blocked on preload-time pgstat wiring.
+On PG18, `CREATE EXTENSION ecaz` invokes `_PG_init`, registering the EXPLAIN option and any PG18 diagnostics setup that is not still blocked on preload-time pgstat wiring.
 
 ## Dependencies
 

--- a/spec/functional/index/hnsw/FR-007-hnsw-page-layout.md
+++ b/spec/functional/index/hnsw/FR-007-hnsw-page-layout.md
@@ -154,19 +154,19 @@ The on-disk layout is composed of one metadata page (`MetadataPage`) plus interl
 | FR-007-AC-5 | Concurrent inserts do not deadlock under stress (10 concurrent inserters for 30 seconds) | Test |
 
 ### FR-007-AC-1: Metadata page readable
-After CREATE INDEX, page 0 SHALL contain valid metadata with the specified M and ef_construction.
+After CREATE INDEX, page 0 contains valid metadata with the specified M and ef_construction.
 
 ### FR-007-AC-2: Element tuple round-trip
-Writing and reading a TqElementTuple to/from a page SHALL preserve all fields.
+Writing and reading a TqElementTuple to/from a page preserves all fields.
 
 ### FR-007-AC-3: Neighbor tuple integrity
-Each element's neighbortid SHALL point to a valid TqNeighborTuple on the same or adjacent page.
+Each element's neighbortid points to a valid TqNeighborTuple on the same or adjacent page.
 
 ### FR-007-AC-4: Page extension works
-Inserting more tuples than fit on a single page SHALL extend the relation without errors.
+Inserting more tuples than fit on a single page extends the relation without errors.
 
 ### FR-007-AC-5: Lock ordering prevents deadlock
-Concurrent inserts SHALL not deadlock (verified by stress test with 10 concurrent inserters for 30 seconds).
+Concurrent inserts do not deadlock (verified by stress test with 10 concurrent inserters for 30 seconds).
 
 ## Dependencies
 

--- a/spec/functional/index/hnsw/FR-008-hnsw-build.md
+++ b/spec/functional/index/hnsw/FR-008-hnsw-build.md
@@ -221,24 +221,24 @@ flowchart TD
 | FR-008-AC-6 | `WITH (m = 0)` raises ERROR; `WITH (m = 8, ef_construction = 64)` succeeds | Test |
 
 ### FR-008-AC-1: Bulk build populates graph
-After `CREATE INDEX ... USING ec_hnsw` on a table with 1000 rows, the index SHALL contain 1000 element tuples.
+After `CREATE INDEX ... USING ec_hnsw` on a table with 1000 rows, the index contains 1000 element tuples.
 
 ### FR-008-AC-2: Crash safety
-If the server crashes during ambuild, the partially-built index SHALL be automatically cleaned up on recovery (standard Postgres behavior for unfinished index builds).
+If the server crashes during ambuild, the partially-built index is automatically cleaned up on recovery (standard Postgres behavior for unfinished index builds).
 
 ### FR-008-AC-3: GenericXLog usage
-Every page modification in ambuild SHALL be wrapped in GenericXLogStart/GenericXLogFinish.
+Every page modification in ambuild is wrapped in GenericXLogStart/GenericXLogFinish.
 
 ### FR-008-AC-4: Two-pass TID correctness
-After ambuild, every neighbor TID in every TqNeighborTuple SHALL point to a valid TqElementTuple.
+After ambuild, every neighbor TID in every TqNeighborTuple points to a valid TqElementTuple.
 
 ### FR-008-AC-5: Build uses f32 distance
-During ambuild in the default build mode, the native graph builder SHALL use
+During ambuild in the default build mode, the native graph builder uses
 f32 inner product distance from a supplied raw-vector source, not compressed
 code distance.
 
 ### FR-008-AC-6: amoptions validation
-`WITH (m = 0)` SHALL raise ERROR. `WITH (m = 8, ef_construction = 64)` SHALL succeed.
+`WITH (m = 0)` raises ERROR. `WITH (m = 8, ef_construction = 64)` succeeds.
 
 ## Dependencies
 

--- a/spec/functional/index/hnsw/FR-009-hnsw-scan.md
+++ b/spec/functional/index/hnsw/FR-009-hnsw-scan.md
@@ -254,22 +254,22 @@ flowchart TD
 | FR-009-AC-6 | Scanning a 50K-row index keeps simultaneously pinned buffers bounded (< 10) | Analysis |
 
 ### FR-009-AC-1: Top-k results returned
-`SELECT id FROM t ORDER BY col <#> $q LIMIT 10` SHALL return exactly 10 rows (given >= 10 rows in the table).
+`SELECT id FROM t ORDER BY col <#> $q LIMIT 10` returns exactly 10 rows (given >= 10 rows in the table).
 
 ### FR-009-AC-2: Results ordered by distance
-Results SHALL be ordered by ascending negative inner product (highest similarity first).
+Results are ordered by ascending negative inner product (highest similarity first).
 
 ### FR-009-AC-3: Index scan used
-EXPLAIN SHALL confirm an Index Scan using `ec_hnsw`, not a sequential scan, when the index exists and the bootstrap-stage planner cost override has been removed.
+EXPLAIN confirms an Index Scan using `ec_hnsw`, not a sequential scan, when the index exists and the bootstrap-stage planner cost override has been removed.
 
 ### FR-009-AC-4: ef_search affects recall
-Higher ef_search values SHALL produce higher recall at the cost of increased latency.
+Higher ef_search values produce higher recall at the cost of increased latency.
 
 ### FR-009-AC-5: GUC is session-settable
-`SET ec_hnsw.ef_search = 200` SHALL succeed and affect subsequent queries in the same session.
+`SET ec_hnsw.ef_search = 200` succeeds and affects subsequent queries in the same session.
 
 ### FR-009-AC-6: No excessive buffer pins
-During a scan of a 50K-row index, the maximum number of simultaneously pinned buffers SHALL be bounded (< 10).
+During a scan of a 50K-row index, the maximum number of simultaneously pinned buffers stays bounded (< 10).
 
 ## Dependencies
 

--- a/spec/functional/index/hnsw/FR-010-hnsw-vacuum.md
+++ b/spec/functional/index/hnsw/FR-010-hnsw-vacuum.md
@@ -73,13 +73,13 @@ flowchart TD
 | FR-010-AC-3 | VACUUM concurrent with INSERT and SELECT for 60 seconds produces no errors, panics, or corrupted results (`ecaz stress vacuum` harness) | Demonstration |
 
 ### FR-010-AC-1: Deleted rows removed from results
-After DELETE + VACUUM, a search SHALL NOT return the deleted row.
+After DELETE + VACUUM, a search does not return the deleted row.
 
 ### FR-010-AC-2: Graph connectivity maintained
-After vacuuming 10% of rows, the remaining rows SHALL still be reachable. Recall SHALL NOT drop below 80% of pre-vacuum recall when measured using the same dataset, query set, ground-truth method, `m`, `ef_construction`, `ef_search`, and reporting conditions required by NFR-003.
+After vacuuming 10% of rows, the remaining rows are still reachable. Recall does not drop below 80% of pre-vacuum recall when measured using the same dataset, query set, ground-truth method, `m`, `ef_construction`, `ef_search`, and reporting conditions required by NFR-003.
 
 ### FR-010-AC-3: No corruption under concurrent load
-Running VACUUM concurrently with INSERT and SELECT for 60 seconds SHALL NOT produce errors, panics, or corrupted results.
+Running VACUUM concurrently with INSERT and SELECT for 60 seconds produces no errors, panics, or corrupted results.
 
 Current validation note:
 - `main` now carries `ecaz stress vacuum`, a CLI harness that runs concurrent

--- a/spec/functional/index/hnsw/FR-016-hnsw-insert.md
+++ b/spec/functional/index/hnsw/FR-016-hnsw-insert.md
@@ -183,13 +183,13 @@ flowchart TD
 | FR-016-AC-4 | Queryable statistics expose total live nodes and nodes inserted since the last bulk build or REINDEX for recall-drift measurement | Test |
 
 ### FR-016-AC-1: Insert updates graph
-After inserting a new row into an indexed table, the new vector SHALL be reachable via HNSW search.
+After inserting a new row into an indexed table, the new vector is reachable via HNSW search.
 
 ### FR-016-AC-2: GenericXLog usage
-Every page modification in aminsert SHALL be wrapped in GenericXLogStart/GenericXLogFinish.
+Every page modification in aminsert is wrapped in GenericXLogStart/GenericXLogFinish.
 
 ### FR-016-AC-3: No deadlock under concurrent insert
-Concurrent inserts SHALL not deadlock when page locks are acquired in the protocol defined by FR-007.
+Concurrent inserts do not deadlock when page locks are acquired in the protocol defined by FR-007.
 
 Current validation note:
 - `main` now closes the lock-ordering and stale-plan retry portion of this requirement for the
@@ -197,7 +197,7 @@ Current validation note:
   runtime follow-up, so A5 should not be read as a throughput proof.
 
 ### FR-016-AC-4: Recall drift is measurable
-The implementation SHALL expose queryable statistics that identify total live nodes and nodes inserted since the last bulk build or REINDEX, so recall drift checkpoints can be measured as incremental inserts accumulate after bulk build.
+The implementation exposes queryable statistics that identify total live nodes and nodes inserted since the last bulk build or REINDEX, so recall drift checkpoints can be measured as incremental inserts accumulate after bulk build.
 
 ## Dependencies
 

--- a/spec/functional/quant/FR-004-encode-to-tqvector.md
+++ b/spec/functional/quant/FR-004-encode-to-tqvector.md
@@ -69,16 +69,16 @@ encode_to_tqvector(real[], integer, bigint) RETURNS tqvector
 | FR-004-AC-4 | Output payload length equals `4 + ceil(original_dim * (bits-1) / 8) + ceil(original_dim / 8)` regardless of transform padding | Test |
 
 ### FR-004-AC-1: Encode produces valid tqvector
-`encode_to_tqvector(ARRAY[1.0, 2.0, 3.0, 4.0]::float4[], 4, 42)` SHALL return a value that can be stored and retrieved from a `tqvector` column.
+`encode_to_tqvector(ARRAY[1.0, 2.0, 3.0, 4.0]::float4[], 4, 42)` returns a value that can be stored and retrieved from a `tqvector` column.
 
 ### FR-004-AC-2: Deterministic output
-Two calls with identical arguments SHALL produce byte-identical results.
+Two calls with identical arguments produce byte-identical results.
 
 ### FR-004-AC-3: Reject invalid bits
-`encode_to_tqvector(ARRAY[1.0]::float4[], 0, 42)` SHALL raise ERROR.
+`encode_to_tqvector(ARRAY[1.0]::float4[], 0, 42)` raises ERROR.
 
 ### FR-004-AC-4: Code length correctness
-The output quantized payload length SHALL equal `4 + ceil(original_dim * (bits-1) / 8) + ceil(original_dim / 8)`. Internal transform padding SHALL NOT change the persisted payload length. The embedded `code_bytes` subsection excludes the 4-byte `gamma` field and therefore has length `ceil(original_dim * (bits-1) / 8) + ceil(original_dim / 8)`.
+The output quantized payload length equals `4 + ceil(original_dim * (bits-1) / 8) + ceil(original_dim / 8)`. Internal transform padding does not change the persisted payload length. The embedded `code_bytes` subsection excludes the 4-byte `gamma` field and therefore has length `ceil(original_dim * (bits-1) / 8) + ceil(original_dim / 8)`.
 
 ## Dependencies
 

--- a/spec/functional/quant/FR-005-code-to-code-inner-product.md
+++ b/spec/functional/quant/FR-005-code-to-code-inner-product.md
@@ -68,13 +68,13 @@ tqvector_inner_product(tqvector, tqvector) RETURNS float4
 | FR-005-AC-3 | `tqvector_inner_product(a, b)` equals `tqvector_inner_product(b, a)` for all valid inputs | Test |
 
 ### FR-005-AC-1: Known-vector code-to-code accuracy
-Given two known 1536-dim vectors encoded at b=4, the code-to-code estimate SHALL be benchmarked against true fp32 inner product using the formulas defined in FR-013 and FR-015.
+Given two known 1536-dim vectors encoded at b=4, the code-to-code estimate is benchmarked against true fp32 inner product using the formulas defined in FR-013 and FR-015.
 
 ### FR-005-AC-2: Dimension mismatch error
-`tqvector_inner_product(v1536, v768)` SHALL raise ERROR containing "mismatch".
+`tqvector_inner_product(v1536, v768)` raises ERROR containing "mismatch".
 
 ### FR-005-AC-3: Symmetry
-`tqvector_inner_product(a, b)` SHALL equal `tqvector_inner_product(b, a)` for all valid inputs.
+`tqvector_inner_product(a, b)` equals `tqvector_inner_product(b, a)` for all valid inputs.
 
 ## Dependencies
 

--- a/spec/functional/quant/FR-013-quantization-pipeline.md
+++ b/spec/functional/quant/FR-013-quantization-pipeline.md
@@ -140,22 +140,22 @@ flowchart TD
 | FR-013-AC-6 | QJL output is exactly `ceil(original_dim / 8)` bytes for any input dimension | Test |
 
 ### FR-013-AC-1: Codebook centroids are symmetric
-For any even number of centroids, the codebook SHALL be symmetric around zero (sum of all centroids < 1e-3).
+For any even number of centroids, the codebook is symmetric around zero (sum of all centroids < 1e-3).
 
 ### FR-013-AC-2: Beta PDF integrates to one
-The Beta PDF for any dimension d >= 2 SHALL integrate to 1.0 ± 0.001 over [-1, 1].
+The Beta PDF for any dimension d >= 2 integrates to 1.0 ± 0.001 over [-1, 1].
 
 ### FR-013-AC-3: SRHT rotation preserves norm
 `||SRHT(v)|| == ||v||` within floating-point tolerance (< 1e-5 relative error).
 
 ### FR-013-AC-4: Encode-decode round-trip fidelity
-For 1536-dim 4-bit encoding, the cosine similarity between the original and decoded vector SHALL be > 0.85 on average over random unit vectors.
+For 1536-dim 4-bit encoding, the cosine similarity between the original and decoded vector is > 0.85 on average over random unit vectors.
 
 ### FR-013-AC-5: Deterministic encoding
-Encoding the same vector with the same `(bits, seed)` SHALL produce byte-identical codes.
+Encoding the same vector with the same `(bits, seed)` produces byte-identical codes.
 
 ### FR-013-AC-6: QJL bit count correctness
-The QJL output SHALL be exactly `ceil(original_dim / 8)` bytes for any input dimension.
+The QJL output is exactly `ceil(original_dim / 8)` bytes for any input dimension.
 
 ## Dependencies
 

--- a/spec/functional/quant/FR-014-simd-acceleration.md
+++ b/spec/functional/quant/FR-014-simd-acceleration.md
@@ -129,25 +129,25 @@ flowchart TD
 
 ### FR-014-AC-1: Scalar fallback correctness
 On a CPU without a family-supported SIMD ISA, every quantized scoring path
-SHALL produce correct results using scalar fallback.
+produces correct results using scalar fallback.
 
 ### FR-014-AC-2: SIMD-scalar equivalence
-Each accelerated family SHALL prove scalar/SIMD equivalence under its accepted
-anchor mode and SHALL preserve recall in benchmark cells used for acceptance.
+Each accelerated family proves scalar/SIMD equivalence under its accepted
+anchor mode and preserves recall in benchmark cells used for acceptance.
 
 ### FR-014-AC-3: No SIGILL on unsupported CPU
-Running the extension on a CPU without AVX2, NEON, SVE, or SVE2 support SHALL
-NOT produce an illegal instruction fault.
+Running the extension on a CPU without AVX2, NEON, SVE, or SVE2 support does
+not produce an illegal instruction fault.
 
 ### FR-014-AC-4: Counter attribution
 
-Accepted benchmark evidence SHALL include `(surface, quant_kind, isa)` rows
+Accepted benchmark evidence includes `(surface, quant_kind, isa)` rows
 with kernel/scalar counters and width buckets for any claimed block-kernel
 latency or coverage result.
 
 ### FR-014-AC-5: Completeness matrix
 
-The project-level Task 99 matrix SHALL identify every shipped
+The project-level Task 99 matrix identifies every shipped
 `(AM, quant, ISA)` cell as complete, partial, missing-kernel, structurally
 absent, or deferred, with source packets for measured claims.
 

--- a/spec/functional/quant/FR-015-prodquantizer.md
+++ b/spec/functional/quant/FR-015-prodquantizer.md
@@ -211,34 +211,34 @@ after construction and fully derived from `(original_dim, bits, seed)`:
 | FR-015-AC-10 | Index-local adapters preserve deterministic scalar scoring, route batches through `QuantCodec`, and keep AM code off ISA-specific kernel functions | Inspection |
 
 ### FR-015-AC-1: Encode produces correct code length
-`ProdQuantizer::new(1536, 4, 42).encode(&vec)` SHALL produce a quantized payload of exactly 772 bytes, consisting of 4-byte `gamma`, 576-byte `mse_packed`, and 192-byte `qjl_packed`.
+`ProdQuantizer::new(1536, 4, 42).encode(&vec)` produces a quantized payload of exactly 772 bytes, consisting of 4-byte `gamma`, 576-byte `mse_packed`, and 192-byte `qjl_packed`.
 
 ### FR-015-AC-2: Encode + decode round-trip
-Decode(encode(v)) SHALL have cosine similarity > 0.85 with v on average over a fixed-seed sample of 100 random 1536-dim unit vectors.
+Decode(encode(v)) has cosine similarity > 0.85 with v on average over a fixed-seed sample of 100 random 1536-dim unit vectors.
 
 ### FR-015-AC-3: Prepared-query scoring matches the declared formula
-`score_ip_encoded` with a prepared query SHALL match the formula declared in FR-013 within floating-point tolerance.
+`score_ip_encoded` with a prepared query matches the formula declared in FR-013 within floating-point tolerance.
 
 ### FR-015-AC-4: Code-to-code scoring is symmetric
 `score_ip_encoded_lite(a, b) == score_ip_encoded_lite(b, a)` for all valid inputs.
 
 ### FR-015-AC-5: Pack/unpack round-trip
-pack then unpack of MSE indices SHALL be lossless for all bit widths 1–7.
+pack then unpack of MSE indices is lossless for all bit widths 1–7.
 
 ### FR-015-AC-6: Deterministic construction
-Two `ProdQuantizer::new(1536, 4, 42)` instances SHALL produce identical codebooks and sign vectors.
+Two `ProdQuantizer::new(1536, 4, 42)` instances produce identical codebooks and sign vectors.
 
 ### FR-015-AC-7: Zero allocation in score_ip_encoded
-Repeated calls to `score_ip_encoded` with the same LUT SHALL not allocate heap memory (verified by benchmarking).
+Repeated calls to `score_ip_encoded` with the same LUT do not allocate heap memory (verified by benchmarking).
 
 ### FR-015-AC-8: Backend-local cache reuse
-Repeated construction requests for the same `(original_dim, bits, seed)` within a backend SHALL reuse cached immutable quantizer state.
+Repeated construction requests for the same `(original_dim, bits, seed)` within a backend reuse cached immutable quantizer state.
 
 ### FR-015-AC-9: Code-to-code scorer ignores QJL in v0.1
-Altering only `gamma` and QJL bits while keeping MSE indices fixed SHALL NOT change `score_ip_encoded_lite`.
+Altering only `gamma` and QJL bits while keeping MSE indices fixed does not change `score_ip_encoded_lite`.
 
 ### FR-015-AC-10: QuantCodec adapter boundary
-Index-local TurboQuant adapters SHALL preserve deterministic scalar scoring,
+Index-local TurboQuant adapters preserve deterministic scalar scoring,
 route scan-time candidate batches through `QuantCodec`, and keep AM code from
 calling ISA-specific TurboQuant kernel functions directly.
 

--- a/spec/functional/quant/FR-017-prepared-query-inner-product.md
+++ b/spec/functional/quant/FR-017-prepared-query-inner-product.md
@@ -110,16 +110,16 @@ tqvector_query_inner_product(tqvector, real[]) RETURNS float4
 | FR-017-AC-4 | The LUT for 1536-dim 4-bit occupies <= 48 KB | Analysis |
 
 ### FR-017-AC-1: Known-vector query-to-code accuracy
-Given a known 1536-dim raw query vector and a known encoded candidate at b=4, the query-to-code estimate SHALL be benchmarked against true fp32 inner product using the formulas defined in FR-013 and FR-015.
+Given a known 1536-dim raw query vector and a known encoded candidate at b=4, the query-to-code estimate is benchmarked against true fp32 inner product using the formulas defined in FR-013 and FR-015.
 
 ### FR-017-AC-2: Dimension mismatch error
-`tqvector_query_inner_product(v1536, q768)` SHALL raise ERROR containing "mismatch".
+`tqvector_query_inner_product(v1536, q768)` raises ERROR containing "mismatch".
 
 ### FR-017-AC-3: Zero allocation in prepared-query hot path
-After prepared-query setup, `score_ip_encoded` SHALL not allocate heap memory (verified by benchmarking, no per-call Vec or Box).
+After prepared-query setup, `score_ip_encoded` does not allocate heap memory (verified by benchmarking, no per-call Vec or Box).
 
 ### FR-017-AC-4: LUT memory footprint
-The LUT for 1536-dim 4-bit SHALL occupy <= 48 KB.
+The LUT for 1536-dim 4-bit occupies <= 48 KB.
 
 ## Dependencies
 

--- a/spec/functional/quant/FR-018-negative-inner-product-wrappers.md
+++ b/spec/functional/quant/FR-018-negative-inner-product-wrappers.md
@@ -58,10 +58,10 @@ tqvector_negative_query_inner_product(tqvector, real[]) RETURNS float4
 | FR-018-AC-2 | `tqvector_negative_query_inner_product(candidate, query)` equals `-1 * tqvector_query_inner_product(candidate, query)` for any valid inputs | Test |
 
 ### FR-018-AC-1: Negative code-to-code wrapper correctness
-For any valid inputs `a` and `b`, `tqvector_negative_inner_product(a, b)` SHALL equal `-1 * tqvector_inner_product(a, b)`.
+For any valid inputs `a` and `b`, `tqvector_negative_inner_product(a, b)` equals `-1 * tqvector_inner_product(a, b)`.
 
 ### FR-018-AC-2: Negative query wrapper correctness
-For any valid encoded candidate and raw query, `tqvector_negative_query_inner_product(candidate, query)` SHALL equal `-1 * tqvector_query_inner_product(candidate, query)`.
+For any valid encoded candidate and raw query, `tqvector_negative_query_inner_product(candidate, query)` equals `-1 * tqvector_query_inner_product(candidate, query)`.
 
 ## Dependencies
 

--- a/spec/non-functional/NFR-007-benchmark-provenance.md
+++ b/spec/non-functional/NFR-007-benchmark-provenance.md
@@ -57,7 +57,7 @@ Every benchmark row in `docs/benchmarks.md` cites a source packet under `benchma
 
 ### NFR-007-AC-2
 
-Benchmark packets used for measurement claims include `manifest.md` and packet-local raw logs under `benchmarks/<topic>/artifacts/`. Code-review packets that cite benchmark evidence SHALL link to the owning `benchmarks/<topic>/` packet.
+Benchmark packets used for measurement claims include `manifest.md` and packet-local raw logs under `benchmarks/<topic>/artifacts/`. Code-review packets that cite benchmark evidence link to the owning `benchmarks/<topic>/` packet.
 
 ### NFR-007-AC-3
 

--- a/spec/non-functional/NFR-012-cloud-throughput-targets.md
+++ b/spec/non-functional/NFR-012-cloud-throughput-targets.md
@@ -111,11 +111,11 @@ recording `single_row_per_sec`, `copy_rows_per_sec`, `wal_bytes_per_sec`.
 ### NFR-012-AC-3
 
 When more than one profile run's artifacts exist in S3, the harness
-SHALL emit a `comparison.md` cross-tabulating QPS and write
+emits a `comparison.md` cross-tabulating QPS and write
 throughput against targets above.
 
 ### NFR-012-AC-4
 
-Distributed runs SHALL emit `coordinator_overhead_ms` (libpq
+Distributed runs emit `coordinator_overhead_ms` (libpq
 round-trip + merge) as a separate field in `read_qps.json` so the
 "sharding wins?" question is answerable from artifacts alone.


### PR DESCRIPTION
Closes #60. Umbrella: agent-ix/quire-rs#17.

## Scope correction first

This issue was scoped at **2,413 cells**. That number counted ecaz's 23 worktree checkouts as separate repos — `ac_corpus_sweep.py` never deduped them (fixed in agent-ix/quire-rs#30). The real figure in `spec/` is **127**, which is what this PR converts. Full derivation in the issue comment.

## What changed

CR-013 made the assertion the single canonical shape: the owning requirement states the obligation, the criterion states what is observed.

The `| ID | Criteria | Verification |` **table rows were already canonical.** The obligations lived in the `### FR-XXX-AC-N:` expansion prose beneath them, which restated each criterion with SHALL. Only that prose changed.

```
before:  `WITH (m = 0)` SHALL raise ERROR
after:   `WITH (m = 0)` raises ERROR

before:  After DELETE + VACUUM, a search SHALL NOT return the deleted row.
after:   After DELETE + VACUUM, a search does not return the deleted row.
```

## Meaning preservation

Every expansion already had a canonical table row asserting the same claim, so the intended assertion was never ambiguous — this is the rewrite the table already specified.

The diff is **120 insertions / 120 deletions across 29 files**: strictly line-for-line. No criterion added, dropped, split, or merged. The sweep counts **414 AC cells before and after**.

## Measurement

`quire-rs/scripts/ac_corpus_sweep.py --root <this worktree>`:

| check | before | after |
|---|---|---|
| `ac:non-canonical-shape` | 127 | **0** |
| `ac:non-singular` | 4 | **0** |

`non-singular` cleared as a side effect — those cells were "X SHALL … and SHALL …" pairs that read as single assertions once de-obligated.

## Validation

27 of 29 documents validate clean through `quire.validate_document` against `spec-artifacts-iso`.

`NFR-007` and `NFR-012` do not: they author `## Acceptance Criteria` as prose rather than the now-required table. **They fail identically at HEAD before this change** — that is spec-artifacts-iso#11 (B3) scope, not this sweep's. Verified explicitly rather than assumed.

## Not in scope

The remaining ecaz findings are `ears:*` checks on requirement statements plus 3 `ac:vague-response` and 2 `ac:unclassifiable`. Different checks, different tickets.