### PR TITLE
spec: convert the last criteria-section shapes to the asserted tables

### DIFF
--- a/spec/stakeholder/StR-008-distributed-search-single-instance-economics.md
+++ b/spec/stakeholder/StR-008-distributed-search-single-instance-economics.md
@@ -39,24 +39,10 @@ mode.
 
 ## Validation Criteria
 
-This need is satisfied when a distributed access method demonstrates, on the
-standard staged corpora at 10k/50k/100k with release-verified builds via
-`ecaz bench suite`: distinct_recall@10 ≥ 0.999; 3-worker multinode p50 at or
-below the release single-instance IVF anchor at matched recall; and a
-per-query record-touch count bounded by the configured traversal budget
-(beam width × hop rounds), independent of corpus size.
 
-**Conformance precondition.** Every criterion above is evaluated only on a
-configuration satisfying
-[NFR-021](../non-functional/NFR-021-distann-distribution-invariant.md): no
-single node holding index state proportional to corpus size. A configuration
-that meets the p50 criterion by ceasing to distribute the index does not satisfy
-this need — it abandons it. The single-instance comparison exists to show that
-distribution need not cost latency, not to license removing the distribution.
-
-The corpus must remain distributed across the roster for a result to count. This
-precondition is stated explicitly because the other criteria are all *per-query
-work* bounds, which a single-node configuration satisfies trivially.
+| ID | Criteria | Validation |
+|----|----------|------------|
+| StR-008-VC-1 | A distributed access method demonstrates, on the standard staged corpora at 10k/50k/100k with release-verified builds via `ecaz bench suite`: distinct_recall@10 ≥ 0.999; 3-worker multinode p50 at or below the release single-instance IVF anchor at matched recall; and a per-query record-touch count bounded by the configured traversal budget (beam width × hop rounds), independent of corpus size. **Conformance precondition.** Every criterion above is evaluated only on a configuration satisfying [NFR-021](../non-functional/NFR-021-distann-distribution-invariant.md): no single node holding index state proportional to corpus size. A configuration that meets the p50 criterion by ceasing to distribute the index does not satisfy this need — it abandons it. The single-instance comparison exists to show that distribution need not cost latency, not to license removing the distribution. The corpus must remain distributed across the roster for a result to count. This precondition is stated explicitly because the other criteria are all *per-query work* bounds, which a single-node configuration satisfies trivially. | Analysis |
 
 ## Stakeholders
 


### PR DESCRIPTION
agent-ix/spec-artifacts-iso#11. Three shapes earlier passes refused for reasons that turned out to be **cosmetic rather than risky**:

- **A boilerplate lead-in** ("This need is considered satisfied when:") ahead of a numbered or bulleted list. Earlier passes aborted on "prose before a list" — but that sentence is the shape statement the table header now makes, so it is dropped and the list converts. A lead-in carrying *real* content still aborts the conversion.
- **`…satisfied when, on opening the dashboard, X`** — the comma straight after `when` defeated the opener pattern.
- **A bare paragraph with no opener at all** → one row, carried whole.

Enumerated lists are still split only on the author's own list markers, and a bare paragraph is **never** split. Any trailing "Satisfaction is judged by …" sentence is kept below the table, where it describes the need rather than one row.