### PR TITLE
spec: convert bullet-list Validation Criteria to the asserted table

### DIFF
--- a/spec/stakeholder/StR-001-native-compressed-vector-storage.md
+++ b/spec/stakeholder/StR-001-native-compressed-vector-storage.md
@@ -28,6 +28,10 @@ A PostgreSQL extension SHALL provide a native data type that stores TurboQuant-c
 
 ## Validation Criteria
 
-- 1M vectors at 1536-dim, 4-bit stored in < 1GB of index space
-- ANN queries return results via standard SQL (ORDER BY ... <#> ... LIMIT k)
-- Extension installable via `CREATE EXTENSION ecaz` on PostgreSQL 18, with PostgreSQL 17 retained as a compatibility fallback
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-001-VC-1 | 1M vectors at 1536-dim, 4-bit stored in < 1GB of index space. | Demonstration |
+| StR-001-VC-2 | ANN queries return results via standard SQL (ORDER BY ... <#> ... LIMIT k). | Demonstration |
+| StR-001-VC-3 | Extension installable via `CREATE EXTENSION ecaz` on PostgreSQL 18, with PostgreSQL 17 retained as a compatibility fallback. | Demonstration |
+

--- a/spec/stakeholder/StR-002-mit-license.md
+++ b/spec/stakeholder/StR-002-mit-license.md
@@ -24,5 +24,9 @@ The `tqvector` extension SHALL be MIT licensed and fully owned by Agent-IX. It S
 
 ## Validation Criteria
 
-- LICENSE file declares MIT
-- `cargo deny check licenses` passes with no copyleft violations
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-002-VC-1 | LICENSE file declares MIT. | Demonstration |
+| StR-002-VC-2 | `cargo deny check licenses` passes with no copyleft violations. | Demonstration |
+

--- a/spec/stakeholder/StR-003-per-agent-isolation.md
+++ b/spec/stakeholder/StR-003-per-agent-isolation.md
@@ -24,5 +24,9 @@ The HNSW index access method SHALL operate correctly on partitioned tables. A qu
 
 ## Validation Criteria
 
-- HNSW index per partition operates independently
-- INSERT/SCAN/VACUUM on one partition does not touch other partitions' index pages
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-003-VC-1 | HNSW index per partition operates independently. | Demonstration |
+| StR-003-VC-2 | INSERT/SCAN/VACUUM on one partition does not touch other partitions' index pages. | Demonstration |
+

--- a/spec/stakeholder/StR-004-pg18-performance-and-planner-integration.md
+++ b/spec/stakeholder/StR-004-pg18-performance-and-planner-integration.md
@@ -39,8 +39,12 @@ The extension SHALL:
 
 ## Validation Criteria
 
-- PG18 is the default build target and PG17 remains a compatibility fallback.
-- Planner selection, strategy translation, and EXPLAIN diagnostics are live for the implemented access-method surfaces.
-- `ecaz_stats()` is live, with shared pgstat behavior available through preload configuration.
-- Parallel HNSW build has landed locally; larger-scale speedup claims are deferred to AWS/RDS-class hardware.
-- Parallel index scan is marked shelved, not an active blocker.
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-004-VC-1 | PG18 is the default build target and PG17 remains a compatibility fallback. | Demonstration |
+| StR-004-VC-2 | Planner selection, strategy translation, and EXPLAIN diagnostics are live for the implemented access-method surfaces. | Demonstration |
+| StR-004-VC-3 | `ecaz_stats()` is live, with shared pgstat behavior available through preload configuration. | Demonstration |
+| StR-004-VC-4 | Parallel HNSW build has landed locally; larger-scale speedup claims are deferred to AWS/RDS-class hardware. | Demonstration |
+| StR-004-VC-5 | Parallel index scan is marked shelved, not an active blocker. | Demonstration |
+


### PR DESCRIPTION
agent-ix/spec-artifacts-iso#11. Each bullet becomes one row with its text preserved **verbatim**; only the `Validation` method is new, derived from what the criterion describes.

**Partial** — this repo also has StR documents whose Validation Criteria are a prose *paragraph* rather than a list. Splitting a paragraph into rows risks changing what is claimed, so those are left for a separate pass rather than automated here.

No criterion is added, dropped, split or reworded.