### PR TITLE
spec: convert numbered and `### <ID>` criteria blocks to the asserted tables

### DIFF
--- a/spec/non-functional/NFR-004-safety-and-stability.md
+++ b/spec/non-functional/NFR-004-safety-and-stability.md
@@ -169,28 +169,12 @@ completed evidence.
 
 ## Acceptance Criteria
 
-### NFR-004-AC-1
 
-`docs/hardening.md` documents every Task 34 hardening lane, its command, its
-tool prerequisites, and whether the lane is local, nightly, PG18/live-cluster,
-or standalone/report-only.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-004-AC-1 | `docs/hardening.md` documents every Task 34 hardening lane, its command, its tool prerequisites, and whether the lane is local, nightly, PG18/live-cluster, or standalone/report-only. | Demonstration |
+| NFR-004-AC-2 | `make hardening-local` runs the stable local hardening subset without requiring a live PostgreSQL cluster. | Demonstration |
+| NFR-004-AC-3 | `make hardening-nightly-local` runs the toolchain-sensitive local lanes or skips unsupported platform-specific sanitizer lanes with an explicit message. | Demonstration |
+| NFR-004-AC-4 | The review packet for a hardening-lane change stores raw tool logs and records which lanes passed, skipped, or remain manually gated. | Inspection |
+| NFR-004-AC-5 | New unsafe blocks require nearby `SAFETY` comments, and the unsafe audit baseline detects new uncommented unsafe lines. | Inspection |
 
-### NFR-004-AC-2
-
-`make hardening-local` runs the stable local hardening subset without requiring
-a live PostgreSQL cluster.
-
-### NFR-004-AC-3
-
-`make hardening-nightly-local` runs the toolchain-sensitive local lanes or
-skips unsupported platform-specific sanitizer lanes with an explicit message.
-
-### NFR-004-AC-4
-
-The review packet for a hardening-lane change stores raw tool logs and records
-which lanes passed, skipped, or remain manually gated.
-
-### NFR-004-AC-5
-
-New unsafe blocks require nearby `SAFETY` comments, and the unsafe audit
-baseline detects new uncommented unsafe lines.

--- a/spec/non-functional/NFR-007-benchmark-provenance.md
+++ b/spec/non-functional/NFR-007-benchmark-provenance.md
@@ -51,20 +51,11 @@ unevidenced performance requirements complete.
 
 ## Acceptance Criteria
 
-### NFR-007-AC-1
 
-Every benchmark row in `docs/benchmarks.md` cites a source packet under `benchmarks/<topic>/` (or a code-review packet under `reviews/task-{id}/{ordinal}-<topic>/`) or clearly states that the evidence is historical/local.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-007-AC-1 | Every benchmark row in `docs/benchmarks.md` cites a source packet under `benchmarks/<topic>/` (or a code-review packet under `reviews/task-{id}/{ordinal}-<topic>/`) or clearly states that the evidence is historical/local. | Analysis |
+| NFR-007-AC-2 | Benchmark packets used for measurement claims include `manifest.md` and packet-local raw logs under `benchmarks/<topic>/artifacts/`. Code-review packets that cite benchmark evidence link to the owning `benchmarks/<topic>/` packet. | Analysis |
+| NFR-007-AC-3 | `spec/tests.md` records measurement gaps rather than marking unevidenced performance requirements complete. | Inspection |
+| NFR-007-AC-4 | Latency and recall benchmark packets cite either a suite manifest backend profile field or an equivalent packet-local artifact proving the measured backend build profile. | Analysis |
 
-### NFR-007-AC-2
-
-Benchmark packets used for measurement claims include `manifest.md` and packet-local raw logs under `benchmarks/<topic>/artifacts/`. Code-review packets that cite benchmark evidence link to the owning `benchmarks/<topic>/` packet.
-
-### NFR-007-AC-3
-
-`spec/tests.md` records measurement gaps rather than marking unevidenced performance requirements complete.
-
-### NFR-007-AC-4
-
-Latency and recall benchmark packets cite either a suite manifest backend
-profile field or an equivalent packet-local artifact proving the measured
-backend build profile.

--- a/spec/non-functional/NFR-008-scale-boundary.md
+++ b/spec/non-functional/NFR-008-scale-boundary.md
@@ -39,14 +39,10 @@ rather than as an unfinished blocker for landed local implementation tasks.
 
 ## Acceptance Criteria
 
-### NFR-008-AC-1
 
-Docs/specs identify local IVF and DiskANN results as local evidence.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-008-AC-1 | Docs/specs identify local IVF and DiskANN results as local evidence. | Demonstration |
+| NFR-008-AC-2 | Specs do not list parallel index scan as active work. | Demonstration |
+| NFR-008-AC-3 | Future AWS/RDS-scale work is tracked as deferred measurement, not as an unfinished blocker for landed local implementation tasks. | Demonstration |
 
-### NFR-008-AC-2
-
-Specs do not list parallel index scan as active work.
-
-### NFR-008-AC-3
-
-Future AWS/RDS-scale work is tracked as deferred measurement, not as an unfinished blocker for landed local implementation tasks.

--- a/spec/non-functional/NFR-009-cli-drift-and-artifact-discipline.md
+++ b/spec/non-functional/NFR-009-cli-drift-and-artifact-discipline.md
@@ -45,14 +45,10 @@ functional requirement, and drift discipline to a validation case.
 
 ## Acceptance Criteria
 
-### NFR-009-AC-1
 
-Docs expose the current CLI command tree and link from the README, usage guide, getting-started guide, and benchmark docs.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-009-AC-1 | Docs expose the current CLI command tree and link from the README, usage guide, getting-started guide, and benchmark docs. | Analysis |
+| NFR-009-AC-2 | The test matrix traces the CLI user story, functional requirement, and drift discipline to a validation case. | Test |
+| NFR-009-AC-3 | Benchmark docs instruct operators to use packet-local CLI logs for review evidence. | Analysis |
 
-### NFR-009-AC-2
-
-The test matrix traces the CLI user story, functional requirement, and drift discipline to a validation case.
-
-### NFR-009-AC-3
-
-Benchmark docs instruct operators to use packet-local CLI logs for review evidence.

--- a/spec/non-functional/NFR-010-cloud-cost-discipline.md
+++ b/spec/non-functional/NFR-010-cloud-cost-discipline.md
@@ -69,22 +69,11 @@ lifecycle rule.
 
 ## Acceptance Criteria
 
-### NFR-010-AC-1
 
-A teardown of any profile via `ecaz cloud down` followed by
-`ecaz cloud status` reports zero compute resources and only the
-intentionally-retained snapshot/bucket.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-010-AC-1 | A teardown of any profile via `ecaz cloud down` followed by `ecaz cloud status` reports zero compute resources and only the intentionally-retained snapshot/bucket. | Demonstration |
+| NFR-010-AC-2 | `ecaz cloud status --json` includes `estimated_hourly_usd` and `retained_monthly_usd` fields with non-null numeric values. | Demonstration |
+| NFR-010-AC-3 | A profile larger than `dev` cannot be `up`'d without `--confirm-cost <usd>` matching the projected daily cost. | Demonstration |
+| NFR-010-AC-4 | Terraform plan for any profile contains zero NAT gateway resources. | Demonstration |
 
-### NFR-010-AC-2
-
-`ecaz cloud status --json` includes `estimated_hourly_usd` and
-`retained_monthly_usd` fields with non-null numeric values.
-
-### NFR-010-AC-3
-
-A profile larger than `dev` cannot be `up`'d without
-`--confirm-cost <usd>` matching the projected daily cost.
-
-### NFR-010-AC-4
-
-Terraform plan for any profile contains zero NAT gateway resources.

--- a/spec/non-functional/NFR-011-cloud-load-throughput.md
+++ b/spec/non-functional/NFR-011-cloud-load-throughput.md
@@ -66,18 +66,10 @@ suite run.
 
 ## Acceptance Criteria
 
-### NFR-011-AC-1
 
-The `dev`-profile load completes within the target wall time on
-the first end-to-end smoke run.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-011-AC-1 | The `dev`-profile load completes within the target wall time on the first end-to-end smoke run. | Analysis |
+| NFR-011-AC-2 | `corpus load` artifacts include a `throughput.json` recording `rows`, `bytes`, `wall_seconds`, `rows_per_sec`, `bytes_per_sec`, and `worker_count`. | Analysis |
+| NFR-011-AC-3 | Throughput artifacts are uploaded to the profile's S3 bucket under `bench-artifacts/<run-id>/load/`. | Analysis |
 
-### NFR-011-AC-2
-
-`corpus load` artifacts include a `throughput.json` recording
-`rows`, `bytes`, `wall_seconds`, `rows_per_sec`, `bytes_per_sec`,
-and `worker_count`.
-
-### NFR-011-AC-3
-
-Throughput artifacts are uploaded to the profile's S3 bucket under
-`bench-artifacts/<run-id>/load/`.

--- a/spec/non-functional/NFR-012-cloud-throughput-targets.md
+++ b/spec/non-functional/NFR-012-cloud-throughput-targets.md
@@ -98,24 +98,11 @@ separately as `qps_high_recall`.
 
 ## Acceptance Criteria
 
-### NFR-012-AC-1
 
-`ecaz cloud bench` artifacts include `read_qps.json` recording
-`p50_us`, `p99_us`, `qps`, `nprobe`, `concurrency`, `cache_state`.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-012-AC-1 | `ecaz cloud bench` artifacts include `read_qps.json` recording `p50_us`, `p99_us`, `qps`, `nprobe`, `concurrency`, `cache_state`. | Demonstration |
+| NFR-012-AC-2 | `ecaz cloud bench` artifacts include `write_throughput.json` recording `single_row_per_sec`, `copy_rows_per_sec`, `wal_bytes_per_sec`. | Demonstration |
+| NFR-012-AC-3 | When more than one profile run's artifacts exist in S3, the harness emits a `comparison.md` cross-tabulating QPS and write throughput against targets above. | Analysis |
+| NFR-012-AC-4 | Distributed runs emit `coordinator_overhead_ms` (libpq round-trip + merge) as a separate field in `read_qps.json` so the "sharding wins?" question is answerable from artifacts alone. | Inspection |
 
-### NFR-012-AC-2
-
-`ecaz cloud bench` artifacts include `write_throughput.json`
-recording `single_row_per_sec`, `copy_rows_per_sec`, `wal_bytes_per_sec`.
-
-### NFR-012-AC-3
-
-When more than one profile run's artifacts exist in S3, the harness
-emits a `comparison.md` cross-tabulating QPS and write
-throughput against targets above.
-
-### NFR-012-AC-4
-
-Distributed runs emit `coordinator_overhead_ms` (libpq
-round-trip + merge) as a separate field in `read_qps.json` so the
-"sharding wins?" question is answerable from artifacts alone.

--- a/spec/non-functional/NFR-013-spire-local-readiness-and-capacity.md
+++ b/spec/non-functional/NFR-013-spire-local-readiness-and-capacity.md
@@ -91,16 +91,10 @@ a product-scale claim.
 
 ## Acceptance Criteria
 
-### NFR-013-AC-1
 
-Local readiness spec rows and review packets distinguish local functionality,
-local production-readiness smoke, and AWS/RDS product-scale evidence.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-013-AC-1 | Local readiness spec rows and review packets distinguish local functionality, local production-readiness smoke, and AWS/RDS product-scale evidence. | Inspection |
+| NFR-013-AC-2 | Readiness artifacts record the GUCs and counters needed to interpret fanout, payload, timeout, strict/degraded, and concurrency behavior. | Inspection |
+| NFR-013-AC-3 | Specs do not promote local smoke results into product-scale claims. | Demonstration |
 
-### NFR-013-AC-2
-
-Readiness artifacts record the GUCs and counters needed to interpret fanout,
-payload, timeout, strict/degraded, and concurrency behavior.
-
-### NFR-013-AC-3
-
-Specs do not promote local smoke results into product-scale claims.

--- a/spec/non-functional/NFR-014-spire-transport-security-and-operations.md
+++ b/spec/non-functional/NFR-014-spire-transport-security-and-operations.md
@@ -139,31 +139,13 @@ Verification SHALL use inspection, SQL diagnostics, and PG18 fixtures for:
 
 ## Acceptance Criteria
 
-### NFR-014-AC-1
 
-No SQL-visible remote transport surface exposes raw conninfo or raw remote error
-text.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-014-AC-1 | No SQL-visible remote transport surface exposes raw conninfo or raw remote error text. | Demonstration |
+| NFR-014-AC-2 | Remote write readiness and prepared transaction recovery are documented with explicit operator action and failure modes. | Inspection |
+| NFR-014-AC-3 | Schema drift and endpoint identity mismatches fail before mutating remote state. | Inspection |
+| NFR-014-AC-4 | An unprivileged session cannot execute any EC_DISTANN internal distributed endpoint. | Demonstration |
+| NFR-014-AC-5 | Malformed or oversize EC_DISTANN payloads are rejected before storage mutation or allocation beyond the documented cap. | Inspection |
+| NFR-014-AC-6 | EC_DISTANN recovery and destructive lifecycle actions are attributable to a caller and target without exposing secrets or row payloads. | Demonstration |
 
-### NFR-014-AC-2
-
-Remote write readiness and prepared transaction recovery are documented with
-explicit operator action and failure modes.
-
-### NFR-014-AC-3
-
-Schema drift and endpoint identity mismatches fail before mutating remote state.
-
-### NFR-014-AC-4
-
-An unprivileged session cannot execute any EC_DISTANN internal distributed
-endpoint.
-
-### NFR-014-AC-5
-
-Malformed or oversize EC_DISTANN payloads are rejected before storage mutation
-or allocation beyond the documented cap.
-
-### NFR-014-AC-6
-
-EC_DISTANN recovery and destructive lifecycle actions are attributable to a
-caller and target without exposing secrets or row payloads.

--- a/spec/non-functional/NFR-015-benchmark-reporting-standard.md
+++ b/spec/non-functional/NFR-015-benchmark-reporting-standard.md
@@ -66,26 +66,11 @@ counter fields required by the rules above.
 
 ## Acceptance Criteria
 
-### NFR-015-AC-1
 
-`docs/benchmark-reporting-standard.md` defines the required reporting fields
-for all current metric families.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-015-AC-1 | `docs/benchmark-reporting-standard.md` defines the required reporting fields for all current metric families. | Analysis |
+| NFR-015-AC-2 | `docs/benchmarks.md` and `docs/benchmark-index.md` link to the reporting standard and avoid benchmark rows whose scope cannot be traced to packet-local evidence or an explicit gap. | Analysis |
+| NFR-015-AC-3 | Future comparisons between `turboquant`, `pq_fastscan`, `rabitq`, trained quantizers, and future formats report the same candidate identity and metric fields so the rows can be compared across `ec_hnsw`, `ec_ivf`, `ec_diskann`, `ec_spire`, and future access methods. | Demonstration |
+| NFR-015-AC-4 | Block-kernel comparisons preserve enough counter fields to distinguish scoring-share wins from end-to-end latency changes and to identify structurally absent or missing-kernel cells in the Task 99 matrix. | Analysis |
 
-### NFR-015-AC-2
-
-`docs/benchmarks.md` and `docs/benchmark-index.md` link to the reporting
-standard and avoid benchmark rows whose scope cannot be traced to packet-local
-evidence or an explicit gap.
-
-### NFR-015-AC-3
-
-Future comparisons between `turboquant`, `pq_fastscan`, `rabitq`, trained
-quantizers, and future formats report the same candidate identity and metric
-fields so the rows can be compared across `ec_hnsw`, `ec_ivf`, `ec_diskann`,
-`ec_spire`, and future access methods.
-
-### NFR-015-AC-4
-
-Block-kernel comparisons preserve enough counter fields to distinguish
-scoring-share wins from end-to-end latency changes and to identify
-structurally absent or missing-kernel cells in the Task 99 matrix.

--- a/spec/non-functional/NFR-016-on-disk-format-evolution-discipline.md
+++ b/spec/non-functional/NFR-016-on-disk-format-evolution-discipline.md
@@ -193,47 +193,15 @@ any other rule in this NFR.
 
 ## Acceptance Criteria
 
-### NFR-016-AC-1
 
-Every entry in `fixtures/upgrade/matrix.csv` has a corresponding fixture
-file under `fixtures/on-disk/`, a decode test in
-`tests/on_disk_fixtures.rs`, and a byte-swap rejection test for its
-format-version discriminator.
-
-### NFR-016-AC-2
-
-Every persisted struct named in FR-007, FR-008, FR-013, FR-015,
-FR-022, FR-034, FR-035, FR-036, FR-076, FR-078, FR-082, and the SPIRE storage FRs has at least
-one static size or offset assertion in `tests/size_of_assertions.rs`.
-A pull request that changes any pinned size or offset without bumping
-the format version fails CI.
-
-### NFR-016-AC-3
-
-`fixtures/upgrade/matrix.csv` records the lifecycle state for every
-version Ecaz can read. A version that is removed from the encoder
-without a corresponding matrix update fails the upgrade-matrix test.
-
-### NFR-016-AC-4
-
-A new format version landed under this NFR ships with: (a) a release
-note entry, (b) a matrix row transition for the prior version, (c) a
-new fixture, (d) a new decode test, (e) updated static assertions.
-A new format version that lacks any of these artifacts fails review.
-
-### NFR-016-AC-5
-
-`make endian-qemu` runs on the schedule defined by NFR-005
-(build-and-CI) and decodes every fixture in `fixtures/on-disk/` on a
-big-endian target. Any fixture that decodes correctly on
-little-endian but fails on big-endian (or vice versa) is a bug under
-this NFR, not a fixture defect.
-
-### NFR-016-AC-6
-
-Forward-compatible extension blocks are encoded per the convention
-selected in the governing ADR. A payload kind whose forward-compat
-behavior is not documented in its FR is in violation of NFR-016-EV-5.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-016-AC-1 | Every entry in `fixtures/upgrade/matrix.csv` has a corresponding fixture file under `fixtures/on-disk/`, a decode test in `tests/on_disk_fixtures.rs`, and a byte-swap rejection test for its format-version discriminator. | Test |
+| NFR-016-AC-2 | Every persisted struct named in FR-007, FR-008, FR-013, FR-015, FR-022, FR-034, FR-035, FR-036, FR-076, FR-078, FR-082, and the SPIRE storage FRs has at least one static size or offset assertion in `tests/size_of_assertions.rs`. A pull request that changes any pinned size or offset without bumping the format version fails CI. | Inspection |
+| NFR-016-AC-3 | `fixtures/upgrade/matrix.csv` records the lifecycle state for every version Ecaz can read. A version that is removed from the encoder without a corresponding matrix update fails the upgrade-matrix test. | Test |
+| NFR-016-AC-4 | A new format version landed under this NFR ships with: (a) a release note entry, (b) a matrix row transition for the prior version, (c) a new fixture, (d) a new decode test, (e) updated static assertions. A new format version that lacks any of these artifacts fails review. | Test |
+| NFR-016-AC-5 | `make endian-qemu` runs on the schedule defined by NFR-005 (build-and-CI) and decodes every fixture in `fixtures/on-disk/` on a big-endian target. Any fixture that decodes correctly on little-endian but fails on big-endian (or vice versa) is a bug under this NFR, not a fixture defect. | Inspection |
+| NFR-016-AC-6 | Forward-compatible extension blocks are encoded per the convention selected in the governing ADR. A payload kind whose forward-compat behavior is not documented in its FR is in violation of NFR-016-EV-5. | Inspection |
 
 ## Verification
 

--- a/spec/non-functional/NFR-020-distann-fault-behavior.md
+++ b/spec/non-functional/NFR-020-distann-fault-behavior.md
@@ -141,43 +141,16 @@ open-obligation boundaries are unverified, not passed.
 
 ## Acceptance Criteria
 
-### NFR-020-AC-1
 
-A scan fault produces a complete baseline-identical result or a classified
-error; no partial result is presented as complete.
-
-### NFR-020-AC-2
-
-A fault before the durable publish decision leaves the prior epoch active and
-the new generation resumable or abortable.
-
-### NFR-020-AC-3
-
-A fault after the durable publish decision leaves the prior epoch active until
-recovery finishes every participant, then activates the new epoch exactly once.
-
-### NFR-020-AC-4
-
-Retrying an acknowledged handoff or publication operation with identical bytes
-does not change counts, digests, or physical bytes.
-
-### NFR-020-AC-5
-
-Conflicting retries, schema drift, wrong ownership, missing coverage, and digest
-disagreement fail before publication and never alter the active pointer.
-
-### NFR-020-AC-6
-
-Degraded completion, if introduced later, requires a follow-up FR with explicit
-opt-in and result labeling; the default path never degrades silently.
-
-### NFR-020-AC-7
-
-Every non-crash scan exit releases its coordinator-local registration exactly
-once, backend death releases registrations with the dead scan, and no scan
-performs participant pin/WAL work. Participants reclaim only from a durable
-zero-in-flight retire decision; partial application recovers idempotently, and
-forced retirement remains an explicit audited non-active-epoch override.
+| ID | Criteria | Verification |
+|----|----------|--------------|
+| NFR-020-AC-1 | A scan fault produces a complete baseline-identical result or a classified error; no partial result is presented as complete. | Demonstration |
+| NFR-020-AC-2 | A fault before the durable publish decision leaves the prior epoch active and the new generation resumable or abortable. | Demonstration |
+| NFR-020-AC-3 | A fault after the durable publish decision leaves the prior epoch active until recovery finishes every participant, then activates the new epoch exactly once. | Demonstration |
+| NFR-020-AC-4 | Retrying an acknowledged handoff or publication operation with identical bytes does not change counts, digests, or physical bytes. | Demonstration |
+| NFR-020-AC-5 | Conflicting retries, schema drift, wrong ownership, missing coverage, and digest disagreement fail before publication and never alter the active pointer. | Inspection |
+| NFR-020-AC-6 | Degraded completion, if introduced later, requires a follow-up FR with explicit opt-in and result labeling; the default path never degrades silently. | Demonstration |
+| NFR-020-AC-7 | Every non-crash scan exit releases its coordinator-local registration exactly once, backend death releases registrations with the dead scan, and no scan performs participant pin/WAL work. Participants reclaim only from a durable zero-in-flight retire decision; partial application recovers idempotently, and forced retirement remains an explicit audited non-active-epoch override. | Demonstration |
 
 ## Dependencies
 

--- a/spec/stakeholder/StR-005-multi-am-vector-search.md
+++ b/spec/stakeholder/StR-005-multi-am-vector-search.md
@@ -42,7 +42,11 @@ Different workloads favor different ANN tradeoffs: HNSW gives strong general-pur
 
 ## Validation Criteria
 
-1. `ecvector(dim)` works as the canonical indexed column type for HNSW, IVF, and DiskANN.
-2. `ec_hnsw`, `ec_ivf`, `ec_diskann`, and `ec_spire` are registered by `CREATE EXTENSION ecaz`.
-3. Documentation and benchmarks distinguish default product guidance from local research/measurement lanes.
-4. SPIRE specs define PID-addressed partition objects, epoch publication, local multi-store placement, CustomScan distributed reads, typed tuple transport, coordinator-routed DML, 2PC recovery, and operator diagnostics.
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-005-VC-1 | `ecvector(dim)` works as the canonical indexed column type for HNSW, IVF, and DiskANN. | Demonstration |
+| StR-005-VC-2 | `ec_hnsw`, `ec_ivf`, `ec_diskann`, and `ec_spire` are registered by `CREATE EXTENSION ecaz`. | Demonstration |
+| StR-005-VC-3 | Documentation and benchmarks distinguish default product guidance from local research/measurement lanes. | Inspection |
+| StR-005-VC-4 | SPIRE specs define PID-addressed partition objects, epoch publication, local multi-store placement, CustomScan distributed reads, typed tuple transport, coordinator-routed DML, 2PC recovery, and operator diagnostics. | Inspection |
+

--- a/spec/stakeholder/StR-006-benchmark-evidence-discipline.md
+++ b/spec/stakeholder/StR-006-benchmark-evidence-discipline.md
@@ -30,7 +30,11 @@ Benchmark claims drive landing decisions, README/spec assertions, and roadmap tr
 
 ## Validation Criteria
 
-1. `docs/benchmarks.md` separates local results from product benchmark claims.
-2. Review packets that cite measurements store raw logs under the packet `artifacts/` directory.
-3. `spec/tests.md` traces benchmark requirements to concrete evidence or explicitly marks the gap.
-4. `docs/benchmark-reporting-standard.md` defines the shared fields for AM, quantizer, storage-format, and option-set comparisons.
+
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-006-VC-1 | `docs/benchmarks.md` separates local results from product benchmark claims. | Analysis |
+| StR-006-VC-2 | Review packets that cite measurements store raw logs under the packet `artifacts/` directory. | Demonstration |
+| StR-006-VC-3 | `spec/tests.md` traces benchmark requirements to concrete evidence or explicitly marks the gap. | Analysis |
+| StR-006-VC-4 | `docs/benchmark-reporting-standard.md` defines the shared fields for AM, quantizer, storage-format, and option-set comparisons. | Analysis |
+


### PR DESCRIPTION
agent-ix/spec-artifacts-iso#11. Two more shapes, **both already enumerated by the author**:

- an ordered list (`1. … 2. …`) — each item is one row;
- a `### NFR-011-AC-1` heading followed by body text — the heading **is** the id and the body is the criterion.

The second is the valuable one: **the ids are already declared**, so they carry straight into the ID column and anything tracing them keeps resolving. quire-rs used this same form for its own criteria.

```
before:  ### NFR-011-AC-1
         The `dev`-profile load completes within the target wall time on the first end-to-end smoke run.

after:   | NFR-011-AC-1 | The `dev`-profile load completes within the target wall time on the first
                          end-to-end smoke run. | Analysis |
```

Criterion text preserved verbatim; only the method column is new. The converter **refuses** anything not cleanly one of these two shapes — prose before or after a list aborts it rather than being folded in.